### PR TITLE
[bitnami/keycloak] The secret name of the externaldb is inherited by the .Release.Name and not by the (include "common.names.fullname" .) function.

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.5.1 (2025-04-05)
+## 24.5.1 (2025-04-07)
 
 * [bitnami/keycloak] The secret name of the externaldb is inherited by the .Release.Name and not by the (include "common.names.fullname" .) function. ([#32823](https://github.com/bitnami/charts/pull/32823))
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 24.5.1 (2025-04-05)
+
+* [bitnami/keycloak] The secret name of the externaldb is inherited by the .Release.Name and not by the (include "common.names.fullname" .) function. ([#32823](https://github.com/bitnami/charts/pull/32823))
+
 ## 24.5.0 (2025-04-04)
 
-* [bitnami/keycloak] Set `usePasswordFiles=true` by default ([#32594](https://github.com/bitnami/charts/pull/32594))
+* [bitnami/keycloak] Set `usePasswordFiles=true` by default (#32594) ([6206296](https://github.com/bitnami/charts/commit/620629645b6354dc79fd49c5e33e794ab569d024)), closes [#32594](https://github.com/bitnami/charts/issues/32594)
 
 ## <small>24.4.14 (2025-04-01)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.5.0
+version: 24.5.1

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -168,7 +168,7 @@ Return the Database encrypted password
         {{- default (include "keycloak.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
     {{- end -}}
 {{- else -}}
-    {{- default (printf "%s-externaldb" .Release.Name) (tpl .Values.externalDatabase.existingSecret $) -}}
+    {{- default (printf "%s-externaldb" (include "common.names.fullname" .)) (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/keycloak/templates/secret-external-db.yaml
+++ b/bitnami/keycloak/templates/secret-external-db.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" .Release.Name }}
+  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
   {{- if or .Values.externalDatabase.annotations .Values.commonAnnotations }}
@@ -15,5 +15,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  db-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-externaldb" .Release.Name) "key" "db-password" "length" 10 "providedValues" (list "externalDatabase.password") "context" $) }}
+  db-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-externaldb" (include "common.names.fullname" .)) "key" "db-password" "length" 10 "providedValues" (list "externalDatabase.password") "context" $) }}
 {{- end }}


### PR DESCRIPTION
Title says everything :)