### PR TITLE
[bitnami/wordpress] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.18 (2025-03-06)
+## 24.2.0 (2025-04-02)
 
-* [bitnami/wordpress] fix network policy when metrics enabled ([#32338](https://github.com/bitnami/charts/pull/32338))
+* [bitnami/wordpress] Set `usePasswordFiles=true` by default ([#32770](https://github.com/bitnami/charts/pull/32770))
+
+## <small>24.1.18 (2025-03-07)</small>
+
+* [bitnami/wordpress] fix network policy when metrics enabled (#32338) ([ddcee74](https://github.com/bitnami/charts/commit/ddcee74411ab886e7ff1831e248392cf6dfed668)), closes [#32338](https://github.com/bitnami/charts/issues/32338)
 
 ## <small>24.1.17 (2025-03-06)</small>
 

--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.2.0 (2025-04-02)
+## 24.2.0 (2025-04-04)
 
 * [bitnami/wordpress] Set `usePasswordFiles=true` by default ([#32770](https://github.com/bitnami/charts/pull/32770))
 

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -45,4 +45,4 @@ maintainers:
 name: wordpress
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 24.1.18
+version: 24.2.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -294,6 +294,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `commonAnnotations`      | Annotations to add to all deployed resources                                                 | `{}`            |
 | `clusterDomain`          | Kubernetes Cluster Domain                                                                    | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                            | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                            | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                         | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                            | `["infinity"]`  |

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -370,19 +370,6 @@ spec:
             - mountPath: /bitnami/wordpress
               name: wordpress-data
               subPath: wordpress
-            {{- if .Values.usePasswordFiles }}
-            - name: wordpress-secrets
-              projected:
-                sources:
-                  - secret:
-                      name:  {{ include "wordpress.secretName" . }}
-                  - secret:
-                      name:  {{ include "wordpress.databaseSecretName" . }}
-                  {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
-                  - secret:
-                      name:  {{ include "wordpress.smtpSecretName" . }}
-                  {{- end }}
-            {{- end }}
             {{- if  .Values.usePasswordFiles }}
             - name: wordpress-secrets
               mountPath: /opt/bitnami/wordpress/secrets
@@ -466,6 +453,19 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if .Values.usePasswordFiles }}
+        - name: wordpress-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "wordpress.secretName" . }}
+              - secret:
+                  name:  {{ include "wordpress.databaseSecretName" . }}
+              {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
+              - secret:
+                  name:  {{ include "wordpress.smtpSecretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
         - name: wordpress-config
           secret:

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -198,18 +198,28 @@ spec:
               value: {{ include "wordpress.databaseName" . | quote }}
             - name: WORDPRESS_DATABASE_USER
               value: {{ include "wordpress.databaseUser" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: WORDPRESS_DATABASE_PASSWORD_FILE
+              value: "/opt/bitnami/wordpress/secrets/mariadb-password"
+            {{- else }}
             - name: WORDPRESS_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "wordpress.databaseSecretName" . }}
                   key: mariadb-password
+            {{- end }}
             - name: WORDPRESS_USERNAME
               value: {{ .Values.wordpressUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: WORDPRESS_PASSWORD_FILE
+              value: "/opt/bitnami/wordpress/secrets/wordpress-password"
+            {{- else }}
             - name: WORDPRESS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "wordpress.secretName" . }}
                   key: wordpress-password
+            {{- end }}
             - name: WORDPRESS_EMAIL
               value: {{ .Values.wordpressEmail | quote }}
             - name: WORDPRESS_FIRST_NAME
@@ -260,11 +270,16 @@ spec:
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
             {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
+            {{- if .Values.usePasswordFiles }}
+            - name: SMTP_PASSWORD_FILE
+              value: "/opt/bitnami/wordpress/secrets/smtp-password"
+            {{- else }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "wordpress.smtpSecretName" . }}
                   key: smtp-password
+            {{- end }}
             {{- end }}
             {{- if .Values.smtpProtocol }}
             - name: SMTP_PROTOCOL
@@ -355,6 +370,23 @@ spec:
             - mountPath: /bitnami/wordpress
               name: wordpress-data
               subPath: wordpress
+            {{- if .Values.usePasswordFiles }}
+            - name: wordpress-secrets
+              projected:
+                sources:
+                  - secret:
+                      name:  {{ include "wordpress.secretName" . }}
+                  - secret:
+                      name:  {{ include "wordpress.databaseSecretName" . }}
+                  {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
+                  - secret:
+                      name:  {{ include "wordpress.smtpSecretName" . }}
+                  {{- end }}
+            {{- end }}
+            {{- if  .Values.usePasswordFiles }}
+            - name: wordpress-secrets
+              mountPath: /opt/bitnami/wordpress/secrets
+            {{- end }}
             {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
             - name: wordpress-config
               mountPath: /opt/bitnami/wordpress/wp-config.php

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -57,6 +57,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
