### PR TITLE
[bitnami/tomcat] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/tomcat/CHANGELOG.md
+++ b/bitnami/tomcat/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 11.6.1 (2025-03-27)
+## 11.7.0 (2025-04-02)
 
-* [bitnami/tomcat] Release 11.6.1 ([#32629](https://github.com/bitnami/charts/pull/32629))
+* [bitnami/tomcat] Set `usePasswordFiles=true` by default ([#32767](https://github.com/bitnami/charts/pull/32767))
+
+## <small>11.6.1 (2025-03-27)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/tomcat] Release 11.6.1 (#32629) ([da54156](https://github.com/bitnami/charts/commit/da541565254f8a73b4bf1eb62746235e70dbed12)), closes [#32629](https://github.com/bitnami/charts/issues/32629)
 
 ## 11.6.0 (2025-03-12)
 

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 11.6.1
+version: 11.7.0

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -195,6 +195,7 @@ You can enable this init container by setting `volumePermissions.enabled` to `tr
 | `commonAnnotations` | Add annotations to all the deployed resources                                                | `{}`            |
 | `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
+| `usePasswordFiles`  | Mount credentials as files instead of using environment variables                            | `true`          |
 
 ### Tomcat parameters
 

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -59,6 +59,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## @section Tomcat parameters
 ##
 


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
