### PR TITLE
[bitnami/grafana-operator] Fix link to grafana-operator dashboards documentation

### DIFF
--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -163,7 +163,7 @@ Install the [Bitnami Kube Prometheus helm chart](https://github.com/bitnami/char
 
 After the installation, create Dashboards under a CRD of your Kubernetes cluster.
 
-For more details regarding what is possible with those CRDs please have a look at [Working with Dashboards](https://github.com/integr8ly/grafana-operator/blob/master/documentation/dashboards.md).
+For more details regarding what is possible with those CRDs please have a look at [Working with Dashboards](https://github.com/grafana/grafana-operator/blob/master/docs/docs/dashboards.md).
 
 ### Deploy extra Grafana resources or objects
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Fixes: #32494 
This pull request contains update of link to Grafana's Dashboards documentation. The previous one seems to be outdated.

### Benefits

The most up to date links to docs.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
