### PR TITLE
[bitnami/neo4j] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/neo4j
 - https://github.com/bitnami/containers/tree/main/bitnami/neo4j
 - https://github.com/neo4j/neo4j
-version: 0.3.3
+version: 0.4.0

--- a/bitnami/neo4j/templates/statefulset.yaml
+++ b/bitnami/neo4j/templates/statefulset.yaml
@@ -129,6 +129,10 @@ spec:
               value: {{ .Values.service.ports.bolt | quote }}
             - name: NEO4J_HTTP_ADVERTISED_PORT_NUMBER
               value: {{ .Values.service.ports.http | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: NEO4J_PASSWORD_FILE
+              value: "/opt/bitnami/neo4j/secrets/password"
+            {{- else }}
             - name: NEO4J_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -223,6 +227,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/neo4j/run
               subPath: app-run-dir
+            {{- if  .Values.usePasswordFiles }}
+            - name: neo4j-secrets
+              mountPath: /opt/bitnami/neo4j/secrets
+            {{- end }}
             {{- if or .Values.existingConfigmap .Values.configuration .Values.apocConfiguration }}
             - name: config-dir
               mountPath: /bitnami/neo4j/conf
@@ -250,6 +258,13 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if .Values.usePasswordFiles }}
+        - name: neo4j-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "neo4j.secretName" . }}
+        {{- end }}
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/neo4j/values.yaml
+++ b/bitnami/neo4j/values.yaml
@@ -66,6 +66,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Diagnostic mode
 ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
 ## @param diagnosticMode.command Command to override all containers in the chart release


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
