### PR TITLE
Use VIB_ENV_TARGET_PLATFORM instead of VIB_ENV_ALTERNATIVE_TARGET_PLATFORM

### DIFF
--- a/.vib/apisix/vib-verify.json
+++ b/.vib/apisix/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/apisix"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/aspnet-core/vib-verify.json
+++ b/.vib/aspnet-core/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/aspnet-core"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/cloudnative-pg/vib-verify.json
+++ b/.vib/cloudnative-pg/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/cloudnative-pg"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "M4"
           }

--- a/.vib/contour/vib-verify.json
+++ b/.vib/contour/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/contour"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/elasticsearch/vib-verify.json
+++ b/.vib/elasticsearch/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/elasticsearch"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "L4"
           }

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/fluentd"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4",
             "worker_nodes_instance_count": 1

--- a/.vib/gitlab-runner/vib-verify.json
+++ b/.vib/gitlab-runner/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/gitlab-runner"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/kong"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/kubernetes-event-exporter/vib-verify.json
+++ b/.vib/kubernetes-event-exporter/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/kubernetes-event-exporter"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/memcached/vib-verify.json
+++ b/.vib/memcached/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/memcached"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/milvus/vib-verify.json
+++ b/.vib/milvus/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/milvus"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "L4"
           }

--- a/.vib/nginx-ingress-controller/vib-verify.json
+++ b/.vib/nginx-ingress-controller/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/nginx-ingress-controller"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/odoo/vib-verify.json
+++ b/.vib/odoo/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/odoo"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "M4"
           }

--- a/.vib/opensearch/vib-verify.json
+++ b/.vib/opensearch/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/opensearch"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "L4"
           }

--- a/.vib/pinniped/vib-verify.json
+++ b/.vib/pinniped/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/pinniped"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/rabbitmq-cluster-operator/vib-verify.json
+++ b/.vib/rabbitmq-cluster-operator/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/rabbitmq-cluster-operator"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "M4"
           }

--- a/.vib/redmine/vib-verify.json
+++ b/.vib/redmine/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/redmine"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "S4"
           }

--- a/.vib/sonarqube/vib-verify.json
+++ b/.vib/sonarqube/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/sonarqube"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "L4"
           }

--- a/.vib/victoriametrics/vib-verify.json
+++ b/.vib/victoriametrics/vib-verify.json
@@ -32,7 +32,7 @@
           "path": "/bitnami/victoriametrics"
         },
         "target_platform": {
-          "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
             "name": "M4"
           }


### PR DESCRIPTION
Since both environment variables were pointing to GKE (now EKS), this PR unifies the pipeline definitions to consistently use the same variable.