### PR TITLE
[bitnami/matomo] Adds matomo-secrets volume to matomo-archive cronjob

### DIFF
--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.3.1 (2025-04-08)
+## 9.3.2 (2025-04-09)
 
-* [bitnami/matomo] Add missing `app.kubernetes.io/component` label to deployment and pdb ([#32774](https://github.com/bitnami/charts/pull/32774))
+* [bitnami/matomo] Adds matomo-secrets volume to matomo-archive cronjob ([#32924](https://github.com/bitnami/charts/pull/32924))
+
+## <small>9.3.1 (2025-04-09)</small>
+
+* [bitnami/matomo] Add missing `app.kubernetes.io/component` label to deployment and pdb (#32774) ([eacfbe1](https://github.com/bitnami/charts/commit/eacfbe1d77a27ad59168aef51ddcf7a2c220dea8)), closes [#32774](https://github.com/bitnami/charts/issues/32774)
 
 ## 9.3.0 (2025-03-31)
 

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 9.3.1
+version: 9.3.2

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -147,6 +147,13 @@ spec:
                 {{- toYaml .Values.resources | nindent 16 }}
               {{- end }}
           volumes:
+            {{- if .Values.usePasswordFiles }}
+            - name: matomo-secrets
+              projected:
+                sources:
+                  - secret:
+                      name:  {{ include "matomo.databaseSecretName" . }}
+            {{- end }}
             {{- if .Values.certificates.customCAs }}
             - name: etc-ssl-certs
               emptyDir:


### PR DESCRIPTION
### Description of the change

Added matomo-secrets volume to matomo-archive cronjob.

### Benefits

Deployable archive cronjob

### Possible drawbacks

-

### Applicable issues

- fixes #32884

### Additional information

-

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
