### PR TITLE
[bitnami/opensearch] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/opensearch/CHANGELOG.md
+++ b/bitnami/opensearch/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 1.8.1 (2025-03-31)
+## 1.9.0 (2025-04-03)
 
-* [bitnami/opensearch] Update nodes heapSize to half the memory preset ([#32686](https://github.com/bitnami/charts/pull/32686))
+* [bitnami/opensearch] Set `usePasswordFiles=true` by default ([#32797](https://github.com/bitnami/charts/pull/32797))
+
+## <small>1.8.2 (2025-04-02)</small>
+
+* [bitnami/opensearch] Release 1.8.2 (#32783) ([be1ab6d](https://github.com/bitnami/charts/commit/be1ab6dd868fdbd45d25d97e9cbc5cf54005b0e4)), closes [#32783](https://github.com/bitnami/charts/issues/32783)
+
+## <small>1.8.1 (2025-03-31)</small>
+
+* [bitnami/opensearch] Update nodes heapSize to half the memory preset (#32686) ([e467b2b](https://github.com/bitnami/charts/commit/e467b2b30b36dcaca94d9355315e05d50adf09f6)), closes [#32686](https://github.com/bitnami/charts/issues/32686)
 
 ## 1.8.0 (2025-03-19)
 

--- a/bitnami/opensearch/CHANGELOG.md
+++ b/bitnami/opensearch/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.8.2 (2025-04-02)
+## 1.9.0 (2025-04-04)
 
-* [bitnami/opensearch] Release 1.8.2 ([#32783](https://github.com/bitnami/charts/pull/32783))
+* [bitnami/opensearch] Set `usePasswordFiles=true` by default ([#32797](https://github.com/bitnami/charts/pull/32797))
+
+## <small>1.8.2 (2025-04-02)</small>
+
+* [bitnami/opensearch] Release 1.8.2 (#32783) ([be1ab6d](https://github.com/bitnami/charts/commit/be1ab6dd868fdbd45d25d97e9cbc5cf54005b0e4)), closes [#32783](https://github.com/bitnami/charts/issues/32783)
 
 ## <small>1.8.1 (2025-03-31)</small>
 

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 1.8.1
+version: 1.9.0

--- a/bitnami/opensearch/README.md
+++ b/bitnami/opensearch/README.md
@@ -219,6 +219,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                       | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -580,6 +580,14 @@ Add environment variables to configure database values
   value: {{ coalesce .Values.security.tls.adminDN "CN=admin;CN=admin" }}
 - name: OPENSEARCH_ENABLE_SECURITY
   value: "true"
+{{- if .Values.usePasswordFiles }}
+- name: OPENSEARCH_PASSWORD_FILE
+  value: "/opt/bitnami/opensearch/secrets/opensearch-password"
+- name: OPENSEARCH_DASHBOARDS_PASSWORD_FILE
+  value: "/opt/bitnami/opensearch/secrets/opensearch-dashboards-password"
+- name: LOGSTASH_PASSWORD_FILE
+  value: "/opt/bitnami/opensearch/secrets/logstash-password"
+{{- else }}
 - name: OPENSEARCH_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -595,6 +603,7 @@ Add environment variables to configure database values
     secretKeyRef:
         name: {{ include "opensearch.secretName" . }}
         key: logstash-password
+{{- end }}
 - name: OPENSEARCH_ENABLE_FIPS_MODE
   value: {{ .Values.security.fipsMode | quote }}
 - name: OPENSEARCH_TLS_VERIFICATION_MODE
@@ -611,25 +620,40 @@ Add environment variables to configure database values
   value: "/opt/bitnami/opensearch/config/certs/{{ .Values.security.tls.truststoreFilename }}"
 {{- end }}
 {{- if and (not .Values.security.tls.usePemCerts) (or .Values.security.tls.keystorePassword .Values.security.tls.passwordsSecret) }}
+{{- if .Values.usePasswordFiles }}
+- name: OPENSEARCH_KEYSTORE_PASSWORD_FILE
+  value: {{ printf "/opt/bitnami/opensearch/secrets/%s" (include "opensearch.keystorePasswordKey" .) }}
+{{- else }}
 - name: OPENSEARCH_KEYSTORE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "opensearch.tlsPasswordsSecret" . }}
       key: {{ include "opensearch.keystorePasswordKey" . | quote }}
 {{- end }}
+{{- end }}
 {{- if and (not .Values.security.tls.usePemCerts) (or .Values.security.tls.truststorePassword .Values.security.tls.passwordsSecret) }}
+{{- if .Values.usePasswordFiles }}
+- name: OPENSEARCH_KEYSTORE_PASSWORD_FILE
+  value: {{ printf "/opt/bitnami/opensearch/secrets/%s" (include "opensearch.truststorePasswordKey" .) }}
+{{- else }}
 - name: OPENSEARCH_TRUSTSTORE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "opensearch.tlsPasswordsSecret" . }}
       key: {{ include "opensearch.truststorePasswordKey" . | quote }}
 {{- end }}
+{{- end }}
 {{- if and .Values.security.tls.usePemCerts (or .Values.security.tls.keyPassword .Values.security.tls.passwordsSecret) }}
+{{- if .Values.usePasswordFiles }}
+- name: OPENSEARCH_KEY_PASSWORD_FILE
+  value: {{ printf "/opt/bitnami/opensearch/secrets/%s" (include "opensearch.keyPasswordKey" .) }}
+{{- else }}
 - name: OPENSEARCH_KEY_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "opensearch.tlsPasswordsSecret" . }}
       key: {{ include "opensearch.keyPasswordKey" . | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/bitnami/opensearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/opensearch/templates/coordinating/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         {{- if .Values.sysctlImage.enabled }}
           {{- include "opensearch.sysctl.initContainer" . | nindent 8}}
         {{- end }}
-        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "coordinating" "context" $) | nindent 8 }} 
+        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "coordinating" "context" $) | nindent 8 }}
         {{- if .Values.coordinating.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -231,6 +231,10 @@ spec:
               subPath: app-plugins-dir
             - name: data
               mountPath: /bitnami/opensearch/data
+            {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+            - name: opensearch-secrets
+              mountPath: /opt/bitnami/opensearch/secrets
+            {{- end }}
             {{- if .Values.config }}
             - mountPath: /opt/bitnami/opensearch/config/opensearch.yml
               name: config
@@ -288,6 +292,17 @@ spec:
         - name: config
           configMap:
             name: {{ include "common.names.fullname" . }}
+        {{- end }}
+        {{- if and .Values.usePasswordFiles .Values.security.enabled  }}
+        - name: opensearch-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "opensearch.secretName" . }}
+              {{- if or .Values.security.tls.keystorePassword .Values.security.tls.truststorePassword .Values.security.tls.keyPassword .Values.security.tls.passwordsSecret }}
+              - secret:
+                  name: {{ include "opensearch.tlsPasswordsSecret" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.security.enabled }}
         - name: opensearch-certificates

--- a/bitnami/opensearch/templates/dashboards/deployment.yaml
+++ b/bitnami/opensearch/templates/dashboards/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.dashboards.terminationGracePeriodSeconds }}
       {{- end }}
       initContainers:
-        {{- include "opensearch.dashboards.copy-default-plugins.initContainer" . | nindent 8 }} 
+        {{- include "opensearch.dashboards.copy-default-plugins.initContainer" . | nindent 8 }}
         {{- if .Values.dashboards.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.dashboards.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -94,11 +94,16 @@ spec:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.dashboards.image.debug .Values.diagnosticMode.enabled) | quote }}
             {{- if .Values.security.enabled }}
+            {{- if .Values.usePasswordFiles }}
+            - name: OPENSEARCH_DASHBOARDS_PASSWORD_FILE
+              value: "/opt/bitnami/opensearch-dashboards/secrets/opensearch-dashboards-password"
+            {{- else }}
             - name: OPENSEARCH_DASHBOARDS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "opensearch.secretName" . }}
                   key: opensearch-dashboards-password
+            {{- end }}
             {{- end }}
             {{- if .Values.dashboards.tls.enabled }}
             - name: OPENSEARCH_DASHBOARDS_SERVER_ENABLE_TLS
@@ -174,6 +179,10 @@ spec:
               subPath: app-plugins-dir
             - name: dashboards-data
               mountPath: /bitnami/opensearch-dashboards
+            {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+            - name: opensearch-dashboards-secrets
+              mountPath: /opt/bitnami/opensearch-dashboards/secrets
+            {{- end }}
             {{- if .Values.security.enabled }}
             - name: opensearch-certificates
               mountPath: /opt/bitnami/opensearch-dashboards/config/certs/opensearch
@@ -193,6 +202,14 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+        - name: opensearch-dashboards-secrets
+          secret:
+            secretName: {{ include "opensearch.secretName" . }}
+            items:
+              - key: opensearch-dashboards-password
+                path: opensearch-dashboards-password
+        {{- end }}
         - name: dashboards-data
         {{- if .Values.dashboards.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/opensearch/templates/data/statefulset.yaml
+++ b/bitnami/opensearch/templates/data/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: data
               mountPath: /bitnami/opensearch/data
         {{- end }}
-        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "data" "context" $) | nindent 8 }} 
+        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "data" "context" $) | nindent 8 }}
         {{- if .Values.data.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.data.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -257,6 +257,10 @@ spec:
               subPath: app-plugins-dir
             - name: data
               mountPath: /bitnami/opensearch/data
+            {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+            - name: opensearch-secrets
+              mountPath: /opt/bitnami/opensearch/secrets
+            {{- end }}
             {{- if .Values.config }}
             - mountPath: /opt/bitnami/opensearch/config/opensearch.yml
               name: config
@@ -312,6 +316,17 @@ spec:
         - name: config
           configMap:
             name: {{ template "common.names.fullname" . }}
+        {{- end }}
+        {{- if and .Values.usePasswordFiles .Values.security.enabled  }}
+        - name: opensearch-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "opensearch.secretName" . }}
+              {{- if or .Values.security.tls.keystorePassword .Values.security.tls.truststorePassword .Values.security.tls.keyPassword .Values.security.tls.passwordsSecret }}
+              - secret:
+                  name: {{ include "opensearch.tlsPasswordsSecret" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.security.enabled }}
         - name: opensearch-certificates

--- a/bitnami/opensearch/templates/ingest/statefulset.yaml
+++ b/bitnami/opensearch/templates/ingest/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         {{- if .Values.sysctlImage.enabled }}
           {{- include "opensearch.sysctl.initContainer" .  | nindent 8}}
         {{- end }}
-        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "ingest" "context" $) | nindent 8 }} 
+        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "ingest" "context" $) | nindent 8 }}
         {{- if .Values.ingest.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.ingest.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -231,6 +231,10 @@ spec:
               subPath: app-plugins-dir
             - name: data
               mountPath: /bitnami/opensearch/data
+            {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+            - name: opensearch-secrets
+              mountPath: /opt/bitnami/opensearch/secrets
+            {{- end }}
             {{- if .Values.config }}
             - mountPath: /opt/bitnami/opensearch/config/opensearch.yml
               name: config
@@ -288,6 +292,17 @@ spec:
         - name: config
           configMap:
             name: {{ template "common.names.fullname" . }}
+        {{- end }}
+        {{- if and .Values.usePasswordFiles .Values.security.enabled  }}
+        - name: opensearch-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "opensearch.secretName" . }}
+              {{- if or .Values.security.tls.keystorePassword .Values.security.tls.truststorePassword .Values.security.tls.keyPassword .Values.security.tls.passwordsSecret }}
+              - secret:
+                  name: {{ include "opensearch.tlsPasswordsSecret" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.security.enabled }}
         - name: opensearch-certificates

--- a/bitnami/opensearch/templates/master/statefulset.yaml
+++ b/bitnami/opensearch/templates/master/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: data
               mountPath: /bitnami/opensearch/data
         {{- end }}
-        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "master" "context" $) | nindent 8 }} 
+        {{- include "opensearch.copy-default-plugins.initContainer" (dict "component" "master" "context" $) | nindent 8 }}
         {{- if .Values.master.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.master.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -269,6 +269,10 @@ spec:
               subPath: app-plugins-dir
             - name: data
               mountPath: /bitnami/opensearch/data
+            {{- if and .Values.usePasswordFiles .Values.security.enabled }}
+            - name: opensearch-secrets
+              mountPath: /opt/bitnami/opensearch/secrets
+            {{- end }}
             {{- if .Values.config }}
             - mountPath: /opt/bitnami/opensearch/config/opensearch.yml
               name: config
@@ -324,6 +328,17 @@ spec:
         - name: config
           configMap:
             name: {{ template "common.names.fullname" . }}
+        {{- end }}
+        {{- if and .Values.usePasswordFiles .Values.security.enabled  }}
+        - name: opensearch-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "opensearch.secretName" . }}
+              {{- if or .Values.security.tls.keystorePassword .Values.security.tls.truststorePassword .Values.security.tls.keyPassword .Values.security.tls.passwordsSecret }}
+              - secret:
+                  name: {{ include "opensearch.tlsPasswordsSecret" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.security.enabled }}
         - name: opensearch-certificates

--- a/bitnami/opensearch/values.yaml
+++ b/bitnami/opensearch/values.yaml
@@ -64,6 +64,9 @@ extraDeploy: []
 ## @param namespaceOverride String to fully override common.names.namespace
 ##
 namespaceOverride: ""
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
