### PR TITLE
[bitnami/etcd] fix livenessprobe when metrics.useSeparateEndpoint is set

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.2.3 (2025-04-08)
+## 11.2.3 (2025-04-09)
 
 * [bitnami/etcd] fix livenessprobe when metrics.useSeparateEndpoint is set ([#32870](https://github.com/bitnami/charts/pull/32870))
 

--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.2 (2025-04-01)
+## 11.2.3 (2025-04-08)
 
-* [bitnami/etcd] Release 11.2.2 ([#32727](https://github.com/bitnami/charts/pull/32727))
+* [bitnami/etcd] fix livenessprobe when metrics.useSeparateEndpoint is set ([#32870](https://github.com/bitnami/charts/pull/32870))
+
+## <small>11.2.2 (2025-04-01)</small>
+
+* [bitnami/etcd] Release 11.2.2 (#32727) ([b34eff7](https://github.com/bitnami/charts/commit/b34eff75291633a39b02ed46c27c60250a07d3f9)), closes [#32727](https://github.com/bitnami/charts/issues/32727)
 
 ## <small>11.2.1 (2025-03-28)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 11.2.2
+version: 11.2.3

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -297,7 +297,7 @@ spec:
                 - /opt/bitnami/scripts/etcd/healthcheck.sh
             {{- else }}
             httpGet:
-              port: {{ .Values.containerPorts.client }}
+              port: {{ .Values.metrics.useSeparateEndpoint | ternary .Values.containerPorts.metrics .Values.containerPorts.client }}
               path: /livez
               scheme: "HTTP"
             {{- end }}


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

fix livenessprobe when metrics.useSeparateEndpoint is set.

Force to listen on metrics port instead of client port.

### Benefits

Allow livenessProbe to succeed when metrics.useSeparateEndpoint is set.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
