### PR TITLE
[bitnami/moodle] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/moodle/CHANGELOG.md
+++ b/bitnami/moodle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 25.2.0 (2025-04-01)
+## 25.2.0 (2025-04-04)
 
 * [bitnami/moodle] Set `usePasswordFiles=true` by default ([#32705](https://github.com/bitnami/charts/pull/32705))
 

--- a/bitnami/moodle/CHANGELOG.md
+++ b/bitnami/moodle/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 25.1.5 (2025-03-17)
+## 25.2.0 (2025-04-01)
 
-* [bitnami/moodle] Release 25.1.5 ([#32473](https://github.com/bitnami/charts/pull/32473))
+* [bitnami/moodle] Set `usePasswordFiles=true` by default ([#32705](https://github.com/bitnami/charts/pull/32705))
+
+## <small>25.1.5 (2025-03-17)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/moodle] Release 25.1.5 (#32473) ([313c5b6](https://github.com/bitnami/charts/commit/313c5b61f8981333edbe04e7b66d37594f04dc1a)), closes [#32473](https://github.com/bitnami/charts/issues/32473)
 
 ## <small>25.1.4 (2025-02-21)</small>
 

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 25.1.5
+version: 25.2.0

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -162,14 +162,15 @@ You may want to review the [PV reclaim policy](https://kubernetes.io/docs/tasks/
 
 ### Common parameters
 
-| Name                | Description                                                                                                | Value |
-| ------------------- | ---------------------------------------------------------------------------------------------------------- | ----- |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                                       | `""`  |
-| `nameOverride`      | String to partially override moodle.fullname template                                                      | `""`  |
-| `fullnameOverride`  | String to fully override moodle.fullname template                                                          | `""`  |
-| `commonAnnotations` | Common annotations to add to all Harbor resources (sub-charts are not considered). Evaluated as a template | `{}`  |
-| `commonLabels`      | Common labels to add to all Harbor resources (sub-charts are not considered). Evaluated as a template      | `{}`  |
-| `extraDeploy`       | Array with extra yaml to deploy with the chart. Evaluated as a template                                    | `[]`  |
+| Name                | Description                                                                                                | Value  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- | ------ |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                                       | `""`   |
+| `nameOverride`      | String to partially override moodle.fullname template                                                      | `""`   |
+| `fullnameOverride`  | String to fully override moodle.fullname template                                                          | `""`   |
+| `commonAnnotations` | Common annotations to add to all Harbor resources (sub-charts are not considered). Evaluated as a template | `{}`   |
+| `commonLabels`      | Common labels to add to all Harbor resources (sub-charts are not considered). Evaluated as a template      | `{}`   |
+| `extraDeploy`       | Array with extra yaml to deploy with the chart. Evaluated as a template                                    | `[]`   |
+| `usePasswordFiles`  | Mount credentials as files instead of using environment variables                                          | `true` |
 
 ### Moodle&trade; parameters
 

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -169,20 +169,30 @@ spec:
               value: {{ include "moodle.databaseName" . | quote }}
             - name: MOODLE_DATABASE_USER
               value: {{ include "moodle.databaseUser" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MOODLE_DATABASE_PASSWORD_FILE
+              value: "/opt/bitnami/moodle/secrets/mariadb-password"
+            {{- else }}
             - name: MOODLE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "moodle.databaseSecretName" . }}
                   key: mariadb-password
+            {{- end }}
             - name: MOODLE_SKIP_BOOTSTRAP
               value: {{ ternary "yes" "no" .Values.moodleSkipInstall | quote }}
             - name: MOODLE_USERNAME
               value: {{ .Values.moodleUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MOODLE_PASSWORD_FILE
+              value: "/opt/bitnami/moodle/secrets/moodle-password"
+            {{- else }}
             - name: MOODLE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "moodle.secretName" . }}
                   key: moodle-password
+            {{- end }}
             {{- if .Values.moodleSiteName }}
             - name: MOODLE_SITE_NAME
               value: {{ .Values.moodleSiteName| quote }}
@@ -206,11 +216,16 @@ spec:
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
             {{- if .Values.smtpPassword }}
+            {{- if .Values.usePasswordFiles }}
+            - name: SMTP_PASSWORD
+              value: "/opt/bitnami/moodle/secrets/smtp-password"
+            {{- else }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.names.fullname" . }}
                   key: smtp-password
+            {{- end }}
             {{- end }}
             {{- if .Values.smtpProtocol }}
             - name: SMTP_PROTOCOL
@@ -289,6 +304,10 @@ spec:
             - name: moodle-data
               mountPath: /bitnami/moodledata
               subPath: moodledata
+            {{- if  .Values.usePasswordFiles }}
+            - name: moodle-secrets
+              mountPath: /opt/bitnami/moodle/secrets
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -322,6 +341,19 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if .Values.usePasswordFiles }}
+        - name: moodle-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "moodle.databaseSecretName" . }}
+              - secret:
+                  name: {{ include "moodle.secretName" . }}
+              {{- if .Values.smtpPassword }}
+              - secret:
+                  name: {{ include "common.names.fullname" . }}
+              {{- end }}
+        {{- end }}
         - name: moodle-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -171,7 +171,7 @@ spec:
               value: {{ include "moodle.databaseUser" . | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: MOODLE_DATABASE_PASSWORD_FILE
-              value: "/opt/bitnami/moodle/secrets/mariadb-password"
+              value: "/secrets/mariadb-password"
             {{- else }}
             - name: MOODLE_DATABASE_PASSWORD
               valueFrom:
@@ -185,7 +185,7 @@ spec:
               value: {{ .Values.moodleUsername | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: MOODLE_PASSWORD_FILE
-              value: "/opt/bitnami/moodle/secrets/moodle-password"
+              value: "/secrets/moodle-password"
             {{- else }}
             - name: MOODLE_PASSWORD
               valueFrom:
@@ -218,7 +218,7 @@ spec:
             {{- if .Values.smtpPassword }}
             {{- if .Values.usePasswordFiles }}
             - name: SMTP_PASSWORD
-              value: "/opt/bitnami/moodle/secrets/smtp-password"
+              value: "/secrets/smtp-password"
             {{- else }}
             - name: SMTP_PASSWORD
               valueFrom:
@@ -306,7 +306,7 @@ spec:
               subPath: moodledata
             {{- if  .Values.usePasswordFiles }}
             - name: moodle-secrets
-              mountPath: /opt/bitnami/moodle/secrets
+              mountPath: /secrets
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -52,6 +52,9 @@ commonLabels: {}
 ## @param extraDeploy Array with extra yaml to deploy with the chart. Evaluated as a template
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## @section Moodle&trade; parameters
 
 ## Bitnami Moodle&trade; image version


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
