### PR TITLE
bitnami/spring-cloud-dataflow fix for #32453

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -54,4 +54,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 35.0.0
+version: 35.0.1

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -102,8 +102,12 @@ spec:
             - name: rsocket
               containerPort: {{ .Values.metrics.containerPorts.rsocket }}
               protocol: TCP
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
           {{- if .Values.metrics.extraVolumeMounts }}
-          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.metrics.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.resources "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Changes prometheus-proxy/deployment.yaml so that `/tmp` becomes writable, as per [comment on #32453](https://github.com/bitnami/charts/issues/32453#issuecomment-2724184253)

(forced push on the branch from #32456 in order to fix conflicts preventing merge, so ended up here with the previous PR closed, apologies for the noise)

### Benefits

`/tmp` becomes writable, fixing #32453

### Possible drawbacks

N/A

### Applicable issues

- fixes #32453

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
