### PR TITLE
[bitnami/kubernetes-event-exporter] ci: more flexible regexp on Ginkgo tests

### DIFF
--- a/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
@@ -43,7 +43,7 @@ var _ = Describe("Kubernetes Event Exporter:", func() {
 
 		Describe("the exporter logs", func() {
 			It("shows its kubernetes events", func() {
-				pattern := "event=.*Created container: nginx-" + *namespace + ".*sink=.*dump"
+				pattern := "event=.*Created container.*nginx-" + *namespace + ".*sink=.*dump"
 				podLabel := "app.kubernetes.io/name=kubernetes-event-exporter"
 				containerName := "event-exporter"
 

--- a/bitnami/kubernetes-event-exporter/CHANGELOG.md
+++ b/bitnami/kubernetes-event-exporter/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.4.3 (2025-03-05)
+## 3.4.4 (2025-03-17)
 
-* [bitnami/kubernetes-event-exporter] Release 3.4.3 ([#32300](https://github.com/bitnami/charts/pull/32300))
+* [bitnami/kubernetes-event-exporter] ci: more flexible regexp on Ginkgo tests ([#32481](https://github.com/bitnami/charts/pull/32481))
+
+## <small>3.4.3 (2025-03-05)</small>
+
+* [bitnami/kubernetes-event-exporter] Release 3.4.3 (#32300) ([44db9c2](https://github.com/bitnami/charts/commit/44db9c27201acce8545c6e3547216c1301041333)), closes [#32300](https://github.com/bitnami/charts/issues/32300)
 
 ## <small>3.4.2 (2025-03-04)</small>
 

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.4.3
+version: 3.4.4


### PR DESCRIPTION
### Description of the change

Depending on the K8s platform, the kubernetes event will display a different message to state the container was created. This PR makes the regexp more flexible.

### Benefits

CI works on different K8s platforms.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
