### PR TITLE
[bitnami/deepspeed] Fix probes for different user ids

### DIFF
--- a/.vib/deepspeed/runtime-parameters.yaml
+++ b/.vib/deepspeed/runtime-parameters.yaml
@@ -6,11 +6,11 @@ source:
 client:
   podSecurityContext:
     enabled: true
-    fsGroup: 1001
+    fsGroup: 1002
   containerSecurityContext:
     enabled: true
-    runAsUser: 1001
-    runAsGroup: 1001
+    runAsUser: 1002
+    runAsGroup: 1002
   serviceAccount:
     create: true
   automountServiceAccountToken: true

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -36,4 +36,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.3.6
+version: 2.3.7

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -158,8 +158,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.client.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - deepspeed
-                - --help
+                - bash
+                - -c
+                - |
+                  [[ -f "/opt/bitnami/scripts/deepspeed/entrypoint.sh" ]] && source "/opt/bitnami/scripts/deepspeed/entrypoint.sh"
+                  deepspeed --help
           {{- end }}
           {{- if .Values.client.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.client.customReadinessProbe "context" $) | nindent 12 }}
@@ -167,9 +170,11 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.client.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - python
+                - bash
                 - -c
-                - import deepspeed; deepspeed.__version__
+                - |
+                  [[ -f "/opt/bitnami/scripts/deepspeed/entrypoint.sh" ]] && source "/opt/bitnami/scripts/deepspeed/entrypoint.sh"
+                  python -c "import deepspeed; print(deepspeed.__version__)"
           {{- end }}
           {{- if .Values.client.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.client.customStartupProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

This change updates readiness and liveness probes to make them work with an user different from 1001