### PR TITLE
[bitnami/valkey-cluster] Add support for templating nodes, replicas, resources, and persistent storage values

### DIFF
--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.0 (2025-02-21)
+## 2.2.1 (2025-03-19)
 
-* [bitnami/valkey-cluster] Set `usePasswordFiles=true` by default ([#32122](https://github.com/bitnami/charts/pull/32122))
+* [bitnami/valkey-cluster] Add support for templating node and replica values ([#32520](https://github.com/bitnami/charts/pull/32520))
+
+## 2.2.0 (2025-02-24)
+
+* [bitnami/valkey-cluster] Set `usePasswordFiles=true` by default (#32122) ([c46b8f0](https://github.com/bitnami/charts/commit/c46b8f0029226245c04a3fed93225e82a9ab3e57)), closes [#32122](https://github.com/bitnami/charts/issues/32122)
 
 ## <small>2.1.3 (2025-02-20)</small>
 

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.1 (2025-03-20)
+## 2.2.1 (2025-03-21)
 
 * [bitnami/valkey-cluster] Add support for templating nodes, replicas, resources, and persistent storage values ([#32520](https://github.com/bitnami/charts/pull/32520))
 

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.1 (2025-03-19)
+## 2.2.1 (2025-03-20)
 
 * [bitnami/valkey-cluster] Add support for templating node and replica values ([#32520](https://github.com/bitnami/charts/pull/32520))
 

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.1 (2025-03-20)
 
-* [bitnami/valkey-cluster] Add support for templating node and replica values ([#32520](https://github.com/bitnami/charts/pull/32520))
+* [bitnami/valkey-cluster] Add support for templating nodes, replicas, resources, and persistent storage values ([#32520](https://github.com/bitnami/charts/pull/32520))
 
 ## 2.2.0 (2025-02-24)
 

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -34,4 +34,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 2.2.0
+version: 2.2.1

--- a/bitnami/valkey-cluster/templates/update-cluster.yaml
+++ b/bitnami/valkey-cluster/templates/update-cluster.yaml
@@ -207,7 +207,7 @@ spec:
               value: {{ .Values.valkey.containerPorts.valkey | quote }}
             {{- end }}
             - name: VALKEY_CLUSTER_REPLICAS
-              value: {{ .Values.cluster.replicas | quote }}
+              value: {{ if eq (typeOf .Values.cluster.replicas) "float64" -}}{{ .Values.cluster.replicas | quote }}{{- else -}}{{ tpl .Values.cluster.replicas . | quote }}{{- end }}
             {{- if .Values.usePassword }}
             - name: REDISCLI_AUTH
               valueFrom:

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.valkey.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-  replicas: {{ .Values.cluster.nodes }}
+  replicas: {{ if eq (typeOf .Values.cluster.nodes) "float64" -}}{{ .Values.cluster.nodes }}{{- else -}}{{ tpl .Values.cluster.nodes . | int }}{{- end }}
   serviceName: {{ include "common.names.fullname" . }}-headless
   podManagementPolicy: {{ .Values.valkey.podManagementPolicy }}
   template:
@@ -116,7 +116,7 @@ spec:
               {{- if .Values.cluster.init }}
               if [[ "$pod_index" == "0" ]]; then
                 export VALKEY_CLUSTER_CREATOR="yes"
-                export VALKEY_CLUSTER_REPLICAS="{{ .Values.cluster.replicas }}"
+                export VALKEY_CLUSTER_REPLICAS="{{ if eq (typeOf .Values.cluster.replicas) "float64" -}}{{ .Values.cluster.replicas | quote }}{{- else -}}{{ tpl .Values.cluster.replicas . | int }}{{- end }}"
               fi
               {{- end }}
               /opt/bitnami/scripts/valkey-cluster/entrypoint.sh /opt/bitnami/scripts/valkey-cluster/run.sh
@@ -133,7 +133,7 @@ spec:
               pod_index="${pod_index[-1]}"
               if [[ "$pod_index" == "0" ]]; then
                 export VALKEY_CLUSTER_CREATOR="yes"
-                export VALKEY_CLUSTER_REPLICAS="{{ .Values.cluster.replicas }}"
+                export VALKEY_CLUSTER_REPLICAS="{{ if eq (typeOf .Values.cluster.replicas) "float64" -}}{{ .Values.cluster.replicas | quote }}{{- else -}}{{ tpl .Values.cluster.replicas . | int }}{{- end }}"
               fi
               {{- end }}
               /opt/bitnami/scripts/valkey-cluster/entrypoint.sh /opt/bitnami/scripts/valkey-cluster/run.sh

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -153,7 +153,7 @@ spec:
               value: "no"
             {{- else }}
             - name: VALKEY_NODES
-              value: "{{ $count := .Values.cluster.nodes | int }}{{ range $i, $v := until $count }}{{ include "common.names.fullname" $ }}-{{ $i }}.{{ template "common.names.fullname" $ }}-headless {{ end }}"
+              value: '{{- $count := 0 -}}{{ if eq (typeOf .Values.cluster.replicas) "float64" -}}{{ $count = .Values.cluster.nodes | int }}{{- else -}}{{ $count = tpl .Values.cluster.nodes . | int }}{{- end -}}{{ range $i, $v := until $count }}{{ include "common.names.fullname" $ }}-{{ $i }}.{{ template "common.names.fullname" $ }}-headless {{ end }}'
             {{- end }}
             {{- if .Values.usePassword }}
             - name: REDISCLI_AUTH

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -267,7 +267,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.valkey.resources }}
-          resources: {{- toYaml .Values.valkey.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.valkey.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.valkey.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.valkey.resourcesPreset) | nindent 12 }}
           {{- end }}
@@ -492,7 +492,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
+            storage: {{ tpl .Values.persistence.size . | quote }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         {{- if or .Values.persistence.matchLabels .Values.persistence.matchExpressions }}
         selector:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds support to template the values input for the nodes, replicas, resources, and persistent storage of a cluster.

### Benefits

Currently, this helm chart does not allow configuration by shard. This PR allows for abstraction when used as a subchart, or when the user just wants to configure things differently.

For example, this abstraction becomes possible:

```yaml
global:
  cache:
    shards: 18
    replicas: 3

cluster:
  nodes: "{{ .Values.global.cache.shards | int | mul .Values.global.cache.replicas | int }}"
  replicas: "{{ .Values.global.cache.replicas }}"
```

### Possible drawbacks

This should be compatible with all existing usage.


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
