### PR TITLE
[bitnami/schema-registry] feat: bump major due to major bump on Kafka dep

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 25.0.0 (2025-03-26)
+
+* [bitnami/schema-registry] feat: bump major due to major bump on Kafka dep ([#32618](https://github.com/bitnami/charts/pull/32618))
+
 ## 24.0.0 (2025-03-12)
 
-* [bitnami/schema-registry] Release 24.0.0 ([#32424](https://github.com/bitnami/charts/pull/32424))
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/schema-registry] Release 24.0.0 (#32424) ([1817445](https://github.com/bitnami/charts/commit/18174456aa09c324493c5e1d08c4b9f3c68891d7)), closes [#32424](https://github.com/bitnami/charts/issues/32424)
 
 ## <small>23.1.4 (2025-03-04)</small>
 

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 31.5.0
+  version: 32.0.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.30.0
-digest: sha256:4c8b4b99f443f7afa6616e42ba06f6923c7b7191995f1da0f95635e2d311dc31
-generated: "2025-03-12T15:54:54.483658258Z"
+digest: sha256:321e893954e5f92805a8fa6f0748a58e90d6a424c061c0733bf2eccdd10ba254
+generated: "2025-03-26T15:56:30.192454+01:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 31.x.x
+  version: 32.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 24.0.0
+version: 25.0.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -436,6 +436,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 24.0.0
+
+This major updates the Kafka subchart to its newest major, 32.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3200).
+
 ### To 23.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -394,20 +394,20 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ### Kafka chart parameters
 
-| Name                                | Description                                                                                                                  | Value                                |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `kafka.enabled`                     | Enable/disable Kafka chart installation                                                                                      | `true`                               |
-| `kafka.controller.replicaCount`     | Number of Kafka controller-eligible (controller+broker) nodes                                                                | `1`                                  |
-| `kafka.listeners.client.protocol`   | Authentication protocol for communications with clients. Allowed protocols: `PLAINTEXT`, `SASL_PLAINTEXT`, `SASL_SSL`, `SSL` | `PLAINTEXT`                          |
-| `kafka.service.ports.client`        | Kafka svc port for client connections                                                                                        | `9092`                               |
-| `kafka.extraConfig`                 | Additional configuration to be appended at the end of the generated Kafka configuration file.                                | `offsets.topic.replication.factor=1` |
-| `kafka.sasl.client.users`           | Comma-separated list of usernames for Kafka client listener when SASL is enabled                                             | `["user"]`                           |
-| `kafka.sasl.client.passwords`       | Comma-separated list of passwords for client listener when SASL is enabled, must match the number of client.users            | `""`                                 |
-| `externalKafka.brokers`             | Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port                                                | `["PLAINTEXT://localhost:9092"]`     |
-| `externalKafka.listener.protocol`   | Kafka listener protocol. Allowed protocols: PLAINTEXT, SASL_PLAINTEXT, SASL_SSL and SSL                                      | `PLAINTEXT`                          |
-| `externalKafka.sasl.user`           | User for SASL authentication                                                                                                 | `user`                               |
-| `externalKafka.sasl.password`       | Password for SASL authentication                                                                                             | `""`                                 |
-| `externalKafka.sasl.existingSecret` | Name of the existing secret containing a password for SASL authentication (under the key named "client-passwords")           | `""`                                 |
+| Name                                | Description                                                                                                                  | Value                            |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `kafka.enabled`                     | Enable/disable Kafka chart installation                                                                                      | `true`                           |
+| `kafka.controller.replicaCount`     | Number of Kafka controller-eligible (controller+broker) nodes                                                                | `1`                              |
+| `kafka.listeners.client.protocol`   | Authentication protocol for communications with clients. Allowed protocols: `PLAINTEXT`, `SASL_PLAINTEXT`, `SASL_SSL`, `SSL` | `PLAINTEXT`                      |
+| `kafka.service.ports.client`        | Kafka svc port for client connections                                                                                        | `9092`                           |
+| `kafka.overrideConfiguration`       | Kafka common configuration override                                                                                          | `{}`                             |
+| `kafka.sasl.client.users`           | Comma-separated list of usernames for Kafka client listener when SASL is enabled                                             | `["user"]`                       |
+| `kafka.sasl.client.passwords`       | Comma-separated list of passwords for client listener when SASL is enabled, must match the number of client.users            | `""`                             |
+| `externalKafka.brokers`             | Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port                                                | `["PLAINTEXT://localhost:9092"]` |
+| `externalKafka.listener.protocol`   | Kafka listener protocol. Allowed protocols: PLAINTEXT, SASL_PLAINTEXT, SASL_SSL and SSL                                      | `PLAINTEXT`                      |
+| `externalKafka.sasl.user`           | User for SASL authentication                                                                                                 | `user`                           |
+| `externalKafka.sasl.password`       | Password for SASL authentication                                                                                             | `""`                             |
+| `externalKafka.sasl.existingSecret` | Name of the existing secret containing a password for SASL authentication (under the key named "client-passwords")           | `""`                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -156,7 +156,7 @@ spec:
               {{- if .Values.kafka.enabled }}
               {{- $brokers := list }}
               {{- $kafkaBrokerReplicaCount := int .Values.kafka.broker.replicaCount }}
-              {{- $kafkaControllerReplicaCount := ternary 0 (int .Values.kafka.controller.replicaCount) (or (not .Values.kafka.kraft.enabled) (.Values.kafka.controller.controllerOnly)) }}
+              {{- $kafkaControllerReplicaCount := ternary 0 (int .Values.kafka.controller.replicaCount) (.Values.kafka.controller.controllerOnly) }}
               {{- range $e, $i := until $kafkaBrokerReplicaCount }}
               {{- $brokers = append $brokers (printf "%s://%s-broker-%d.%s-broker-headless.%s.svc.%s:%d" $kafkaProtocol $kafkaFullname $i $kafkaFullname $releaseNamespace $clusterDomain $kafkaPort) }}
               {{- end }}

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -750,7 +750,7 @@ kafka:
   service:
     ports:
       client: 9092
-  ## @param kafka.overrideConfiguration Kafka common configuration override
+  ## @param kafka.overrideConfiguration [object] Kafka common configuration override
   ##
   overrideConfiguration:
     offsets.topic.replication.factor: 1

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -750,10 +750,10 @@ kafka:
   service:
     ports:
       client: 9092
-  ## @param kafka.extraConfig Additional configuration to be appended at the end of the generated Kafka configuration file.
+  ## @param kafka.overrideConfiguration Kafka common configuration override
   ##
-  extraConfig: |-
-    offsets.topic.replication.factor=1
+  overrideConfiguration:
+    offsets.topic.replication.factor: 1
   ## @param kafka.sasl.client.users Comma-separated list of usernames for Kafka client listener when SASL is enabled
   ## @param kafka.sasl.client.passwords Comma-separated list of passwords for client listener when SASL is enabled, must match the number of client.users
   ##


### PR DESCRIPTION
### Description of the change

This PR bumps the chart major version given we bumped the major version in one of the chart dependencies: Kafka. Find more information below:

- https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3200

### Benefits

Keep the chart up-to-date with latest deps changes.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)