### PR TITLE
Update README.md

### DIFF
--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -336,7 +336,7 @@ passwordUpdateJob:
 In the following example we update the password via values.yaml in a MongoDB installation with replication and several usernames and databases (including metrics).
 
 ```yaml
-architecture: "replication"
+architecture: "replicaset"
 
 auth:
   usernames:


### PR DESCRIPTION
### Description of the change

In the updating password section it gave the architecture setting a value of "replication", instead of a "replicaset"->

### Benefits

It makes the instructions clearer, some may run into an error trying to put the  architecture as "replication"
### Possible drawbacks




### Additional information

It really is not a functional change, it was probably just a typo from someone


