### PR TITLE
[bitnami/wildfly] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/wildfly/CHANGELOG.md
+++ b/bitnami/wildfly/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 23.0.6 (2025-03-27)
+## 23.1.0 (2025-04-01)
 
-* [bitnami/wildfly] Release 23.0.6 ([#32630](https://github.com/bitnami/charts/pull/32630))
+* [bitnami/wildfly] Set `usePasswordFiles=true` by default ([#32704](https://github.com/bitnami/charts/pull/32704))
+
+## <small>23.0.6 (2025-03-27)</small>
+
+* [bitnami/wildfly] Release 23.0.6 (#32630) ([a28ac2f](https://github.com/bitnami/charts/commit/a28ac2f0c9ed06113d9c4a03db96e15d540422db)), closes [#32630](https://github.com/bitnami/charts/issues/32630)
 
 ## <small>23.0.5 (2025-03-13)</small>
 

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: wildfly
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wildfly
-version: 23.0.6
+version: 23.1.0

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -172,6 +172,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                       | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)              | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                 | `["infinity"]`  |

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -126,11 +126,16 @@ spec:
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: WILDFLY_USERNAME
               value: {{ default "" .Values.wildflyUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: WILDFLY_PASSWORD_FILE
+              value: "/opt/bitnami/wildfly/secrets/wildfly-password"
+            {{- else }}
             - name: WILDFLY_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "common.names.fullname" . }}
                   key: wildfly-password
+            {{- end }}
             - name: WILDFLY_HTTP_PORT_NUMBER
               value: {{ .Values.containerPorts.http | quote }}
             - name: WILDFLY_HTTPS_PORT_NUMBER
@@ -205,6 +210,10 @@ spec:
               subPath: tmp-dir
             - name: data
               mountPath: /bitnami/wildfly
+            {{- if  .Values.usePasswordFiles }}
+            - name: wildfly-secrets
+              mountPath: /opt/bitnami/wildfly/secrets
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -214,6 +223,13 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if .Values.usePasswordFiles }}
+        - name: wildfly-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ template "common.names.fullname" . }}
+        {{- end }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -57,6 +57,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment(s)/statefulset(s)
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
