### PR TITLE
[bitnami/redmine] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/redmine/CHANGELOG.md
+++ b/bitnami/redmine/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 32.1.6 (2025-03-11)
+## 32.2.0 (2025-04-02)
 
-* [bitnami/redmine] Release 32.1.6 ([#32389](https://github.com/bitnami/charts/pull/32389))
+* [bitnami/redmine] Set `usePasswordFiles=true` by default ([#32771](https://github.com/bitnami/charts/pull/32771))
+
+## <small>32.1.6 (2025-03-11)</small>
+
+* [bitnami/redmine] Release 32.1.6 (#32389) ([15830e2](https://github.com/bitnami/charts/commit/15830e283f3cdfe6000a1366b2b7e52a1e2a85ea)), closes [#32389](https://github.com/bitnami/charts/issues/32389)
 
 ## <small>32.1.5 (2025-02-28)</small>
 

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 32.1.6
+version: 32.2.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -268,6 +268,7 @@ helm install test --set persistence.existingClaim=PVC_REDMINE,mariadb.persistenc
 | `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
 | `clusterDomain`          | Default Kubernetes cluster domain                                                       | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                       | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the the deployment                                | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the the deployment                                   | `["infinity"]`  |

--- a/bitnami/redmine/templates/cronjob.yaml
+++ b/bitnami/redmine/templates/cronjob.yaml
@@ -92,11 +92,16 @@ spec:
                   value: {{ template "redmine.database.name" . }}
                 - name: REDMINE_MAIL_RECEIVER_DB_USERNAME
                   value: {{ template "redmine.database.username" . }}
+                {{- if .Values.usePasswordFiles }}
+                - name: REDMINE_MAIL_RECEIVER_DB_PASSWORD_FILE
+                  value: {{ printf "/opt/bitnami/redmine/secrets/%s" (include "redmine.database.secretKey" .) }}
+                {{- else }}
                 - name: REDMINE_MAIL_RECEIVER_DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: {{ include "redmine.database.secretName" . }}
                       key: {{ include "redmine.database.secretKey" . }}
+                {{- end }}
                 - name: REDMINE_MAIL_RECEIVER_DB_PORT
                   value: {{ include "redmine.database.port" . | quote }}
                 - name: REDMINE_MAIL_RECEIVER_HOST
@@ -105,11 +110,16 @@ spec:
                   value: {{ .Values.mailReceiver.port | quote }}
                 - name: REDMINE_MAIL_RECEIVER_USERNAME
                   value: {{ .Values.mailReceiver.username | quote }}
+                {{- if .Values.usePasswordFiles }}
+                - name: REDMINE_MAIL_RECEIVER_PASSWORD_FILE
+                  value: "/opt/bitnami/redmine/secrets/mail-receiver-password"
+                {{- else }}
                 - name: REDMINE_MAIL_RECEIVER_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       name: {{ template "redmine.secretName" . }}
                       key: mail-receiver-password
+                {{- end }}
                 - name: REDMINE_MAIL_RECEIVER_USE_SSL
                   value: {{ .Values.mailReceiver.ssl | quote }}
                 - name: REDMINE_MAIL_RECEIVER_STARTTLS
@@ -168,6 +178,10 @@ spec:
               volumeMounts:
                 - name: mail-receiver
                   mountPath: /cj
+                {{- if  .Values.usePasswordFiles }}
+                - name: redmine-secrets
+                  mountPath: /opt/bitnami/redmine/secrets
+                {{- end }}
                 {{- if .Values.mailReceiver.extraVolumeMounts }}
                 {{- include "common.tplvalues.render" (dict "value" .Values.mailReceiver.extraVolumeMounts "context" $) | nindent 16 }}
                 {{- end }}
@@ -179,6 +193,15 @@ spec:
               configMap:
                 name: {{ include "common.names.fullname" . }}
                 defaultMode: 0744
+            {{- if .Values.usePasswordFiles }}
+            - name: redmine-secrets
+              projected:
+                sources:
+                  - secret:
+                      name: {{ include "redmine.secretName" . }}
+                  - secret:
+                      name: {{ include "redmine.database.secretName" . }}
+            {{- end }}
             {{- if .Values.mailReceiver.extraVolumes }}
             {{- include "common.tplvalues.render" (dict "value" .Values.mailReceiver.extraVolumes "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/redmine/templates/deployment.yaml
+++ b/bitnami/redmine/templates/deployment.yaml
@@ -124,20 +124,30 @@ spec:
               value: {{ include "redmine.database.name" . }}
             - name: REDMINE_DATABASE_USER
               value: {{ include "redmine.database.username" . }}
+            {{- if .Values.usePasswordFiles }}
+            - name: REDMINE_DATABASE_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/redmine/secrets/%s" (include "redmine.database.secretKey" .) }}
+            {{- else }}
             - name: REDMINE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redmine.database.secretName" . }}
                   key: {{ include "redmine.database.secretKey" . }}
+            {{- end }}
             - name: REDMINE_DATABASE_PORT_NUMBER
               value: {{ include "redmine.database.port" . | quote }}
             - name: REDMINE_USERNAME
               value: {{ default "" .Values.redmineUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: REDMINE_PASSWORD_FILE
+              value: "/opt/bitnami/redmine/secrets/redmine-password"
+            {{- else }}
             - name: REDMINE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redmine.secretName" . }}
                   key: redmine-password
+            {{- end }}
             - name: REDMINE_EMAIL
               value: {{ .Values.redmineEmail | quote }}
             - name: REDMINE_LANG
@@ -155,11 +165,16 @@ spec:
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
             {{- if .Values.smtpPassword }}
+            {{- if .Values.usePasswordFiles }}
+            - name: REDMINE_SMTP_PASSWORD_FILE
+              value: "/opt/bitnami/redmine/secrets/smtp-password"
+            {{- else }}
             - name: REDMINE_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "redmine.secretName" . }}
                   key: smtp-password
+            {{- end }}
             {{- end }}
             {{- if .Values.smtpTls }}
             - name: REDMINE_SMTP_PROTOCOL
@@ -218,9 +233,13 @@ spec:
           {{- end }}
           volumeMounts:
             {{- include "certificates.volumeMount" . | indent 12 }}
+            {{- if  .Values.usePasswordFiles }}
+            - name: redmine-secrets
+              mountPath: /opt/bitnami/redmine/secrets
+            {{- end }}
             {{- if .Values.customPostInitScripts }}
-            - mountPath: /docker-entrypoint-init.d
-              name: custom-postinit
+            - name: custom-postinit
+              mountPath: /docker-entrypoint-init.d
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -232,6 +251,15 @@ spec:
         {{- end }}
       volumes:
         {{- include "certificates.volumes" . | indent 8 }}
+        {{- if .Values.usePasswordFiles }}
+        - name: redmine-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "redmine.secretName" . }}
+              - secret:
+                  name: {{ include "redmine.database.secretName" . }}
+        {{- end }}
         - name: redmine-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/redmine/templates/mail-receiver-configmap.yaml
+++ b/bitnami/redmine/templates/mail-receiver-configmap.yaml
@@ -18,6 +18,11 @@ data:
   receive.sh: |
     #!/usr/bin/env bash
 
+    {{- if .Values.usePasswordFiles }}
+    export REDMINE_MAIL_RECEIVER_DB_PASSWORD="$(< $REDMINE_MAIL_RECEIVER_DB_PASSWORD_FILE)"
+    export REDMINE_MAIL_RECEIVER_PASSWORD="$(< $REDMINE_MAIL_RECEIVER_PASSWORD_FILE)"
+    {{- end }}
+
     if [ $REDMINE_MAIL_RECEIVER_DEBUG ]; then
         set -x
     fi

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -57,6 +57,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
