### PR TITLE
[bitnami/kibana] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/kibana/CHANGELOG.md
+++ b/bitnami/kibana/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.6.0 (2025-03-27)
+## 11.6.0 (2025-04-04)
 
 * [bitnami/kibana] Set `usePasswordFiles=true` by default ([#32636](https://github.com/bitnami/charts/pull/32636))
 

--- a/bitnami/kibana/CHANGELOG.md
+++ b/bitnami/kibana/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 11.5.3 (2025-03-25)
+## 11.6.0 (2025-03-27)
 
-* [bitnami/kibana] Release 11.5.3 ([#32604](https://github.com/bitnami/charts/pull/32604))
+* [bitnami/kibana] Set `usePasswordFiles=true` by default ([#32636](https://github.com/bitnami/charts/pull/32636))
+
+## <small>11.5.3 (2025-03-25)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/kibana] Release 11.5.3 (#32604) ([2bc41c9](https://github.com/bitnami/charts/commit/2bc41c9aa9ff2014a0c89cd626e0039a0108b29d)), closes [#32604](https://github.com/bitnami/charts/issues/32604)
 
 ## <small>11.5.2 (2025-03-04)</small>
 

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 11.5.3
+version: 11.6.0

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -283,6 +283,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `commonLabels`           | Labels to add to all deployed objects                                                                     | `{}`            |
 | `extraDeploy`            | A list of extra kubernetes resources to be deployed                                                       | `[]`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                                            | `cluster.local` |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                                         | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                   | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)                                | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                                   | `["infinity"]`  |

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -350,19 +350,19 @@ spec:
             sources:
                 {{- if and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts)) }}
                 - secret:
-                  name: {{ include "kibana.tls.secretName" . }}
+                    name: {{ include "kibana.tls.secretName" . }}
                 {{- end }}
                 {{- if .Values.elasticsearch.security.auth.enabled }}
                 - secret:
-                  name: {{ include "kibana.elasticsearch.auth.secretName" . }}
+                    name: {{ include "kibana.elasticsearch.auth.secretName" . }}
                 {{- end }}
                 {{- if and .Values.elasticsearch.security.auth.enabled .Values.elasticsearch.security.auth.createSystemUser }}
                 - secret:
-                  name: {{ tpl .Values.elasticsearch.security.auth.elasticsearchPasswordSecret . }}
+                    name: {{ tpl .Values.elasticsearch.security.auth.elasticsearchPasswordSecret . }}
                 {{- end }}
                 {{- if and .Values.elasticsearch.security.tls.enabled (not .Values.elasticsearch.security.tls.usePemCerts) (or .Values.elasticsearch.security.tls.truststorePassword .Values.elasticsearch.security.tls.passwordsSecret) }}
                 - secret:
-                  name: {{ include "kibana.elasticsearch.tls.secretName" . }}
+                    name: {{ include "kibana.elasticsearch.tls.secretName" . }}
                 {{- end }}
         {{- end }}
         - name: kibana-data

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -299,7 +299,7 @@ spec:
               mountPath: /bitnami/kibana
             - name: kibana-config
               mountPath: /bitnami/kibana/conf
-            {{- if or .Values.elasticsearch.security.auth.enabled (and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts))) }}
+            {{- if and .Values.usePasswordFiles (or .Values.elasticsearch.security.auth.enabled (and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts)))) }}
             - name: kibana-secrets
               mountPath: /opt/bitnami/kibana/secrets
             {{- end }}
@@ -342,7 +342,9 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
-        {{- if or .Values.elasticsearch.security.auth.enabled (and .Values.tls.enabled ) }}
+        {{- if and .Values.usePasswordFiles (or .Values.elasticsearch.security.auth.enabled
+        (and .Values.elasticsearch.security.tls.enabled (not .Values.elasticsearch.security.tls.usePemCerts) (or .Values.elasticsearch.security.tls.truststorePassword .Values.elasticsearch.security.tls.passwordsSecret))
+        (and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts)))) }}
         - name: kibana-secrets
           projected:
             sources:

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -166,32 +166,52 @@ spec:
               value: "true"
             {{- end }}
             {{- if and .Values.tls.enabled .Values.tls.usePemCerts (or .Values.tls.keyPassword .Values.tls.passwordsSecret) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: KIBANA_SERVER_KEY_PASSWORD_FILE
+              value: "/opt/bitnami/kibana/secrets/kibana-key-password"
+            {{- else }}
             - name: KIBANA_SERVER_KEY_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kibana.tls.secretName" . }}
                   key: kibana-key-password
             {{- end }}
+            {{- end }}
             {{- if and .Values.tls.enabled (not .Values.tls.usePemCerts) (or .Values.tls.keystorePassword .Values.tls.passwordsSecret) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: KIBANA_SERVER_KEYSTORE_PASSWORD_FILE
+              value: "/opt/bitnami/kibana/secrets/kibana-keystore-password"
+            {{- else }}
             - name: KIBANA_SERVER_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kibana.tls.secretName" . }}
                   key: kibana-keystore-password
             {{- end }}
+            {{- end }}
             {{- if .Values.elasticsearch.security.auth.enabled }}
+            {{- if .Values.usePasswordFiles }}
+            - name: KIBANA_PASSWORD_FILE
+              value: "/opt/bitnami/kibana/secrets/kibana-password"
+            {{- else }}
             - name: KIBANA_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kibana.elasticsearch.auth.secretName" . }}
                   key: kibana-password
             {{- end }}
+            {{- end }}
             {{- if and .Values.elasticsearch.security.auth.enabled .Values.elasticsearch.security.auth.createSystemUser }}
+            {{- if .Values.usePasswordFiles }}
+            - name: KIBANA_ELASTICSEARCH_PASSWORD_FILE
+              value: "/opt/bitnami/kibana/secrets/elasticsearch-password"
+            {{- else }}
             - name: KIBANA_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ tpl .Values.elasticsearch.security.auth.elasticsearchPasswordSecret . }}
                   key: elasticsearch-password
+            {{- end }}
             - name: KIBANA_CREATE_USER
               value: "true"
             {{- end }}
@@ -202,11 +222,16 @@ spec:
             - name: KIBANA_ELASTICSEARCH_TLS_VERIFICATION_MODE
               value: {{ .Values.elasticsearch.security.tls.verificationMode | quote }}
             {{- if and .Values.elasticsearch.security.tls.enabled (not .Values.elasticsearch.security.tls.usePemCerts) (or .Values.elasticsearch.security.tls.truststorePassword .Values.elasticsearch.security.tls.passwordsSecret) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: KIBANA_ELASTICSEARCH_TRUSTSTORE_PASSWORD_FILE
+              value: "/opt/bitnami/kibana/secrets/elasticsearch-truststore-password"
+            {{- else }}
             - name: KIBANA_ELASTICSEARCH_TRUSTSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kibana.elasticsearch.tls.secretName" . }}
                   key: elasticsearch-truststore-password
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
@@ -274,6 +299,10 @@ spec:
               mountPath: /bitnami/kibana
             - name: kibana-config
               mountPath: /bitnami/kibana/conf
+            {{- if or .Values.elasticsearch.security.auth.enabled (and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts))) }}
+            - name: kibana-secrets
+              mountPath: /opt/bitnami/kibana/secrets
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: kibana-certificates
               mountPath: /opt/bitnami/kibana/config/certs/server
@@ -313,6 +342,27 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if or .Values.elasticsearch.security.auth.enabled (and .Values.tls.enabled ) }}
+        - name: kibana-secrets
+          projected:
+            sources:
+                {{- if and .Values.tls.enabled (or .Values.tls.passwordsSecret (ternary .Values.tls.keyPassword .Values.tls.keystorePassword .Values.tls.usePemCerts)) }}
+                - secret:
+                  name: {{ include "kibana.tls.secretName" . }}
+                {{- end }}
+                {{- if .Values.elasticsearch.security.auth.enabled }}
+                - secret:
+                  name: {{ include "kibana.elasticsearch.auth.secretName" . }}
+                {{- end }}
+                {{- if and .Values.elasticsearch.security.auth.enabled .Values.elasticsearch.security.auth.createSystemUser }}
+                - secret:
+                  name: {{ tpl .Values.elasticsearch.security.auth.elasticsearchPasswordSecret . }}
+                {{- end }}
+                {{- if and .Values.elasticsearch.security.tls.enabled (not .Values.elasticsearch.security.tls.usePemCerts) (or .Values.elasticsearch.security.tls.truststorePassword .Values.elasticsearch.security.tls.passwordsSecret) }}
+                - secret:
+                  name: {{ include "kibana.elasticsearch.tls.secretName" . }}
+                {{- end }}
+        {{- end }}
         - name: kibana-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -57,6 +57,9 @@ extraDeploy: []
 ## @param clusterDomain Kubernetes cluster domain name
 ##
 clusterDomain: cluster.local
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment(s)/statefulset(s)
 ##
 diagnosticMode:
@@ -510,7 +513,7 @@ ingress:
   ##   path: /
   ##
   extraHosts: []
-  ## @param ingress.extraPaths Additional arbitrary path/backend objects. Evaluated as a template. 
+  ## @param ingress.extraPaths Additional arbitrary path/backend objects. Evaluated as a template.
   ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
   ## extraPaths:
   ## - path: /*


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
