### PR TITLE
[bitnami/minio] Fix issue when using custom secret keys

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.0.3 (2025-04-08)
+## 16.0.4 (2025-04-09)
 
-* [bitnami/minio] Release 16.0.3 ([#32877](https://github.com/bitnami/charts/pull/32877))
+* [bitnami/minio] Fix issue when using custom secret keys ([#32882](https://github.com/bitnami/charts/pull/32882))
+
+## <small>16.0.3 (2025-04-08)</small>
+
+* [bitnami/minio] Release 16.0.3 (#32877) ([3dc1ea0](https://github.com/bitnami/charts/commit/3dc1ea0dbbcf21bd58182639486c7be75b20524d)), closes [#32877](https://github.com/bitnami/charts/issues/32877)
 
 ## <small>16.0.2 (2025-04-03)</small>
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 16.0.3
+version: 16.0.4

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -156,9 +156,9 @@ spec:
               value: {{ ternary "yes" "no" .Values.auth.forceNewKeys | quote }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: MINIO_ROOT_USER_FILE
-              value: "/opt/bitnami/minio/secrets/root-user"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootUserKey" .) }}
             - name: MINIO_ROOT_PASSWORD_FILE
-              value: "/opt/bitnami/minio/secrets/root-password"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootPasswordKey" .) }}
             {{- else }}
             - name: MINIO_ROOT_USER
               valueFrom:

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -258,9 +258,9 @@ spec:
               value: {{ ternary "https" "http" .Values.tls.enabled | quote }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: MINIO_ROOT_USER_FILE
-              value: "/opt/bitnami/minio/secrets/root-user"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootUserKey" .) }}
             - name: MINIO_ROOT_PASSWORD_FILE
-              value: "/opt/bitnami/minio/secrets/root-password"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootPasswordKey" .) }}
             {{- else }}
             - name: MINIO_ROOT_USER
               valueFrom:

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -123,9 +123,9 @@ spec:
               value: {{ .Values.containerPorts.api | quote }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: MINIO_ROOT_USER_FILE
-              value: "/opt/bitnami/minio/secrets/root-user"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootUserKey" .) }}
             - name: MINIO_ROOT_PASSWORD_FILE
-              value: "/opt/bitnami/minio/secrets/root-password"
+              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.rootPasswordKey" .) }}
             {{- else }}
             - name: MINIO_ROOT_USER
               valueFrom:


### PR DESCRIPTION
### Description of the change

Fixes an issue when using values `auth.rootPasswordSecretKey` or `auth.rootUserSecretKey`.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #32850

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
