### PR TITLE
[bitnami/common] Add global.security.allowEmptyPassword

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 2.31.0 (2025-03-28)
 
-* [bitnami/common] Add global.security.allowEmptyPassword ([#32669](https://github.com/bitnami/charts/pull/32669))
+* [bitnami/common] Add global.security.allowEmptyPassword ([#32675](https://github.com/bitnami/charts/pull/32675))
 
 ## 2.30.0 (2025-02-19)
 
-* [bitnami/common] Add helper to check API versions ([#31969](https://github.com/bitnami/charts/pull/31969))
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/common] Add helper to check API versions (#31969) ([5ba89c5](https://github.com/bitnami/charts/commit/5ba89c5afc3d57e36f90364638d9beabb32499f4)), closes [#31969](https://github.com/bitnami/charts/issues/31969)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## <small>2.29.1 (2025-01-23)</small>
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.31.0 (2025-03-28)
+
+* [bitnami/common] Add global.security.allowEmptyPassword ([#32669](https://github.com/bitnami/charts/pull/32669))
+
 ## 2.30.0 (2025-02-19)
 
 * [bitnami/common] Add helper to check API versions ([#31969](https://github.com/bitnami/charts/pull/31969))

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.31.0 (2025-03-28)
+## 2.31.0 (2025-04-21)
 
 * [bitnami/common] Add global.security.allowEmptyPassword ([#32675](https://github.com/bitnami/charts/pull/32675))
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.30.0
+appVersion: 2.31.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.30.0
+version: 2.31.0

--- a/bitnami/common/templates/_errors.tpl
+++ b/bitnami/common/templates/_errors.tpl
@@ -17,13 +17,16 @@ Required password params:
   - context - Context - Required. Parent context.
 */}}
 {{- define "common.errors.upgrade.passwords.empty" -}}
-  {{- $validationErrors := join "" .validationErrors -}}
-  {{- if and $validationErrors .context.Release.IsUpgrade -}}
-    {{- $errorString := "\nPASSWORDS ERROR: You must provide your current passwords when upgrading the release." -}}
-    {{- $errorString = print $errorString "\n                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims." -}}
-    {{- $errorString = print $errorString "\n                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases" -}}
-    {{- $errorString = print $errorString "\n%s" -}}
-    {{- printf $errorString $validationErrors | fail -}}
+  {{- $globalSecurityValues := ((.context.Values.global).security) -}}
+  {{- if not (hasKey $globalSecurityValues "allowEmptyPassword" | ternary $globalSecurityValues.allowEmptyPassword false) -}}
+    {{- $validationErrors := join "" .validationErrors -}}
+    {{- if and $validationErrors .context.Release.IsUpgrade -}}
+      {{- $errorString := "\nPASSWORDS ERROR: You must provide your current passwords when upgrading the release." -}}
+      {{- $errorString = print $errorString "\n                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims." -}}
+      {{- $errorString = print $errorString "\n                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases" -}}
+      {{- $errorString = print $errorString "\n%s" -}}
+      {{- printf $errorString $validationErrors | fail -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

Add an option `global.security.allowEmptyPassword` to bypass empty password verification checks when using external vaults/secrets that manages this part

### Benefits

Creating via `.Values.extraDeploy` an ExternalSecret resource inside the bitnami release when upgrading from values based passwords to external vault secret based passwords

### Possible drawbacks

None as it keeps backward compatibility if the field is not present

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
