### PR TITLE
Fix typo mentioning Geode in Solr and Zookeeper

### DIFF
--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -343,7 +343,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
 | `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
 | `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
-| `ingress.enabled`                       | Enable ingress record generation for Apache Geode                                                                                | `false`                  |
+| `ingress.enabled`                       | Enable ingress record generation for Solr                                                                                        | `false`                  |
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -539,7 +539,7 @@ networkPolicy:
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##
 ingress:
-  ## @param ingress.enabled Enable ingress record generation for Apache Geode
+  ## @param ingress.enabled Enable ingress record generation for Solr
   ##
   enabled: false
   ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -224,7 +224,7 @@ dataLogDir: ""
 ## @param configuration Configure ZooKeeper with a custom zoo.cfg file
 ## e.g:
 ## configuration: |-
-##   deploy-working-dir=/bitnami/geode/data
+##   deploy-working-dir=/bitnami/zookeeper/data
 ##   log-level=info
 ##   ...
 ##


### PR DESCRIPTION
There are some typos in Solr and Zookeeper mentioning Geode.
There is no need to update the chart version or separate the changes into different PRs since the modifications only impact comments.