### PR TITLE
[bitnami/discourse] Support envFrom in `install-plugins`

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.1.7 (2025-03-28)
+## 15.1.8 (2025-04-03)
 
-* [bitnami/discourse] Release 15.1.7 ([#32672](https://github.com/bitnami/charts/pull/32672))
+* [bitnami/discourse] Support envFrom in `install-plugins` ([#32790](https://github.com/bitnami/charts/pull/32790))
+
+## <small>15.1.7 (2025-03-28)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/discourse] Release 15.1.7 (#32672) ([57d6e90](https://github.com/bitnami/charts/commit/57d6e9026b8539d3c993fee402acd47234c4e182)), closes [#32672](https://github.com/bitnami/charts/issues/32672)
 
 ## <small>15.1.6 (2025-02-26)</small>
 

--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.1.8 (2025-04-03)
+## 15.1.8 (2025-04-07)
 
 * [bitnami/discourse] Support envFrom in `install-plugins` ([#32790](https://github.com/bitnami/charts/pull/32790))
 

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 15.1.7
+version: 15.1.8

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -118,6 +118,17 @@ spec:
           {{- if .Values.discourse.extraEnvVars }}
           env:
             {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.names.fullname" . }}
+            {{- if .Values.discourse.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.discourse.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.discourse.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.discourse.extraEnvVarsSecret }}
+            {{- end }}
           {{- end }}
           {{- if .Values.discourse.resources }}
           resources: {{- toYaml .Values.discourse.resources | nindent 12 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This allows the initContainer `install-plugins` to use environment variables set via ConfigMap or Secret. 

### Benefits

Sometimes you need to install discourse plugins from private github repositories and you can do so normally by passing your github personal access token in the url of this plugin repo like this: 

`https://${GITHUBPAT}@github.com/myprivateorg/discourseplugin`

That definitely something you'd want to pass as a secret.

### Possible drawbacks

Maybe by using `.Values.discourse.extraEnvVarsCM` and `.Values.discourse.extraEnvVarsSecret` we are passing unnecessary env vars but I also don't see the harm. We could also add `Values.install-plugins.*`  instead.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
