### PR TITLE
[bitnami/keycloak] fix to enable empty hostname

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.5.1 (2025-04-07)
+## 24.5.2 (2025-04-07)
 
-* [bitnami/keycloak] The secret name of the externaldb is inherited by the .Release.Name and not by the (include "common.names.fullname" .) function. ([#32823](https://github.com/bitnami/charts/pull/32823))
+* [bitnami/keycloak] fix to enable empty hostname ([#32846](https://github.com/bitnami/charts/pull/32846))
+
+## <small>24.5.1 (2025-04-07)</small>
+
+* [bitnami/keycloak] Change .Release.Name to (include "common.names.fullname) ([c3573fd](https://github.com/bitnami/charts/commit/c3573fdc21301f06007546ad4faadab598f6305d))
 
 ## 24.5.0 (2025-04-04)
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.5.2 (2025-04-07)
+## 24.5.2 (2025-04-08)
 
 * [bitnami/keycloak] fix to enable empty hostname ([#32846](https://github.com/bitnami/charts/pull/32846))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.5.1
+version: 24.5.2

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -50,9 +50,11 @@ spec:
   {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned .Values.ingress.secrets )) .Values.ingress.extraTls }}
   tls:
   {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.secrets .Values.ingress.selfSigned) }}
+    {{- if .Values.ingress.hostname }}
     - hosts:
         - {{ (tpl .Values.ingress.hostname .) | quote }}
       secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -637,6 +637,7 @@ ingress:
   ##
   controller: default
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
+  ## leave as empty string if KEYCLOAK_HOSTNAME shall be not set e.g. as outlined in https://www.keycloak.org/server/hostname#_validations
   ##
   hostname: keycloak.local
   ## @param ingress.hostnameStrict Disables dynamically resolving the hostname from request headers.


### PR DESCRIPTION
### Description of the change

- this fixes `hostname` no allowed to be empty within ingress.yaml

### Benefits

It will fully enable an empty hostname without exception within ingress.yaml to be able to disable `KEYCLOAK_HOSTNAME` property.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- None known

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
