### PR TITLE
[bitnami/dremio] Bump MinIO major version 16.x.x

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.6.3 (2025-03-26)
+## 1.0.0 (2025-04-01)
 
-* [bitnami/dremio] Release 0.6.3 ([#32625](https://github.com/bitnami/charts/pull/32625))
+* [bitnami/dremio] Bump MinIO major version 16.x.x ([#32698](https://github.com/bitnami/charts/pull/32698))
+
+## <small>0.6.3 (2025-03-26)</small>
+
+* [bitnami/dremio] Release 0.6.3 (#32625) ([45249e5](https://github.com/bitnami/charts/commit/45249e577b6d6971eb5c807ba4d920713e3c497d)), closes [#32625](https://github.com/bitnami/charts/issues/32625)
 
 ## <small>0.6.2 (2025-03-26)</small>
 

--- a/bitnami/dremio/Chart.lock
+++ b/bitnami/dremio/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.0.7
+  version: 16.0.0
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.7.4
+  version: 13.7.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.30.0
-digest: sha256:46ca5063e5820c488e148bd09b84e97a062f29725493a3769834c064acfd2aa6
-generated: "2025-03-21T14:12:58.864130434Z"
+digest: sha256:a0816f8e2143a0d3ea39a24c5ada295fab5a3a12aed042b9a9e62810f598703c
+generated: "2025-04-01T13:04:54.967008+02:00"

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -42,4 +42,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 0.6.3
+version: 1.0.0

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
+  version: 16.x.x
 - condition: zookeeper.enabled
   name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/dremio/README.md
+++ b/bitnami/dremio/README.md
@@ -1294,6 +1294,12 @@ helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/dremi
 
 ## Troubleshooting
 
+## Upgrading
+
+### To 1.0.0
+
+This major updates the `minio` subchart to its newest major, 16.0.0. For more information on this subchart's major, please refer to [minio upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/minio#to-1600).
+
 ## License
 
 Copyright &copy; 2025 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.


### PR DESCRIPTION
### Description of the change

Bumps a major version updating the Minio subchart version to 16.x.x

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
