### PR TITLE
[bitnami/cassandra] Add dynamic seed discovery to prevent split-brain

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 12.1.3 (2025-02-03)
+## 12.2.0 (2025-03-13)
 
-* [bitnami/cassandra] Release 12.1.3 ([#31721](https://github.com/bitnami/charts/pull/31721))
+* [bitnami/cassandra] Add dynamic seed discovery to prevent split-brain ([#32449](https://github.com/bitnami/charts/pull/32449))
+
+## <small>12.2.1 (2025-03-05)</small>
+
+* [bitnami/cassandra] Release 12.2.1 (#32322) ([5543930](https://github.com/bitnami/charts/commit/554393025cd9165c851b4b139c1ec5bf012fc4e5)), closes [#32322](https://github.com/bitnami/charts/issues/32322)
+
+## 12.2.0 (2025-02-27)
+
+* [bitnami/cassandra] Add support for `usePasswordFiles` (#32080) ([0485a17](https://github.com/bitnami/charts/commit/0485a17a5c115454508c442121efbe6547fe73c6)), closes [#32080](https://github.com/bitnami/charts/issues/32080)
+
+## <small>12.1.4 (2025-02-19)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/cassandra] Release 12.1.4 (#31975) ([93617a2](https://github.com/bitnami/charts/commit/93617a28affb1ab251083cc52c9ec61c76ba647e)), closes [#31975](https://github.com/bitnami/charts/issues/31975)
+
+## <small>12.1.3 (2025-02-04)</small>
+
+* [bitnami/cassandra] Release 12.1.3 (#31721) ([ab93c8e](https://github.com/bitnami/charts/commit/ab93c8e988f52f22486e0cfbc7a6cd03ea89dde2)), closes [#31721](https://github.com/bitnami/charts/issues/31721)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## <small>12.1.2 (2025-01-28)</small>
 
@@ -1279,7 +1297,7 @@
 ## <small>2.3.5 (2019-05-29)</small>
 
 * Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc35728c2a8a9def9e1897b3772d64df621354))
-* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea6430f28ec3593053afb0bfccb75703c79)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea6430f28ec3593053afb0bfccb75703c79))
 * Fix tensorflow and others ([6252f12](https://github.com/bitnami/charts/commit/6252f125d307e55fd638687eac09f1df8451f22f))
 * Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5c91da33da03f9e2d411fe5e004e825c4d))
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.1.3
+version: 12.2.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -194,39 +194,40 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 
 ### Cassandra parameters
 
-| Name                       | Description                                                                                                            | Value                       |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `image.registry`           | Cassandra image registry                                                                                               | `REGISTRY_NAME`             |
-| `image.repository`         | Cassandra image repository                                                                                             | `REPOSITORY_NAME/cassandra` |
-| `image.digest`             | Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                        |
-| `image.pullPolicy`         | image pull policy                                                                                                      | `IfNotPresent`              |
-| `image.pullSecrets`        | Cassandra image pull secrets                                                                                           | `[]`                        |
-| `image.debug`              | Enable image debug mode                                                                                                | `false`                     |
-| `dbUser.user`              | Cassandra admin user                                                                                                   | `cassandra`                 |
-| `dbUser.forcePassword`     | Force the user to provide a non                                                                                        | `false`                     |
-| `dbUser.password`          | Password for `dbUser.user`. Randomly generated if empty                                                                | `""`                        |
-| `dbUser.existingSecret`    | Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)                               | `""`                        |
-| `initDB`                   | Object with cql scripts. Useful for creating a keyspace and pre-populating data                                        | `{}`                        |
-| `initDBConfigMap`          | ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data                                     | `""`                        |
-| `initDBSecret`             | Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data                   | `""`                        |
-| `existingConfiguration`    | ConfigMap with custom cassandra configuration files. This overrides any other Cassandra configuration set in the chart | `""`                        |
-| `cluster.name`             | Cassandra cluster name                                                                                                 | `cassandra`                 |
-| `cluster.seedCount`        | Number of seed nodes                                                                                                   | `1`                         |
-| `cluster.numTokens`        | Number of tokens for each node                                                                                         | `256`                       |
-| `cluster.datacenter`       | Datacenter name                                                                                                        | `dc1`                       |
-| `cluster.rack`             | Rack name                                                                                                              | `rack1`                     |
-| `cluster.endpointSnitch`   | Endpoint Snitch                                                                                                        | `SimpleSnitch`              |
-| `cluster.clientEncryption` | Client Encryption                                                                                                      | `false`                     |
-| `cluster.extraSeeds`       | For an external/second cassandra ring.                                                                                 | `[]`                        |
-| `cluster.enableUDF`        | Enable User defined functions                                                                                          | `false`                     |
-| `jvm.extraOpts`            | Set the value for Java Virtual Machine extra options                                                                   | `""`                        |
-| `jvm.maxHeapSize`          | Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`                          | `""`                        |
-| `jvm.newHeapSize`          | Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`                               | `""`                        |
-| `command`                  | Command for running the container (set to default if not set). Use array form                                          | `[]`                        |
-| `args`                     | Args for running the container (set to default if not set). Use array form                                             | `[]`                        |
-| `extraEnvVars`             | Extra environment variables to be set on cassandra container                                                           | `[]`                        |
-| `extraEnvVarsCM`           | Name of existing ConfigMap containing extra env vars                                                                   | `""`                        |
-| `extraEnvVarsSecret`       | Name of existing Secret containing extra env vars                                                                      | `""`                        |
+| Name                                   | Description                                                                                                            | Value                       |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `image.registry`                       | Cassandra image registry                                                                                               | `REGISTRY_NAME`             |
+| `image.repository`                     | Cassandra image repository                                                                                             | `REPOSITORY_NAME/cassandra` |
+| `image.digest`                         | Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                        |
+| `image.pullPolicy`                     | image pull policy                                                                                                      | `IfNotPresent`              |
+| `image.pullSecrets`                    | Cassandra image pull secrets                                                                                           | `[]`                        |
+| `image.debug`                          | Enable image debug mode                                                                                                | `false`                     |
+| `dbUser.user`                          | Cassandra admin user                                                                                                   | `cassandra`                 |
+| `dbUser.forcePassword`                 | Force the user to provide a non                                                                                        | `false`                     |
+| `dbUser.password`                      | Password for `dbUser.user`. Randomly generated if empty                                                                | `""`                        |
+| `dbUser.existingSecret`                | Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)                               | `""`                        |
+| `initDB`                               | Object with cql scripts. Useful for creating a keyspace and pre-populating data                                        | `{}`                        |
+| `initDBConfigMap`                      | ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data                                     | `""`                        |
+| `initDBSecret`                         | Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data                   | `""`                        |
+| `existingConfiguration`                | ConfigMap with custom cassandra configuration files. This overrides any other Cassandra configuration set in the chart | `""`                        |
+| `cluster.name`                         | Cassandra cluster name                                                                                                 | `cassandra`                 |
+| `cluster.seedCount`                    | Number of seed nodes                                                                                                   | `1`                         |
+| `cluster.numTokens`                    | Number of tokens for each node                                                                                         | `256`                       |
+| `cluster.datacenter`                   | Datacenter name                                                                                                        | `dc1`                       |
+| `cluster.rack`                         | Rack name                                                                                                              | `rack1`                     |
+| `cluster.endpointSnitch`               | Endpoint Snitch                                                                                                        | `SimpleSnitch`              |
+| `cluster.clientEncryption`             | Client Encryption                                                                                                      | `false`                     |
+| `cluster.extraSeeds`                   | For an external/second cassandra ring.                                                                                 | `[]`                        |
+| `cluster.enableUDF`                    | Enable User defined functions                                                                                          | `false`                     |
+| `cluster.dynamicSeedDiscovery.enabled` | Enable dynamic seed discovery                                                                                          | `false`                     |
+| `jvm.extraOpts`                        | Set the value for Java Virtual Machine extra options                                                                   | `""`                        |
+| `jvm.maxHeapSize`                      | Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`                          | `""`                        |
+| `jvm.newHeapSize`                      | Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`                               | `""`                        |
+| `command`                              | Command for running the container (set to default if not set). Use array form                                          | `[]`                        |
+| `args`                                 | Args for running the container (set to default if not set). Use array form                                             | `[]`                        |
+| `extraEnvVars`                         | Extra environment variables to be set on cassandra container                                                           | `[]`                        |
+| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                                                   | `""`                        |
+| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                                                      | `""`                        |
 
 ### Statefulset parameters
 

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -286,7 +286,7 @@ Dynamic Seed Discovery
 */}}
 {{- define "cassandra.dynamicSeedDiscovery" -}}
 - name: dynamic-seed-discovery
-  image: alpine:3.21.3
+  image: alpine:latest
   command:
       - "/bin/sh"
       - "-c"
@@ -299,12 +299,12 @@ Dynamic Seed Discovery
             echo "$NODE_IP" >> ${DYNAMIC_SEED_DIR}/seed-ips.lst; \
           done && \
         if [ ! -s ${DYNAMIC_SEED_DIR}/seed-ips.lst ]; then \
-          echo "No seed nodes found, using pod's own IP: $POD_IP" && \
+          echo "No seed nodes found, using pod's own IP" && \
           echo $POD_IP > ${DYNAMIC_SEED_DIR}/seed-ips.lst; \
         fi && \
-        echo "Seed nodes: " &&
-        cat ${DYNAMIC_SEED_DIR}/seed-ips.lst | head -2 | paste -sd, - > ${DYNAMIC_SEED_DIR}/seed-ips.txt &&
-        cat ${DYNAMIC_SEED_DIR}/seed-ips.txt
+        cat ${DYNAMIC_SEED_DIR}/seed-ips.lst | head -{{ .Values.cluster.seedCount }} | paste -sd, - > ${DYNAMIC_SEED_DIR}/seed-ips.txt &&
+        echo "Seed nodes: $(cat ${DYNAMIC_SEED_DIR}/seed-ips.txt)"
+
   env:
     - name: POD_IP
       valueFrom:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -68,8 +68,12 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if or .Values.initContainers (include "cassandra.tlsEncryption" . ) (and .Values.podSecurityContext.enabled .Values.volumePermissions.enabled .Values.persistence.enabled) }}
+      {{- if or .Values.initContainers .Values.cluster.dynamicSeedDiscovery.enabled (include "cassandra.tlsEncryption" . ) (and .Values.podSecurityContext.enabled .Values.volumePermissions.enabled .Values.persistence.enabled) }}
       initContainers:
+        {{- if .Values.cluster.dynamicSeedDiscovery.enabled -}}
+        {{- include "cassandra.dynamicSeedDiscovery" . | nindent 8 }}
+        {{- end }}
+
         {{- if and .Values.podSecurityContext.enabled .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "cassandra.volumePermissions.image" . }}
@@ -238,6 +242,10 @@ spec:
                   # Only node 0 will execute the startup initdb scripts
                   export CASSANDRA_IGNORE_INITDB_SCRIPTS=1
               fi
+              {{- if .Values.cluster.dynamicSeedDiscovery.enabled }}
+              export CASSANDRA_SEEDS=$(cat /opt/bitnami/cassandra/tmp/seed-ips.txt ) && \
+              echo "Setting Cassandra seeds: $CASSANDRA_SEEDS" && \
+              {{- end }}
               /opt/bitnami/scripts/cassandra/entrypoint.sh /opt/bitnami/scripts/cassandra/run.sh
             {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
@@ -255,8 +263,10 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: CASSANDRA_CLUSTER_NAME
               value: {{ .Values.cluster.name }}
+            {{- if not .Values.cluster.dynamicSeedDiscovery.enabled }}
             - name: CASSANDRA_SEEDS
-              value: {{ (include "cassandra.seeds" .) | quote }}
+              value: {{ (include "cassandra.seeds" .)  }}
+            {{- end }}
             - name: CASSANDRA_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -170,6 +170,8 @@ cluster:
   ##
   extraSeeds: []
   enableUDF: false
+  dynamicSeedDiscovery:
+    enabled: false
 ## JVM Settings
 ## @param jvm.extraOpts Set the value for Java Virtual Machine extra options
 ## @param jvm.maxHeapSize Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -154,6 +154,7 @@ existingConfiguration: ""
 ## @param cluster.clientEncryption Client Encryption
 ## @param cluster.extraSeeds For an external/second cassandra ring.
 ## @param cluster.enableUDF Enable User defined functions
+## @param cluster.dynamicSeedDiscovery.enabled Enable dynamic seed discovery
 ##
 cluster:
   name: cassandra
@@ -170,6 +171,10 @@ cluster:
   ##
   extraSeeds: []
   enableUDF: false
+  ## When enabled, an init container will dynamically resolve available Cassandra pods
+  ## and configure them as seed nodes at startup. This prevents split-brain issues by
+  ## ensuring new pods do not mistakenly form a separate cluster if static seed nodes
+  ## using pod numbers are unavailable.
   dynamicSeedDiscovery:
     enabled: false
 ## JVM Settings


### PR DESCRIPTION
### Description of the change

- Replaced static seed node configuration using pod number with dynamic seed discovery using Kubernetes DNS SRV records
- The new implementation dynamically discovers healthy seed nodes using Kubernetes service discovery.
- An init container now resolves available Cassandra pods and sets them as seed nodes at startup.
- Updated statefulset configuration to use cassandra-headless service for peer discovery.
- This ensures high availability and prevents split-brain issues.


### Benefits

- Eliminates static seed node dependency, reducing the risk of cluster split-brain.
- Enhances cluster stability by ensuring new pods join the correct cluster.
- Automatically discovers available seed nodes, improving resilience and auto-recovery.
- Seamless integration with Kubernetes StatefulSets for managing Cassandra clusters.

### Possible drawbacks

- The init container introduces a small startup delay while discovering healthy seed nodes.
- If all pods are deleted at once, the cluster will still need manual intervention for recovery.

### Applicable issues

- n/a

### Additional information

- Maintains backward compatibility through feature flag cluster.dynamicSeedDiscovery.enabled
- Deployed in Kubernetes 1.26+, ensuring seed discovery worked as expected.
- Simulated node failures to confirm proper seed resolution.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
