### PR TITLE
[bitnami/grafana-mimir] Bump MinIO major version 16.x.x

### DIFF
--- a/bitnami/grafana-mimir/CHANGELOG.md
+++ b/bitnami/grafana-mimir/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.6 (2025-03-31)
+## 2.0.0 (2025-04-01)
 
-* [bitnami/grafana-mimir] Release 1.4.6 ([#32689](https://github.com/bitnami/charts/pull/32689))
+* [bitnami/grafana-mimir] Bump MinIO major version 16.x.x ([#32699](https://github.com/bitnami/charts/pull/32699))
+
+## <small>1.4.6 (2025-03-31)</small>
+
+* [bitnami/grafana-mimir] Release 1.4.6 (#32689) ([2bae692](https://github.com/bitnami/charts/commit/2bae6925d2c4b85b604e60258b6e78db7d4f8826)), closes [#32689](https://github.com/bitnami/charts/issues/32689)
 
 ## <small>1.4.5 (2025-03-13)</small>
 

--- a/bitnami/grafana-mimir/Chart.lock
+++ b/bitnami/grafana-mimir/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.0.7
+  version: 16.0.0
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 7.8.0
@@ -17,5 +17,5 @@ dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.30.0
-digest: sha256:baf977cc28e70f50fcdff8c41bb9a4eaa62e22809cce1f71a00963858aab157a
-generated: "2025-03-31T16:16:43.035229071Z"
+digest: sha256:e78a9060d8102c7676598637285956fee96af3cb72af046b5a817d6ddd309646
+generated: "2025-04-01T13:05:22.459104+02:00"

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
+  version: 16.x.x
 - alias: memcachedmetadata
   condition: memcachedmetadata.enabled
   name: memcached

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -60,4 +60,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 1.4.6
+version: 2.0.0

--- a/bitnami/grafana-mimir/README.md
+++ b/bitnami/grafana-mimir/README.md
@@ -1543,6 +1543,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 2.0.0
+
+This major updates the `minio` subchart to its newest major, 16.0.0. For more information on this subchart's major, please refer to [minio upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/minio#to-1600).
+
 ### To 1.3.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

Bumps a major version updating the Minio subchart version to 16.x.x

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
