### PR TITLE
[bitnami/schema-registry] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 25.1.0 (2025-04-01)
+
+* [bitnami/schema-registry] Set `usePasswordFiles=true` by default ([#32713](https://github.com/bitnami/charts/pull/32713))
+
 ## 25.0.0 (2025-03-26)
 
-* [bitnami/schema-registry] feat: bump major due to major bump on Kafka dep ([#32618](https://github.com/bitnami/charts/pull/32618))
+* [bitnami/schema-registry] feat: bump major due to major bump on Kafka dep (#32618) ([d1bd546](https://github.com/bitnami/charts/commit/d1bd54623e3b6c26ae2358a5295e106b396e3702)), closes [#32618](https://github.com/bitnami/charts/issues/32618)
 
 ## 24.0.0 (2025-03-12)
 

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 25.0.0
+version: 25.1.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -226,6 +226,7 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 | `commonAnnotations`      | Annotations to add to all deployed objects                                                                | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                                            | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                                         | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                                         | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                   | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                                      | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                                         | `["infinity"]`  |

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -176,11 +176,16 @@ spec:
               {{- else }}
               value: {{ .Values.externalKafka.sasl.user | quote }}
               {{- end }}
+            {{- if .Values.userPasswordFiles }}
+            - name: SCHEMA_REGISTRY_KAFKA_SASL_PASSWORDS
+              value: "/opt/bitnami/schema-registry/secrets/client-passwords"
+            {{- else }}
             - name: SCHEMA_REGISTRY_KAFKA_SASL_PASSWORDS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "schema-registry.secretName" . }}
                   key: client-passwords
+            {{- end }}
             {{- end }}
             {{- if contains "SSL" $kafkaProtocol }}
             - name: SCHEMA_REGISTRY_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
@@ -255,6 +260,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/schema-registry/logs
               subPath: app-logs-dir
+            {{- if and .Values.usePasswordFiles (contains "SASL" $kafkaProtocol) }}
+            - name: schema-registry-secrets
+              mountPath: /opt/bitnami/schema-registry/secrets
+            {{- end }}
             {{- if or .Values.configuration .Values.existingConfigmap }}
             - name: configuration
               mountPath: /bitnami/schema-registry/etc/schema-registry/schema-registry.properties
@@ -279,6 +288,13 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if and .Values.usePasswordFiles (contains "SASL" $kafkaProtocol) }}
+        - name: schema-registry-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "schema-registry.secretName" . }}
+        {{- end }}
         {{- if or .Values.configuration .Values.existingConfigmap }}
         - name: configuration
           configMap:

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -57,6 +57,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
