### PR TITLE
[bitnami/kafka] bugfix: upgrade issue due to secret lookup

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 32.1.1 (2025-03-26)
+
+* [bitnami/kafka] bugfix: upgrade issue due to secret lookup ([#32621](https://github.com/bitnami/charts/pull/32621))
+
 ## 32.1.0 (2025-03-26)
 
-* [bitnami/kafka] bugfix: add missing persistentVolumeClaimRetentionPolicy and fix config & network policies when adding extra listeners ([#32615](https://github.com/bitnami/charts/pull/32615))
+* [bitnami/kafka] bugfix: add missing persistentVolumeClaimRetentionPolicy and fix config & network po ([9d1b911](https://github.com/bitnami/charts/commit/9d1b911d005add455ed5db1b379e1df13c33ddd6)), closes [#32615](https://github.com/bitnami/charts/issues/32615)
 
 ## <small>32.0.3 (2025-03-26)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.1.0
+version: 32.1.1

--- a/bitnami/kafka/templates/secrets.yaml
+++ b/bitnami/kafka/templates/secrets.yaml
@@ -68,7 +68,8 @@ type: Opaque
 data:
   cluster-id: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-kraft" (include "common.names.fullname" .)) "key" "cluster-id" "providedValues" (list "clusterId") "length" 22 "context" $) }}
   {{- range $i := until (int .Values.controller.replicaCount) }}
-  controller-{{ $i }}-id: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-kraft" (include "common.names.fullname" $)) "key" "controller-{{ $i }}-id" "providedValues" (list "") "length" 22 "context" $) }}
+  {{- $key := printf "controller-%d-id" $i }}
+  {{ $key }}: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-kraft" (include "common.names.fullname" $)) "key" $key "providedValues" (list "") "length" 22 "context" $) }}
   {{- end }}
 {{- end }}
 {{- if .Values.serviceBindings.enabled }}


### PR DESCRIPTION
### Description of the change

This PR fixes an important upgrading bug due to an issue on secret lookup with the keys.

### Benefits

Upgrading from `32.y.z` versions work

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/32620

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
