### PR TITLE
[bitnami/external-dns] Add RBAC to support F5 TransportServer source

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.7.9 (2025-04-01)
+## 8.7.10 (2025-04-02)
 
-* [bitnami/external-dns] Release 8.7.9 ([#32728](https://github.com/bitnami/charts/pull/32728))
+* [bitnami/external-dns] Add RBAC to support F5 TransportServer source ([#32633](https://github.com/bitnami/charts/pull/32633))
+
+## <small>8.7.9 (2025-04-01)</small>
+
+* [bitnami/external-dns] Release 8.7.9 (#32728) ([dc2f56a](https://github.com/bitnami/charts/commit/dc2f56a79f2e7bf69385081c50fba9ea1109baad)), closes [#32728](https://github.com/bitnami/charts/issues/32728)
 
 ## <small>8.7.8 (2025-03-26)</small>
 

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 8.7.9
+version: 8.7.10

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -111,6 +111,7 @@ rules:
       - cis.f5.com
     resources:
       - virtualservers
+      - transportservers
     verbs:
       - get
       - watch


### PR DESCRIPTION
### Description of the change

This PR adds missing RBAC to the `external-dns` chart.

The change in this PR reflects the following upstream change: https://github.com/kubernetes-sigs/external-dns/pull/5066

Support for TransportServer as a `Source` in `external-dns` where added in `0.16.0` of `external-dns`.

### Benefits

We'll be able to configure the `--source=f5-transportserver` flag which instructs `external-dns` to list all `TransportServer` objects in the cluster, these objects will be used as a source to create DNS records in the given provider.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
