### PR TITLE
[bitnami/matomo] fix mount path for `matomo-secrets` volume on cronjobs

### DIFF
--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.3.3 (2025-04-14)
+## 9.3.3 (2025-04-15)
 
 * [bitnami/matomo] fix mount path for `matomo-secrets` volume on cronjobs ([#32773](https://github.com/bitnami/charts/pull/32773))
 

--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.3.2 (2025-04-09)
+## 9.3.3 (2025-04-14)
 
-* [bitnami/matomo] Adds matomo-secrets volume to matomo-archive cronjob ([#32924](https://github.com/bitnami/charts/pull/32924))
+* [bitnami/matomo] fix mount path for `matomo-secrets` volume on cronjobs ([#32773](https://github.com/bitnami/charts/pull/32773))
+
+## <small>9.3.2 (2025-04-14)</small>
+
+* [bitnami/matomo] Adds matomo-secrets volume to matomo-archive cronjob (#32924) ([3505304](https://github.com/bitnami/charts/commit/350530478550b5b300b06fee2493fbd64050f9b0)), closes [#32924](https://github.com/bitnami/charts/issues/32924)
 
 ## <small>9.3.1 (2025-04-09)</small>
 

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 9.3.2
+version: 9.3.3

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -97,7 +97,7 @@ spec:
                   value: {{ include "matomo.databaseUser" . | quote }}
                 {{- if .Values.usePasswordFiles }}
                 - name: MATOMO_DATABASE_PASSWORD_FILE
-                  value: {{ printf "/opt/bitnami/matomo/secrets/%s" (include "matomo.databasePasswordKey" .) }}
+                  value: {{ printf "/secrets/%s" (include "matomo.databasePasswordKey" .) }}
                 {{- else }}
                 - name: MATOMO_DATABASE_PASSWORD
                   valueFrom:
@@ -113,7 +113,7 @@ spec:
                   mountPath: /bitnami/matomo
                 {{- if .Values.usePasswordFiles }}
                 - name: matomo-secrets
-                  mountPath: /opt/bitnami/matomo/secrets
+                  mountPath: /secrets
                 {{- end }}
                 {{- if .Values.certificates.customCertificate.certificateSecret }}
                 - name: custom-certificate
@@ -292,7 +292,7 @@ spec:
                   value: {{ include "matomo.databaseUser" . | quote }}
                 {{- if .Values.usePasswordFiles }}
                 - name: MATOMO_DATABASE_PASSWORD_FILE
-                  value: {{ printf "/opt/bitnami/matomo/secrets/%s" (include "matomo.databasePasswordKey" .) }}
+                  value: {{ printf "/secrets/%s" (include "matomo.databasePasswordKey" .) }}
                 {{- else }}
                 - name: MATOMO_DATABASE_PASSWORD
                   valueFrom:
@@ -308,7 +308,7 @@ spec:
                   mountPath: /bitnami/matomo
                 {{- if .Values.usePasswordFiles }}
                 - name: matomo-secrets
-                  mountPath: /opt/bitnami/matomo/secrets
+                  mountPath: /secrets
                 {{- end }}
                 {{- if .Values.certificates.customCertificate.certificateSecret }}
                 - name: custom-certificate


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
fix mount path for matomo-secrets volume on cronjobs
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Archive job works with password files.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
none known

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- regression of #32363
- fixes #32884
- closes #32924

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
