### PR TITLE
[bitnami/kong] chore(ClusterRole): Concat namespace in ClusterRole name

### DIFF
--- a/.vib/kong/vib-action.config
+++ b/.vib/kong/vib-action.config
@@ -1,1 +1,0 @@
-verification-mode=SERIAL

--- a/bitnami/kong/CHANGELOG.md
+++ b/bitnami/kong/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.3.1 (2025-03-13)
+## 15.4.0 (2025-03-21)
 
-* [bitnami/kong] Release 15.3.1 ([#32451](https://github.com/bitnami/charts/pull/32451))
+* [bitnami/kong] chore(ClusterRole): Concat namespace in ClusterRole name ([#32544](https://github.com/bitnami/charts/pull/32544))
+
+## <small>15.3.1 (2025-03-13)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/kong] Release 15.3.1 (#32451) ([e8d1314](https://github.com/bitnami/charts/commit/e8d13144e35c0390c6ac68dba03d5603e2035197)), closes [#32451](https://github.com/bitnami/charts/issues/32451)
 
 ## 15.3.0 (2025-02-24)
 

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: kong
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.3.1
+version: 15.4.0

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -99,7 +99,7 @@ subjects:
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname.namespace" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}
@@ -616,7 +616,7 @@ rules:
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname.namespace" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}
@@ -625,7 +625,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kong.ingressController.serviceAccountName" . }}


### PR DESCRIPTION
### Description of the change

Concat namespace to `ClusterRole` and `ClusterRoleBinding` name.

### Benefits

It allows several kong releases in the same cluster.

### Possible drawbacks

Names for `ClusterRole` and `ClusterRoleBinding` resources will change. Users who deploy the chart from the `helm template` result,  could see 2  cluster roles linked to the Kong `ServiceAccount`.

### Additional information

With this change we don't need to test the chart in serial mode.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
