### PR TITLE
[bitnami/grafana] fixed namespaceOverride options

### DIFF
--- a/bitnami/grafana/CHANGELOG.md
+++ b/bitnami/grafana/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.6.4 (2025-04-16)
+## 11.6.4 (2025-04-22)
 
 * [bitnami/grafana] fixed namespaceOverride options ([#33014](https://github.com/bitnami/charts/pull/33014))
 

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 11.6.3
+version: 11.6.4

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -410,6 +410,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 | `extraDeploy`       | Array of extra objects to deploy with the release                                       | `[]`            |
 | `nameOverride`      | String to partially override grafana.fullname template (will maintain the release name) | `""`            |
 | `fullnameOverride`  | String to fully override grafana.fullname template                                      | `""`            |
+| `namespaceOverride` | String to fully override common.names.namespace                                         | `""`            |
 | `clusterDomain`     | Default Kubernetes cluster domain                                                       | `cluster.local` |
 | `commonLabels`      | Labels to add to all deployed objects                                                   | `{}`            |
 | `commonAnnotations` | Annotations to add to all deployed objects                                              | `{}`            |

--- a/bitnami/grafana/templates/configmap.yaml
+++ b/bitnami/grafana/templates/configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-envvars
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/dashboard-provider.yaml
+++ b/bitnami/grafana/templates/dashboard-provider.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-provider
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/datasources-secret.yaml
+++ b/bitnami/grafana/templates/datasources-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-datasources
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/ingress.yaml
+++ b/bitnami/grafana/templates/ingress.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   annotations:

--- a/bitnami/grafana/templates/ldap-secret.yaml
+++ b/bitnami/grafana/templates/ldap-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-ldap-conf" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/prometheusrules.yaml
+++ b/bitnami/grafana/templates/prometheusrules.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
+  namespace: {{ default include "common.names.namespace" .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/grafana/templates/pvc.yaml
+++ b/bitnami/grafana/templates/pvc.yaml
@@ -8,7 +8,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if or .Values.persistence.annotations .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/secret.yaml
+++ b/bitnami/grafana/templates/secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-admin
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/service.yaml
+++ b/bitnami/grafana/templates/service.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if or (and .Values.metrics.enabled .Values.metrics.service.annotations) .Values.service.annotations .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "grafana.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default include "common.names.namespace" .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}

--- a/bitnami/grafana/templates/smtp-secret.yaml
+++ b/bitnami/grafana/templates/smtp-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-smtp
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/templates/tls-secret.yaml
+++ b/bitnami/grafana/templates/tls-secret.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ $.Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if $.Values.commonAnnotations }}
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -48,6 +48,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override grafana.fullname template
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param clusterDomain Default Kubernetes cluster domain
 ##
 clusterDomain: cluster.local


### PR DESCRIPTION
### Description of the change

Use the common namespaceOverride options

### Benefits

deploy the chart in custom namespaces

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
