### PR TITLE
bitnami/airflow  Fix indentation error when providing setupDBJob.resources in values

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 22.7.1 (2025-03-22)
+## 22.7.2 (2025-03-25)
 
-* [bitnami/airflow] Release 22.7.1 ([#32559](https://github.com/bitnami/charts/pull/32559))
+* bitnami/airflow  Fix indentation error when providing setupDBJob.resources in values ([#32599](https://github.com/bitnami/charts/pull/32599))
+
+## <small>22.7.1 (2025-03-22)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/airflow] Release 22.7.1 (#32559) ([4d21c97](https://github.com/bitnami/charts/commit/4d21c9734d3348ee1fcd38d80958af501dbe51c5)), closes [#32559](https://github.com/bitnami/charts/issues/32559)
 
 ## 22.7.0 (2025-03-04)
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.7.1
+version: 22.7.2

--- a/bitnami/airflow/templates/setup-db-job.yaml
+++ b/bitnami/airflow/templates/setup-db-job.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.setupDBJob.containerSecurityContext "context" .) | nindent 12 }}
           {{- end }}
           {{- if .Values.setupDBJob.resources }}
-          resources: {{- toYaml .Values.setupDBJob.resources | nindent 4 }}
+          resources: {{- toYaml .Values.setupDBJob.resources | nindent 12 }}
           {{- else if ne .Values.setupDBJob.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.setupDBJob.resourcesPreset) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes bug due to indentation on the airflow chart setupDBJob.yaml template. 

### Benefits

Allows chart user to override setupDBJob resources to custom needs.

### Possible drawbacks

N/A

### Applicable issues

- fixes #32581 

### Additional information

- Simple one liner change. 
- 
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
