### PR TITLE
[bitnami/keycloak] bugfix: add prefix on projected db secret keys

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.5.3 (2025-04-11)
+## 24.5.4 (2025-04-15)
 
-* [bitnami/keycloak] Release 24.5.3 ([#32970](https://github.com/bitnami/charts/pull/32970))
+* [bitnami/keycloak] bugfix: add prefix on projected db secret keys ([#33004](https://github.com/bitnami/charts/pull/33004))
+
+## <small>24.5.3 (2025-04-11)</small>
+
+* [bitnami/keycloak] Release 24.5.3 (#32970) ([5f9e017](https://github.com/bitnami/charts/commit/5f9e0175fa8e09211ccb591d36abcbe9abfd71a3)), closes [#32970](https://github.com/bitnami/charts/issues/32970)
 
 ## <small>24.5.2 (2025-04-11)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.5.3
+version: 24.5.4

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -158,22 +158,22 @@ spec:
             - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
               value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.secretKey" .) }}
             - name: KEYCLOAK_DATABASE_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.databaseSecretPasswordKey" .) }}
+              value: {{ printf "/opt/bitnami/keycloak/secrets/db-%s" (include "keycloak.databaseSecretPasswordKey" .) }}
             {{- if .Values.externalDatabase.existingSecretHostKey }}
             - name: KEYCLOAK_DATABASE_HOST_FILE
-              value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.databaseSecretHostKey" .) }}
+              value: {{ printf "/opt/bitnami/keycloak/secrets/db-%s" (include "keycloak.databaseSecretHostKey" .) }}
             {{- end }}
             {{- if .Values.externalDatabase.existingSecretPortKey }}
             - name: KEYCLOAK_DATABASE_PORT_FILE
-              value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.databaseSecretPortKey" .) }}
+              value: {{ printf "/opt/bitnami/keycloak/secrets/db-%s" (include "keycloak.databaseSecretPortKey" .) }}
             {{- end }}
             {{- if .Values.externalDatabase.existingSecretUserKey }}
             - name: KEYCLOAK_DATABASE_USER_FILE
-              value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.databaseSecretUserKey" .) }}
+              value: {{ printf "/opt/bitnami/keycloak/secrets/db-%s" (include "keycloak.databaseSecretUserKey" .) }}
             {{- end }}
             {{- if .Values.externalDatabase.existingSecretDatabaseKey }}
             - name: KEYCLOAK_DATABASE_NAME_FILE
-              value: {{ printf "/opt/bitnami/keycloak/secrets/%s" (include "keycloak.databaseSecretDatabaseKey" .) }}
+              value: {{ printf "/opt/bitnami/keycloak/secrets/db-%s" (include "keycloak.databaseSecretDatabaseKey" .) }}
             {{- end }}
             {{- if and .Values.tls.enabled (or .Values.tls.keystorePassword .Values.tls.passwordsSecret) }}
             - name: KEYCLOAK_HTTPS_KEY_STORE_PASSWORD_FILE
@@ -341,7 +341,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/keycloak/providers
               subPath: app-providers-dir
-            {{- if  .Values.usePasswordFiles }}
+            {{- if .Values.usePasswordFiles }}
             - name: keycloak-secrets
               mountPath: /opt/bitnami/keycloak/secrets
             {{- end }}
@@ -383,16 +383,35 @@ spec:
           projected:
             sources:
               - secret:
-                  name:  {{ include "keycloak.secretName" . }}
+                  name: {{ include "keycloak.secretName" . }}
               - secret:
-                  name:  {{ include "keycloak.databaseSecretName" . }}
+                  name: {{ include "keycloak.databaseSecretName" . }}
+                  items:
+                    - key: {{ include "keycloak.databaseSecretPasswordKey" . }}
+                      path: {{ printf "db-%s" (include "keycloak.databaseSecretPasswordKey" .) }}
+                    {{- if .Values.externalDatabase.existingSecretHostKey }}
+                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                      path: {{ printf "db-%s" (include "keycloak.databaseSecretHostKey" .) }}
+                    {{- end }}
+                    {{- if .Values.externalDatabase.existingSecretPortKey }}
+                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                      path: {{ printf "db-%s" (include "keycloak.databaseSecretPortKey" .) }}
+                    {{- end }}
+                    {{- if .Values.externalDatabase.existingSecretUserKey }}
+                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                      path: {{ printf "db-%s" (include "keycloak.databaseSecretUserKey" .) }}
+                    {{- end }}
+                    {{- if .Values.externalDatabase.existingSecretDatabaseKey }}
+                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                      path: {{ printf "db-%s" (include "keycloak.databaseSecretDatabaseKey" .) }}
+                    {{- end }}
               {{- if and .Values.tls.enabled (or .Values.tls.keystorePassword .Values.tls.truststorePassword .Values.tls.passwordsSecret) }}
               - secret:
-                  name:  {{ include "keycloak.tlsPasswordsSecretName" . }}
+                  name: {{ include "keycloak.tlsPasswordsSecretName" . }}
               {{- end }}
               {{- if and .Values.spi.existingSecret (or .Values.spi.truststorePassword .Values.spi.passwordsSecret) }}
               - secret:
-                  name:  {{ include "keycloak.spiPasswordsSecretName" . }}
+                  name: {{ include "keycloak.spiPasswordsSecretName" . }}
               {{- end }}
         {{- end }}
         {{- if or .Values.configuration .Values.existingConfigmap }}


### PR DESCRIPTION
### Description of the change

This PR adds a `db-` prefix on projected database secret keys to avoid collisions with the Keycloak password secret key.

### Benefits

Avoid collisions to overwrite passwords.

### Possible drawbacks

None

### Applicable issues

Reported by @olav-st at https://github.com/bitnami/charts/pull/32594

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
