### PR TITLE
[bitnami/argo-cd] Fix redis password not read when using passwordFiles

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.2.3 (2025-03-11)
+## 7.2.4 (2025-03-17)
 
-* [bitnami/argo-cd] Release 7.2.3 ([#32390](https://github.com/bitnami/charts/pull/32390))
+* [bitnami/argo-cd] Fix redis password not read when using passwordFiles ([#32477](https://github.com/bitnami/charts/pull/32477))
+
+## <small>7.2.3 (2025-03-11)</small>
+
+* [bitnami/argo-cd] Release 7.2.3 (#32390) ([a2c149b](https://github.com/bitnami/charts/commit/a2c149b171e9dcb86ac2d67d06c08be894b4ca76)), closes [#32390](https://github.com/bitnami/charts/issues/32390)
 
 ## <small>7.2.2 (2025-03-04)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.2.3
+version: 7.2.4

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -194,7 +194,7 @@ spec:
           env:
             {{- if (include "argocd.redis.auth.enabled" .) }}
             {{- if .Values.usePasswordFiles }}
-            - name: REDISCLI_PASSWORD_FILE
+            - name: REDIS_PASSWORD_FILE
               value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
             {{- else }}
             - name: REDIS_PASSWORD

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -189,7 +189,7 @@ spec:
             {{- end }}
             {{- if (include "argocd.redis.auth.enabled" .) }}
             {{- if .Values.usePasswordFiles }}
-            - name: REDISCLI_PASSWORD_FILE
+            - name: REDIS_PASSWORD_FILE
               value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
             {{- else }}
             - name: REDIS_PASSWORD


### PR DESCRIPTION
### Description of the change

Fixes the name of the *_FILE environment names in the server and repo-server deployments.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #32444

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
