### PR TITLE
[bitnami/odoo] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: odoo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/odoo
-version: 28.1.4
+version: 28.2.0

--- a/bitnami/odoo/templates/deployment.yaml
+++ b/bitnami/odoo/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
           volumeMounts:
             - name: odoo-data
               mountPath: /bitnami/odoo
-              {{- if .Values.persistence.subPath }} 
-              subPath: {{ .Values.persistence.subPath }} 
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
               {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
@@ -131,11 +131,16 @@ spec:
               value: {{ .Values.odooDatabaseFilter | quote }}
             - name: ODOO_DATABASE_USER
               value: {{ template "odoo.databaseUser" . }}
+            {{- if .Values.usePasswordFiles }}
+            - name: ODOO_DATABASE_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/odoo/secrets/%s" (include "odoo.databaseSecretPasswordKey" .) }}
+            {{- else }}
             - name: ODOO_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "odoo.databaseSecretName" . }}
                   key: {{ include "odoo.databaseSecretPasswordKey" . }}
+            {{- end }}
             {{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.create }}
             - name: POSTGRESQL_CLIENT_DATABASE_HOST
               value: {{ template "odoo.databaseHost" . }}
@@ -143,28 +148,43 @@ spec:
               value: {{ template "odoo.databasePort" . }}
             - name: POSTGRESQL_CLIENT_POSTGRES_USER
               value: {{ .Values.externalDatabase.postgresqlPostgresUser }}
+            {{- if .Values.usePasswordFiles }}
+            - name: POSTGRESQL_CLIENT_POSTGRES_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/odoo/secrets/%s" (include "odoo.databaseSecretPostgresPasswordKey" .) }}
+            {{- else }}
             - name: POSTGRESQL_CLIENT_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "odoo.databaseSecretName" . }}
                   key: {{ include "odoo.databaseSecretPostgresPasswordKey" . }}
+            {{- end }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_NAME
               value: {{ template "odoo.databaseName" . }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_USERNAME
               value: {{ template "odoo.databaseUser" . }}
+            {{- if .Values.usePasswordFiles }}
+            - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/odoo/secrets/%s" (include "odoo.databaseSecretPasswordKey" .) }}
+            {{- else }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "odoo.databaseSecretName" . }}
                   key: {{ include "odoo.databaseSecretPasswordKey" . }}
             {{- end }}
+            {{- end }}
             - name: ODOO_EMAIL
               value: {{ .Values.odooEmail | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: ODOO_PASSWORD_FILE
+              value: "/opt/bitnami/odoo/secrets/odoo-password"
+            {{- else }}
             - name: ODOO_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "odoo.secretName" . }}
                   key: odoo-password
+            {{- end }}
             - name: ODOO_SKIP_BOOTSTRAP
               value: {{ ternary "yes" "no" .Values.odooSkipInstall | quote }}
             - name: ODOO_LOAD_DEMO_DATA
@@ -186,11 +206,16 @@ spec:
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
             {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
+            {{- if .Values.usePasswordFiles }}
+            - name: ODOO_SMTP_PASSWORD_FILE
+              value: "/opt/bitnami/odoo/secrets/smtp-password"
+            {{- else }}
             - name: ODOO_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "odoo.smtpSecretName" . }}
                   key: smtp-password
+            {{- end }}
             {{- end }}
             {{- if .Values.smtpProtocol }}
             - name: ODOO_SMTP_PROTOCOL
@@ -247,9 +272,13 @@ spec:
           volumeMounts:
             - name: odoo-data
               mountPath: /bitnami/odoo
-              {{- if .Values.persistence.subPath }} 
-              subPath: {{ .Values.persistence.subPath }} 
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
               {{- end }}
+            {{- if .Values.usePasswordFiles }}
+            - name: odoo-secrets
+              mountPath: /opt/bitnami/odoo/secrets
+            {{- end }}
             {{- if .Values.customPostInitScripts }}
             - mountPath: /docker-entrypoint-init.d
               name: custom-postinit
@@ -268,6 +297,19 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.usePasswordFiles }}
+        - name: odoo-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "odoo.secretName" . }}
+              - secret:
+                  name: {{ include "odoo.databaseSecretName" . }}
+              {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
+              - secret:
+                  name: {{ template "odoo.smtpSecretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if .Values.customPostInitScripts }}
         - name: custom-postinit
           configMap:

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -59,6 +59,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the statefulset
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
