### PR TITLE
[bitnami/influxdb] bugfix: replace references to .Release.Namespace

### DIFF
--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 6.6.2 (2025-04-01)
+## 6.6.3 (2025-04-14)
 
-* [bitnami/influxdb] Release 6.6.2 ([#32739](https://github.com/bitnami/charts/pull/32739))
+* [bitnami/influxdb] bugfix: replace references to .Release.Namespace ([#32985](https://github.com/bitnami/charts/pull/32985))
+
+## <small>6.6.2 (2025-04-01)</small>
+
+* [bitnami/*] Add tanzuCategory annotation (#32409) ([a8fba5c](https://github.com/bitnami/charts/commit/a8fba5cb01f6f4464ca7f69c50b0fbe97d837a95)), closes [#32409](https://github.com/bitnami/charts/issues/32409)
+* [bitnami/influxdb] Release 6.6.2 (#32739) ([7cbd52e](https://github.com/bitnami/charts/commit/7cbd52ec214f321e3cad390eaf0f7e2667a06309)), closes [#32739](https://github.com/bitnami/charts/issues/32739)
 
 ## <small>6.6.1 (2025-03-05)</small>
 

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 6.6.2
+version: 6.6.3

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -198,6 +198,7 @@ There are K8s distribution, such as OpenShift, where you can dynamically define 
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                  | `""`            |
 | `nameOverride`           | String to partially override influxdb.fullname template with a string (will prepend the release name) | `""`            |
 | `fullnameOverride`       | String to fully override influxdb.fullname template with a string                                     | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace                                                       | `""`            |
 | `clusterDomain`          | Default Kubernetes cluster domain                                                                     | `cluster.local` |
 | `commonAnnotations`      | Annotations to add to all deployed objects                                                            | `{}`            |
 | `commonLabels`           | Labels to add to all deployed objects                                                                 | `{}`            |

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -14,11 +14,11 @@ The chart has been deployed in diagnostic mode. All probes have been disabled an
 
 Get the list of pods by executing:
 
-  kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Access the pod you want to debug by executing
 
-  kubectl exec --namespace {{ .Release.Namespace }} -ti <NAME OF THE POD> -- bash
+  kubectl exec --namespace {{ include "common.names.namespace" . }} -ti <NAME OF THE POD> -- bash
 
 In order to replicate the container startup scripts execute this command:
 
@@ -28,43 +28,43 @@ In order to replicate the container startup scripts execute this command:
 
 InfluxDB&trade; can be accessed through following DNS names from within your cluster:
 
-    InfluxDB&trade;: {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }})
+    InfluxDB&trade;: {{ include "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }} (port {{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }})
     {{- if .Values.metrics.enabled }}
-    InfluxDB&trade; Prometheus Metrics: {{ include "common.names.fullname" . }}-metrics.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.metrics.service.port }})
+    InfluxDB&trade; Prometheus Metrics: {{ include "common.names.fullname" . }}-metrics.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.metrics.service.port }})
     {{- end }}
 
 {{- if .Values.authEnabled }}
 
 To get the password for the {{ .Values.auth.admin.username }} user, run:
 
-    export ADMIN_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.admin-user-password}" | base64 -d)
+    export ADMIN_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.admin-user-password}" | base64 -d)
 
 {{- if .Values.auth.user.username }}
 
 To get the password for the {{ .Values.auth.user.username }} user, run:
 
-    export USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.user-password}" | base64 -d)
+    export USER_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.user-password}" | base64 -d)
 
 {{- end }}
 {{- if .Values.auth.readUser.username }}
 
 To get the password for the {{ .Values.auth.readUser.username }} user, run:
 
-    export READ_USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.read-user-password}" | base64 -d)
+    export READ_USER_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.read-user-password}" | base64 -d)
 
 {{- end }}
 {{- if .Values.auth.writeUser.username }}
 
 To get the password for the {{ .Values.auth.writeUser.username }} user, run:
 
-    export WRITE_USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.write-user-password}" | base64 -d)
+    export WRITE_USER_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.write-user-password}" | base64 -d)
 
 {{- end }}
 {{- end }}
 
 To connect to your database run the following commands:
 
-    kubectl run {{ include "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ .Release.Namespace }} {{ if .Values.authEnabled }}--env="INFLUX_USERNAME={{ .Values.auth.admin.username }}" --env="INFLUX_PASSWORD=$ADMIN_PASSWORD"{{ end }} \
+    kubectl run {{ include "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ include "common.names.namespace" . }} {{ if .Values.authEnabled }}--env="INFLUX_USERNAME={{ .Values.auth.admin.username }}" --env="INFLUX_PASSWORD=$ADMIN_PASSWORD"{{ end }} \
         {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ include "common.names.fullname" . }}-client=true" {{ end }}--image {{ include "influxdb.image" . }} \
         --command -- influx -host {{ include "common.names.fullname" . }} -port {{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }}
 
@@ -91,21 +91,21 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- else if contains "NodePort" .Values.influxdb.service.type }}
 
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
-    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
     {{- if .Values.authEnabled }}INFLUX_USERNAME="{{ .Values.auth.admin.username }}" INFLUX_PASSWORD="$ADMIN_PASSWORD"{{- end }} influx -host $NODE_IP -port $NODE_PORT
 
 {{- else if contains "LoadBalancer" .Values.influxdb.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get --namespace {{ include "common.names.namespace" . }} svc -w {{ include "common.names.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     {{- if .Values.authEnabled }}INFLUX_USERNAME="{{ .Values.auth.admin.username }}" INFLUX_PASSWORD="$ADMIN_PASSWORD"{{- end }} influx -host $SERVICE_IP -port {{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }}
 
 {{- else if contains "ClusterIP" .Values.influxdb.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8086:{{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }} &
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ include "common.names.fullname" . }} 8086:{{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }} &
     {{- if .Values.authEnabled }}INFLUX_USERNAME="{{ .Values.auth.admin.username }}" INFLUX_PASSWORD="$ADMIN_PASSWORD"{{- end }} influx -host 127.0.0.1 -port 8086
 
 {{- end }}

--- a/bitnami/influxdb/templates/configmap-backup.yaml
+++ b/bitnami/influxdb/templates/configmap-backup.yaml
@@ -24,7 +24,8 @@ data:
 
     DATE="$(date +%Y%m%d_%H%M%S)"
 
-    host="{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc"
+
+    host="{{ include "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc"
 
     get_orgs() {
       INFLUX_TOKEN="${INFLUXDB_ADMIN_USER_TOKEN}" influx org list --host "http://${host}:{{ coalesce .Values.influxdb.service.ports.http .Values.influxdb.service.port }}" 2> /dev/null | grep -v 'ID' | awk -F '\t' 'BEGIN{ORS=" "} {print $2}'

--- a/bitnami/influxdb/templates/servicemonitor.yaml
+++ b/bitnami/influxdb/templates/servicemonitor.yaml
@@ -8,8 +8,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
+  {{- $labels := include "common.tplvalues).merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: influxdb-metrics
   {{- if .Values.commonAnnotations }}
@@ -42,5 +42,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -45,6 +45,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override influxdb.fullname template with a string
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param clusterDomain Default Kubernetes cluster domain
 ##
 clusterDomain: cluster.local


### PR DESCRIPTION
### Description of the change

This PR replaces references to `.Release.Namespace` using our common helper `common.names.namespace`

### Benefits

Target namespace can be overwritten via the `namespaceOverride` chart parameter.

### Possible drawbacks

None

### Applicable issues

- fixes #32939

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
