### PR TITLE
bitnami/external-dns: do not set EXTERNAL_DNS_RFC2136_TSIG_SECRET when rfc2136 provider is not used

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.7.10 (2025-04-02)
+## 8.7.11 (2025-04-08)
 
-* [bitnami/external-dns] Add RBAC to support F5 TransportServer source ([#32633](https://github.com/bitnami/charts/pull/32633))
+* bitnami/external-dns: do not set EXTERNAL_DNS_RFC2136_TSIG_SECRET when rfc2136 provider is not used ([#32661](https://github.com/bitnami/charts/pull/32661))
+
+## <small>8.7.10 (2025-04-03)</small>
+
+* [bitnami/external-dns] Add RBAC to support F5 TransportServer source (#32633) ([8ac86c0](https://github.com/bitnami/charts/commit/8ac86c06ed7fafd739abb335a9ff99794ca548aa)), closes [#32633](https://github.com/bitnami/charts/issues/32633)
 
 ## <small>8.7.9 (2025-04-01)</small>
 

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 8.7.10
+version: 8.7.11

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -635,6 +635,7 @@ spec:
                   key: infoblox_wapi_password
             {{- end }}
             {{- end }}
+            {{- if eq .Values.provider "rfc2136" }}
             {{- if .Values.rfc2136.tsigSecret | or (and .Values.rfc2136.kerberosUsername .Values.rfc2136.kerberosPassword) | or .Values.rfc2136.secretName }}
             # RFC 2136 environment variables
             {{- if .Values.rfc2136.rfc3645Enabled }}
@@ -654,6 +655,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "external-dns.secretName" . }}
                   key: rfc2136_tsig_secret
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if eq .Values.provider "pdns" }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change will prevent setting EXTERNAL_DNS_RFC2136_TSIG_SECRET variable from a secret when `.Values.provider` is not set to `rfc2136`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Prevent accidental misconfiguration. Especially when using chart as a downstream library.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

I have a use case where I am using this helm chart as a dependency and allow for configuring two providers. To allow for easy debugging, I am preconfiguring this helm chart and setting `rfc2136.secretName` (secret is generated via other means and name is static). However when I want to use other provider (via `.Values.provider`), the `EXTERNAL_DNS_RFC2136_TSIG_SECRET` is still included in the Deployment object, which I would consider a bug.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
