### PR TITLE
[bitnami/mongodb] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.4.12 (2025-04-02)
+## 16.5.0 (2025-04-03)
 
-* [bitnami/mongodb] Release 16.4.12 ([#32752](https://github.com/bitnami/charts/pull/32752))
+* [bitnami/mongodb] Set `usePasswordFiles=true` by default ([#32800](https://github.com/bitnami/charts/pull/32800))
+
+## <small>16.4.12 (2025-04-02)</small>
+
+* [bitnami/mongodb] Release 16.4.12 (#32752) ([a28adbd](https://github.com/bitnami/charts/commit/a28adbd7b634755e6320c2321e37f97be9578cca)), closes [#32752](https://github.com/bitnami/charts/issues/32752)
 
 ## <small>16.4.11 (2025-03-28)</small>
 

--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 16.5.0 (2025-04-03)
+## 16.5.0 (2025-04-07)
 
 * [bitnami/mongodb] Set `usePasswordFiles=true` by default ([#32800](https://github.com/bitnami/charts/pull/32800))
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.4.12
+version: 16.5.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -520,6 +520,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | `topologyKey`             | Override common lib default topology key. If empty - "kubernetes.io/hostname" is used                     | `""`            |
 | `serviceBindings.enabled` | Create secret for service binding (Experimental)                                                          | `false`         |
 | `enableServiceLinks`      | Whether information about services should be injected into pod's environment variable                     | `true`          |
+| `usePasswordFiles`        | Mount credentials as files instead of using environment variables                                         | `true`          |
 | `diagnosticMode.enabled`  | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                   | `false`         |
 | `diagnosticMode.command`  | Command to override all containers in the deployment                                                      | `["sleep"]`     |
 | `diagnosticMode.args`     | Args to override all containers in the deployment                                                         | `["infinity"]`  |

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -173,6 +173,12 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            - name: MONGODB_REPLICA_SET_KEY_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-replica-set-key"
+            {{- else }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -183,6 +189,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-replica-set-key
+            {{- end }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
@@ -265,6 +272,10 @@ spec:
             - name: empty-dir
               mountPath: /bitnami/mongodb
               subPath: app-volume-dir
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap }}
             - name: config
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
@@ -283,7 +294,12 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
-      {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap .Values.arbiter.extraVolumes .Values.tls.enabled }}
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+        - name: mongodb-secrets
+          secret:
+            secretName: {{ include "mongodb.secretName" . }}
+        {{- end }}
+        {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap .Values.arbiter.extraVolumes .Values.tls.enabled }}
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -120,15 +120,20 @@ spec:
             image: {{ include "mongodb.image" . }}
             imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
             env:
-            {{- if .Values.auth.enabled }}
+              {{- if .Values.auth.enabled }}
               - name: MONGODB_ROOT_USER
                 value: {{ .Values.auth.rootUser | quote }}
+              {{- if .Values.usePasswordFiles }}
+              - name: MONGODB_ROOT_PASSWORD_FILE
+                value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+              {{- else }}
               - name: MONGODB_ROOT_PASSWORD
                 valueFrom:
                   secretKeyRef:
                     name: {{ include "mongodb.secretName" . }}
                     key: mongodb-root-password
-            {{- end }}
+              {{- end }}
+              {{- end }}
               - name: MONGODB_SERVICE_NAME
                 value: {{ include "mongodb.service.nameOverride" . }}
               - name: MONGODB_PORT_NUMBER
@@ -145,7 +150,11 @@ spec:
             command:
               - /bin/sh
               - -c
-              - "mongodump {{- if .Values.auth.enabled }} --username=${MONGODB_ROOT_USER} --password=${MONGODB_ROOT_PASSWORD} --authenticationDatabase=admin {{- end }} --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} {{- if (eq $.Values.architecture "replicaset") }}--oplog{{- end }} --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
+              - |
+                {{- if and .Values.auth.enabled .Values.usePasswordFiles }}
+                export MONGODB_ROOT_PASSWORD="$(< $MONGODB_ROOT_PASSWORD_FILE)"
+                {{- end }}
+                mongodump {{- if .Values.auth.enabled }} --username=${MONGODB_ROOT_USER} --password=${MONGODB_ROOT_PASSWORD} --authenticationDatabase=admin {{- end }} --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} {{- if (eq $.Values.architecture "replicaset") }}--oplog{{- end }} --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz
             {{- end }}
             {{- if .Values.backup.cronjob.resources }}
             resources: {{- include "common.tplvalues.render" (dict "value" .Values.backup.cronjob.resources "context" $) | nindent 14 }}
@@ -156,6 +165,10 @@ spec:
               - name: empty-dir
                 mountPath: /tmp
                 subPath: tmp-dir
+              {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+              - name: mongodb-secrets
+                mountPath: /opt/bitnami/mongodb/secrets
+              {{- end }}
               {{- if .Values.tls.enabled }}
               - name: certs
                 mountPath: /certs
@@ -182,6 +195,11 @@ spec:
               configMap:
                 name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
                 defaultMode: 0o550
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              secret:
+                secretName: {{ include "mongodb.secretName" . }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: certs
               emptyDir: {}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -214,14 +214,25 @@ spec:
             {{- end }}
             {{- if .Values.auth.enabled }}
             {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_EXTRA_PASSWORDS_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-passwords"
+            {{- else }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-passwords
             {{- end }}
+            {{- end }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            - name: MONGODB_REPLICA_SET_KEY_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-replica-set-key"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -233,15 +244,21 @@ spec:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-replica-set-key
             {{- end }}
+            {{- end }}
             {{- if and .Values.metrics.enabled (not (empty .Values.metrics.username)) }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
             {{- if .Values.auth.enabled }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-metrics-password
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
@@ -329,6 +346,10 @@ spec:
               subPath: {{ .Values.hidden.persistence.subPath }}
             - name: common-scripts
               mountPath: /bitnami/scripts
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
@@ -390,6 +411,13 @@ spec:
           {{- else }}
           args:
             - |
+              {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+              {{- if .Values.metrics.username }}
+              export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
+              {{- else }}
+              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              {{- end }}
+              {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
@@ -397,14 +425,23 @@ spec:
             {{- if not .Values.metrics.username }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
             {{- else }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -412,10 +449,15 @@ spec:
                   key: mongodb-metrics-password
             {{- end }}
             {{- end }}
+            {{- end }}
           volumeMounts:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: certs
               mountPath: /certs
@@ -469,6 +511,11 @@ spec:
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
             defaultMode: 0o555
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+        - name: mongodb-secrets
+          secret:
+            secretName: {{ include "mongodb.secretName" . }}
+        {{- end }}
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -415,7 +415,7 @@ spec:
               {{- if .Values.metrics.username }}
               export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
               {{- else }}
-              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              export MONGODB_ROOT_PASSWORD="$(< $MONGODB_ROOT_PASSWORD_FILE)"
               {{- end }}
               {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -216,14 +216,25 @@ spec:
             {{- end }}
             {{- if .Values.auth.enabled }}
             {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_EXTRA_PASSWORDS_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-passwords"
+            {{- else }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-passwords
             {{- end }}
+            {{- end }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            - name: MONGODB_REPLICA_SET_KEY_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-replica-set-key"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -235,15 +246,21 @@ spec:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-replica-set-key
             {{- end }}
+            {{- end }}
             {{- if and .Values.metrics.enabled (not (empty .Values.metrics.username)) }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
             {{- if .Values.auth.enabled }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-metrics-password
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
@@ -341,6 +358,10 @@ spec:
             - name: empty-dir
               mountPath: /.mongodb
               subPath: mongosh-home
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             - name: {{ .Values.persistence.name | default "datadir" }}
               mountPath: {{ .Values.persistence.mountPath }}
               subPath: {{ .Values.persistence.subPath }}
@@ -397,6 +418,13 @@ spec:
           {{- else }}
           args:
             - |
+              {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+              {{- if .Values.metrics.username }}
+              export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
+              {{- else }}
+              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              {{- end }}
+              {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
@@ -404,14 +432,23 @@ spec:
             {{- if not .Values.metrics.username }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
             {{- else }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -419,10 +456,15 @@ spec:
                   key: mongodb-metrics-password
             {{- end }}
             {{- end }}
+            {{- end }}
           volumeMounts:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: certs
               mountPath: /certs
@@ -473,6 +515,11 @@ spec:
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
             defaultMode: 0o550
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+        - name: mongodb-secrets
+          secret:
+            secretName: {{ include "mongodb.secretName" . }}
+        {{- end }}
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -422,7 +422,7 @@ spec:
               {{- if .Values.metrics.username }}
               export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
               {{- else }}
-              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              export MONGODB_ROOT_PASSWORD="$(< $MONGODB_ROOT_PASSWORD_FILE)"
               {{- end }}
               {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -367,7 +367,7 @@ spec:
               {{- if .Values.metrics.username }}
               export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
               {{- else }}
-              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              export MONGODB_ROOT_PASSWORD="$(< $MONGODB_ROOT_PASSWORD_FILE)"
               {{- end }}
               {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -176,29 +176,44 @@ spec:
             {{- end }}
             {{- if .Values.auth.enabled }}
             {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_EXTRA_PASSWORDS_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-passwords"
+            {{- else }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-passwords
             {{- end }}
+            {{- end }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
             {{- end }}
+            {{- end }}
             {{- if and .Values.metrics.enabled (not (empty .Values.metrics.username)) }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
             {{- if .Values.auth.enabled }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-metrics-password
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
@@ -305,6 +320,10 @@ spec:
               subPath: {{ .Values.persistence.subPath }}
             - name: common-scripts
               mountPath: /bitnami/scripts
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
@@ -344,6 +363,13 @@ spec:
           {{- else }}
           args:
             - |
+              {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+              {{- if .Values.metrics.username }}
+              export MONGODB_METRICS_PASSWORD="$(< $MONGODB_METRICS_PASSWORD_FILE)"
+              {{- else }}
+              export MONGODB_ROOT_USER="$(< $MONGODB_ROOT_USER_FILE)"
+              {{- end }}
+              {{- end }}
               /bin/mongodb_exporter {{ include "mongodb.exporterArgs" $ }} --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           {{- end }}
           env:
@@ -351,14 +377,23 @@ spec:
             {{- if not .Values.metrics.username }}
             - name: MONGODB_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-root-password"
+            {{- else }}
             - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
             {{- else }}
             - name: MONGODB_METRICS_USERNAME
               value: {{ .Values.metrics.username | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: MONGODB_METRICS_PASSWORD_FILE
+              value: "/opt/bitnami/mongodb/secrets/mongodb-metrics-password"
+            {{- else }}
             - name: MONGODB_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -366,10 +401,15 @@ spec:
                   key: mongodb-metrics-password
             {{- end }}
             {{- end }}
+            {{- end }}
           volumeMounts:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+            - name: mongodb-secrets
+              mountPath: /opt/bitnami/mongodb/secrets
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: certs
               mountPath: /certs
@@ -420,6 +460,11 @@ spec:
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
             defaultMode: 0o550
+        {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
+        - name: mongodb-secrets
+          secret:
+            secretName: {{ include "mongodb.secretName" . }}
+        {{- end }}
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:

--- a/bitnami/mongodb/templates/update-password/job.yaml
+++ b/bitnami/mongodb/templates/update-password/job.yaml
@@ -129,7 +129,7 @@ spec:
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
-            {{- if not .Values.auth.usePasswordFiles }}
+            {{- if not .Values.usePasswordFiles }}
             - name: MONGODB_PREVIOUS_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -146,7 +146,7 @@ spec:
               value: {{ $customUsers | quote }}
             - name: MONGODB_EXTRA_DATABASES
               value: {{ $customDatabases | quote }}
-            {{- if not .Values.auth.usePasswordFiles }}
+            {{- if not .Values.usePasswordFiles }}
             - name: MONGODB_NEW_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:
@@ -157,7 +157,7 @@ spec:
             {{- if .Values.metrics.username }}
             - name: MONGODB_METRICS_USER
               value: {{ .Values.metrics.username | quote }}
-            {{- if not .Values.auth.usePasswordFiles }}
+            {{- if not .Values.usePasswordFiles }}
             - name: MONGODB_PREVIOUS_METRICS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -217,7 +217,7 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
-        {{- if and .Values.auth.usePasswordFiles }}
+        {{- if and .Values.usePasswordFiles }}
         - name: mongodb-previous-credentials
           secret:
             secretName: {{ template "mongodb.update-job.previousSecretName" . }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -106,6 +106,9 @@ serviceBindings:
 ## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
 ##
 enableServiceLinks: true
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
