### PR TITLE
[bitnami/solr] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 9.5.6 (2025-03-28)
+## 9.6.0 (2025-04-02)
 
-* [bitnami/solr] Release 9.5.6 ([#32650](https://github.com/bitnami/charts/pull/32650))
+* [bitnami/solr] Set `usePasswordFiles=true` by default ([#32782](https://github.com/bitnami/charts/pull/32782))
+
+## <small>9.5.6 (2025-03-28)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/solr] Release 9.5.6 (#32650) ([fc2728c](https://github.com/bitnami/charts/commit/fc2728cf08cbc7bb526b359e8188f3e9001f74f8)), closes [#32650](https://github.com/bitnami/charts/issues/32650)
 
 ## <small>9.5.5 (2025-03-12)</small>
 

--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.5.7 (2025-04-02)
+## 9.6.0 (2025-04-04)
 
-* [bitnami/solr] Release 9.5.7 ([#32784](https://github.com/bitnami/charts/pull/32784))
+* [bitnami/solr] Set `usePasswordFiles=true` by default ([#32782](https://github.com/bitnami/charts/pull/32782))
+
+## <small>9.5.7 (2025-04-02)</small>
+
+* [bitnami/solr] Release 9.5.7 (#32784) ([fd41f2d](https://github.com/bitnami/charts/commit/fd41f2d13d80e1dce5fee2703667d3a7d26ca103)), closes [#32784](https://github.com/bitnami/charts/issues/32784)
 
 ## <small>9.5.6 (2025-03-28)</small>
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.5.6
+version: 9.6.0

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -212,6 +212,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `commonLabels`           | Add labels to all the deployed resources                                                     | `{}`            |
 | `commonAnnotations`      | Add annotations to all the deployed resources                                                | `{}`            |
 | `extraDeploy`            | Extra objects to deploy (value evaluated as a template)                                      | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                            | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the statefulset                                        | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the statefulset                                           | `["infinity"]`  |

--- a/bitnami/solr/templates/metrics-deployment.yaml
+++ b/bitnami/solr/templates/metrics-deployment.yaml
@@ -80,24 +80,35 @@ spec:
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.metrics.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           command:
-            - "/bin/bash"
-            - "-c"
-            - |-
-                /bin/bash
+            - /bin/bash
+            - -ec
+            - |
+                {{- if .Values.usePasswordFiles }}
+                export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
+                {{- end }}
                 printf '%s%s\n' 'httpBasicAuthUser=' $SOLR_ADMIN_USERNAME 'httpBasicAuthPassword=' $SOLR_ADMIN_PASSWORD > /basicauth-properties/basicauth.properties
           env:
             - name: SOLR_ADMIN_USERNAME
               value: {{ .Values.auth.adminUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: SOLR_ADMIN_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/solr/secrets/pass/%s" (include "solr.secretPasswordKey" .) }}
+            {{- else }}
             - name: SOLR_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "solr.secretName" . }}
                   key: {{ include "solr.secretPasswordKey" . }}
+            {{- end }}
           volumeMounts:
             - name: empty-dir
               mountPath: /basicauth-properties/
               subPath: app-basicauth-properties-dir
               readOnly: false
+            {{- if .Values.usePasswordFiles }}
+            - name: solr-pass-secret
+              mountPath: /opt/bitnami/solr/secrets/pass
+            {{- end }}
         {{- end }}
       containers:
         - name: solr-exporter
@@ -201,6 +212,11 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+        - name: solr-pass-secret
+          secret:
+            secretName: {{ include "solr.secretName" . }}
+        {{- end }}
         {{- if .Values.metrics.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/solr/templates/scripts-configmap.yaml
+++ b/bitnami/solr/templates/scripts-configmap.yaml
@@ -19,6 +19,11 @@ data:
 
     . /opt/bitnami/scripts/liblog.sh
 
+    {{- if .Values.usePasswordFiles }}
+    export SOLR_SSL_KEY_STORE_PASSWORD="$(< $SOLR_SSL_KEY_STORE_PASSWORD_FILE)"
+    export SOLR_SSL_TRUST_STORE_PASSWORD="$(< $SOLR_SSL_TRUST_STORE_PASSWORD_FILE)"
+    {{- end }}
+
     if [[ -f "/certs/keystore.p12" ]] && [[ -f "/certs/truststore.p12" ]]; then
         # the user provided keystore.p12 and truststore.p12 files (prefered)
         cp "/certs/keystore.p12" "/opt/bitnami/solr/certs/keystore.p12"

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -319,6 +319,9 @@ spec:
               - /bin/bash
               - -ec
               - |
+                {{- if .Values.usePasswordFiles }}
+                export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
+                {{- end }}
                 curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/solr/admin/info/system | grep --quiet  '\"status\":0'
           {{- end }}
           {{- if .Values.customReadinessProbe }}
@@ -330,6 +333,9 @@ spec:
               - /bin/bash
               - -ec
               - |
+                {{- if .Values.usePasswordFiles }}
+                export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
+                {{- end }}
                 curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/api/node/health | grep --quiet  '\"status\":\"OK\"'
           {{- end }}
           {{- if .Values.customStartupProbe }}
@@ -341,6 +347,9 @@ spec:
               - /bin/bash
               - -ec
               - |
+                {{- if .Values.usePasswordFiles }}
+                export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
+                {{- end }}
                 curl --silent --connect-timeout 15000  {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/api/node/health | grep --quiet  '\"status\":\"OK\"'
           {{- end }}
           {{- end }}

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -319,7 +319,7 @@ spec:
               - /bin/bash
               - -ec
               - |
-                {{- if .Values.usePasswordFiles }}
+                {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
                 export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
                 {{- end }}
                 curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/solr/admin/info/system | grep --quiet  '\"status\":0'
@@ -333,7 +333,7 @@ spec:
               - /bin/bash
               - -ec
               - |
-                {{- if .Values.usePasswordFiles }}
+                {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
                 export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
                 {{- end }}
                 curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/api/node/health | grep --quiet  '\"status\":\"OK\"'
@@ -347,7 +347,7 @@ spec:
               - /bin/bash
               - -ec
               - |
-                {{- if .Values.usePasswordFiles }}
+                {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
                 export SOLR_ADMIN_PASSWORD="$(< $SOLR_ADMIN_PASSWORD_FILE)"
                 {{- end }}
                 curl --silent --connect-timeout 15000  {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/api/node/health | grep --quiet  '\"status\":\"OK\"'
@@ -372,11 +372,13 @@ spec:
             - name: scripts
               mountPath: /scripts/setup.sh
               subPath: setup.sh
-            {{- if .Values.usePasswordFiles }}
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
             - name: solr-pass-secret
-              mountPath: /opt/bitnami/solr/secrets/tls/pass
+              mountPath: /opt/bitnami/solr/secrets/pass
+            {{- end }}
+            {{- if and .Values.usePasswordFiles .Values.tls.enabled }}
             - name: solr-tls-secret
-              mountPath: /opt/bitnami/solr/secrets/tls/tls
+              mountPath: /opt/bitnami/solr/secrets/tls
             {{- end }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
@@ -403,12 +405,12 @@ spec:
           configMap:
             name: {{ printf "%s-scripts" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
             defaultMode: 0755
-        {{- if and .Values.usePasswordFiles (or .Values.auth.enabled .Values.tls.enabled)}}
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
         - name: solr-pass-secret
           secret:
             secretName: {{ include "solr.secretName" . }}
         {{- end }}
-        {{- if and .Values.usePasswordFiles (or .Values.auth.enabled .Values.tls.enabled)}}
+        {{- if and .Values.usePasswordFiles .Values.tls.enabled }}
         - name: solr-tls-secret
           secret:
             secretName: {{ include "solr.tlsPasswordsSecret" . }}

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -143,6 +143,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+            {{- if .Values.usePasswordFiles }}
+            - name: SOLR_SSL_KEY_STORE_PASSWORD_FILE
+              value: "/opt/bitnami/solr/secrets/tls/keystore-password"
+            - name: SOLR_SSL_TRUST_STORE_PASSWORD_FILE
+              value: "/opt/bitnami/solr/secrets/tls/truststore-password"
+            {{- else }}
             - name: SOLR_SSL_KEY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -153,6 +159,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "solr.tlsPasswordsSecret" . }}
                   key: truststore-password
+            {{- end }}
           {{- if .Values.tls.resources }}
           resources: {{- toYaml .Values.tls.resources | nindent 12 }}
           {{- else if ne .Values.tls.resourcesPreset "none" }}
@@ -170,6 +177,10 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if .Values.usePasswordFiles }}
+            - name: solr-secrets
+              mountPath: /opt/bitnami/solr/secrets
+            {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
@@ -230,11 +241,16 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: SOLR_ADMIN_USERNAME
               value: {{ .Values.auth.adminUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: SOLR_ADMIN_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/solr/secrets/pass/%s" (include "solr.secretPasswordKey" .) }}
+            {{- else }}
             - name: SOLR_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "solr.secretName" . }}
                   key: {{ include "solr.secretPasswordKey" . }}
+            {{- end }}
             {{- end }}
             - name: SOLR_ZK_HOSTS
               value: {{ include "solr.zookeeper.hosts" . | quote }}
@@ -249,18 +265,25 @@ spec:
             {{- end }}
             - name: SOLR_SSL_KEY_STORE
               value: /opt/bitnami/solr/certs/keystore.p12
+            - name: SOLR_SSL_TRUST_STORE
+              value: /opt/bitnami/solr/certs/truststore.p12
+            {{- if .Values.usePasswordFiles }}
+            - name: SOLR_SSL_KEY_STORE_PASSWORD_FILE
+              value: "/opt/bitnami/solr/secrets/tls/keystore-password"
+            - name: SOLR_SSL_TRUST_STORE_PASSWORD_FILE
+              value: "/opt/bitnami/solr/secrets/tls/truststore-password"
+            {{- else }}
             - name: SOLR_SSL_KEY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "solr.tlsPasswordsSecret" . }}
                   key: keystore-password
-            - name: SOLR_SSL_TRUST_STORE
-              value: /opt/bitnami/solr/certs/truststore.p12
             - name: SOLR_SSL_TRUST_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "solr.tlsPasswordsSecret" . }}
                   key: truststore-password
+            {{- end }}
             - name: SOLR_SSL_CHECK_PEER_NAME
               value: "false"
             {{- end }}
@@ -340,6 +363,12 @@ spec:
             - name: scripts
               mountPath: /scripts/setup.sh
               subPath: setup.sh
+            {{- if .Values.usePasswordFiles }}
+            - name: solr-pass-secret
+              mountPath: /opt/bitnami/solr/secrets/tls/pass
+            - name: solr-tls-secret
+              mountPath: /opt/bitnami/solr/secrets/tls/tls
+            {{- end }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- if .Values.persistence.subPath }}
@@ -365,6 +394,16 @@ spec:
           configMap:
             name: {{ printf "%s-scripts" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
             defaultMode: 0755
+        {{- if and .Values.usePasswordFiles (or .Values.auth.enabled .Values.tls.enabled)}}
+        - name: solr-pass-secret
+          secret:
+            secretName: {{ include "solr.secretName" . }}
+        {{- end }}
+        {{- if and .Values.usePasswordFiles (or .Values.auth.enabled .Values.tls.enabled)}}
+        - name: solr-tls-secret
+          secret:
+            secretName: {{ include "solr.tlsPasswordsSecret" . }}
+        {{- end }}
         {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -59,6 +59,9 @@ commonAnnotations: {}
 ## @param extraDeploy Extra objects to deploy (value evaluated as a template)
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the statefulset
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
