### PR TITLE
[bitnami/kakfa] bugfix: relax conditions under SASL secret must be mounted as volume

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 32.1.1 (2025-03-26)
+## 32.1.2 (2025-03-27)
 
-* [bitnami/kafka] bugfix: upgrade issue due to secret lookup ([#32621](https://github.com/bitnami/charts/pull/32621))
+* [bitnami/kakfa] bugfix: relax conditions under SASL secret must be mounted as volume ([#32631](https://github.com/bitnami/charts/pull/32631))
+
+## <small>32.1.1 (2025-03-26)</small>
+
+* [bitnami/kafka] bugfix: upgrade issue due to secret lookup (#32621) ([31af2bd](https://github.com/bitnami/charts/commit/31af2bd4ddf75dca1b9e1761a13693a8b0a90e33)), closes [#32621](https://github.com/bitnami/charts/issues/32621)
 
 ## 32.1.0 (2025-03-26)
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.1.1
+version: 32.1.2

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -225,7 +225,7 @@ spec:
               mountPath: /opt/bitnami/kafka/config/certs
               readOnly: true
             {{- end }}
-            {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) (or (regexFind "SCRAM" (upper .Values.sasl.enabledMechanisms)) (regexFind "SCRAM" (upper .Values.sasl.controllerMechanism)) (regexFind "SCRAM" (upper .Values.sasl.interBrokerMechanism))) }}
+            {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) }}
             - name: kafka-sasl
               mountPath: /opt/bitnami/kafka/config/secrets
               readOnly: true
@@ -329,7 +329,7 @@ spec:
               {{- end }}
         {{- end }}
         {{- end }}
-        {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) (or (regexFind "SCRAM" (upper .Values.sasl.enabledMechanisms)) (regexFind "SCRAM" (upper .Values.sasl.controllerMechanism)) (regexFind "SCRAM" (upper .Values.sasl.interBrokerMechanism))) }}
+        {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) }}
         - name: kafka-sasl
           projected:
             sources:

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -237,7 +237,7 @@ spec:
               mountPath: /opt/bitnami/kafka/config/certs
               readOnly: true
             {{- end }}
-            {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) (or (regexFind "SCRAM" (upper .Values.sasl.enabledMechanisms)) (regexFind "SCRAM" (upper .Values.sasl.controllerMechanism)) (regexFind "SCRAM" (upper .Values.sasl.interBrokerMechanism))) }}
+            {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) }}
             - name: kafka-sasl
               mountPath: /opt/bitnami/kafka/config/secrets
               readOnly: true
@@ -341,7 +341,7 @@ spec:
               {{- end }}
         {{- end }}
         {{- end }}
-        {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) (or (regexFind "SCRAM" (upper .Values.sasl.enabledMechanisms)) (regexFind "SCRAM" (upper .Values.sasl.controllerMechanism)) (regexFind "SCRAM" (upper .Values.sasl.interBrokerMechanism))) }}
+        {{- if and .Values.usePasswordFiles (include "kafka.saslEnabled" .) }}
         - name: kafka-sasl
           projected:
             sources:


### PR DESCRIPTION
### Description of the change

This PR relaxes the conditions under SASL secret must be mounted as volume on Kafka pods.

### Benefits

Fix statefulset(s) when using PLAIN as SASL mechanism.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
