### PR TITLE
[bitnami/scylladb] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 3.2.1 (2025-03-22)
+## 3.3.0 (2025-04-01)
 
-* [bitnami/scylladb] Release 3.2.1 ([#32562](https://github.com/bitnami/charts/pull/32562))
+* [bitnami/scylladb] Set `usePasswordFiles=true` by default ([#32710](https://github.com/bitnami/charts/pull/32710))
+
+## <small>3.2.1 (2025-03-22)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/scylladb] Release 3.2.1 (#32562) ([5e073d5](https://github.com/bitnami/charts/commit/5e073d57d40783d8ac90e9a5861f3d10d0499750)), closes [#32562](https://github.com/bitnami/charts/issues/32562)
 
 ## 3.2.0 (2025-02-20)
 

--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.3.0 (2025-04-01)
+## 3.3.0 (2025-04-04)
 
 * [bitnami/scylladb] Set `usePasswordFiles=true` by default ([#32710](https://github.com/bitnami/charts/pull/32710))
 

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: scylladb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 3.2.1
+version: 3.3.0

--- a/bitnami/scylladb/README.md
+++ b/bitnami/scylladb/README.md
@@ -170,6 +170,7 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 | `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                       | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |

--- a/bitnami/scylladb/templates/statefulset.yaml
+++ b/bitnami/scylladb/templates/statefulset.yaml
@@ -210,7 +210,7 @@ spec:
               value: {{ (include "scylladb.seeds" .) | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: SCYLLADB_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password") }}
+              value: {{ printf "/opt/bitnami/scylladb/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password") }}
             {{- else }}
             - name: SCYLLADB_PASSWORD
               valueFrom:

--- a/bitnami/scylladb/templates/statefulset.yaml
+++ b/bitnami/scylladb/templates/statefulset.yaml
@@ -208,11 +208,16 @@ spec:
               value: {{ .Values.cluster.name }}
             - name: SCYLLADB_SEEDS
               value: {{ (include "scylladb.seeds" .) | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: SCYLLADB_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password") }}
+            {{- else }}
             - name: SCYLLADB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.dbUser.existingSecret "context" $) }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password") }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -461,6 +466,10 @@ spec:
             - name: empty-dir
               mountPath: /.cassandra
               subPath: app-cqlsh-tmp-dir
+            {{- if  .Values.usePasswordFiles }}
+            - name: scylladb-secrets
+              mountPath: /opt/bitnami/scylladb/secrets
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -622,6 +631,13 @@ spec:
         - name: init-db-secret
           secret:
             secretName: {{ tpl .Values.initDBSecret $ }}
+        {{- end }}
+        {{- if .Values.usePasswordFiles }}
+        - name: scylladb-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.dbUser.existingSecret "context" $) }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/scylladb/templates/statefulset.yaml
+++ b/bitnami/scylladb/templates/statefulset.yaml
@@ -210,7 +210,7 @@ spec:
               value: {{ (include "scylladb.seeds" .) | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: SCYLLADB_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/scylladb/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password") }}
+              value: {{ printf "/opt/bitnami/scylladb/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "scylladb-password")) }}
             {{- else }}
             - name: SCYLLADB_PASSWORD
               valueFrom:

--- a/bitnami/scylladb/values.yaml
+++ b/bitnami/scylladb/values.yaml
@@ -62,6 +62,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
