### PR TITLE
[bitnami/clickhouse-operator] docs: improve examples on READMEs

### DIFF
--- a/.vib/clickhouse-operator/goss/goss.yaml
+++ b/.vib/clickhouse-operator/goss/goss.yaml
@@ -12,12 +12,6 @@ file:
     contents:
       - /listen_host>::</
       - /listen_host>0.0.0.0</
-  /opt/bitnami/clickhouse/etc/conf.d/chop-generated-hostname-ports.xml:
-    exists: true
-    filetype: symlink
-    contents:
-      - /tcp_port>9000</
-      - /http_port>8123</
   /opt/bitnami/clickhouse/etc/conf.d/chop-generated-zookeeper.xml:
     exists: true
     filetype: symlink

--- a/.vib/clickhouse-operator/goss/goss.yaml
+++ b/.vib/clickhouse-operator/goss/goss.yaml
@@ -22,7 +22,7 @@ file:
     exists: true
     filetype: symlink
     contents:
-      - /chk-vib-vib-0-0/
+      - /chk-vib-vib/
   /opt/bitnami/clickhouse/etc/users.d/chop-generated-users.xml:
     exists: true
     filetype: symlink

--- a/.vib/clickhouse-operator/goss/goss.yaml
+++ b/.vib/clickhouse-operator/goss/goss.yaml
@@ -16,8 +16,8 @@ file:
     exists: true
     filetype: symlink
     contents:
-      - /tcp_port>9001</
-      - /http_port>8124</
+      - /tcp_port>9000</
+      - /http_port>8123</
   /opt/bitnami/clickhouse/etc/conf.d/chop-generated-zookeeper.xml:
     exists: true
     filetype: symlink
@@ -30,11 +30,11 @@ file:
       - /<{{ .Vars.auth.username }}>/
 # Host and ports are hardcoded in the ClickHouseInstallationTemplate
 http:
-  http://127.0.0.1:8124/replicas_status:
+  http://127.0.0.1:8123/replicas_status:
     status: 200
     body:
       - Ok
-  http://chi-vib-vib-0-0:8124/replicas_status:
+  http://chi-vib-vib-0-0:8123/replicas_status:
     status: 200
     body:
       - Ok
@@ -46,7 +46,7 @@ addr:
 command:
   check-cluster-status:
     # Hardcoded port based on the ClickHouseInstallationTemplate spec
-    exec: clickhouse-client --port 9001 --user '{{ .Vars.auth.username }}' --password '{{ .Vars.auth.password }}' --query='SELECT COUNT(*) FROM system.clusters;'
+    exec: clickhouse-client --port 9000 --user '{{ .Vars.auth.username }}' --password '{{ .Vars.auth.password }}' --query='SELECT COUNT(*) FROM system.clusters;'
     exit-status: 0
     stdout:
       - "4"
@@ -55,7 +55,7 @@ command:
     {{- $database := printf "test_goss_%s" (randAlpha 5) }}
     {{- $table := printf "%s.table_%s" $database (randAlpha 5) }}
     {{- $insertValue := 23 }}
-    exec: clickhouse-client --host chi-vib-vib-0-0 --port 9001 --user '{{ .Vars.auth.username }}' --password '{{ .Vars.auth.password }}' --multiquery --query='CREATE DATABASE {{ $database }} ON CLUSTER vib ENGINE = Memory; CREATE TABLE {{ $table }} (a UInt8) ENGINE = Memory;  INSERT INTO {{ $table }} VALUES({{ $insertValue }}); SELECT * FROM {{ $table }};'
+    exec: clickhouse-client --host chi-vib-vib-0-0 --port 9000 --user '{{ .Vars.auth.username }}' --password '{{ .Vars.auth.password }}' --multiquery --query='CREATE DATABASE {{ $database }} ON CLUSTER vib ENGINE = Memory; CREATE TABLE {{ $table }} (a UInt8) ENGINE = Memory;  INSERT INTO {{ $table }} VALUES({{ $insertValue }}); SELECT * FROM {{ $table }};'
     exit-status: 0
     stdout:
       - "{{ $insertValue }}"

--- a/.vib/clickhouse-operator/runtime-parameters.yaml
+++ b/.vib/clickhouse-operator/runtime-parameters.yaml
@@ -219,13 +219,13 @@ extraDeploy:
   metadata:
     name: chk-vib-vib
     labels:
-      clickhouse-keeper.altinity.com/chk: test
-      clickhouse-keeper.altinity.com/cluster: cluster
+      clickhouse-keeper.altinity.com/chk: vib
+      clickhouse-keeper.altinity.com/cluster: vib
   spec:
     ports:
       - port: 2181
         name: client
     selector:
-      clickhouse-keeper.altinity.com/chk: test
-      clickhouse-keeper.altinity.com/cluster: cluster
+      clickhouse-keeper.altinity.com/chk: vib
+      clickhouse-keeper.altinity.com/cluster: vib
       clickhouse-keeper.altinity.com/ready: "yes"

--- a/.vib/clickhouse-operator/runtime-parameters.yaml
+++ b/.vib/clickhouse-operator/runtime-parameters.yaml
@@ -113,7 +113,7 @@ extraDeploy:
           - '::/0'
       zookeeper:
         nodes:
-          - host: chk-test-cluster
+          - host: chk-vib-vib
             port: 2181
       clusters:
         - name: vib
@@ -217,7 +217,7 @@ extraDeploy:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: chk-test-cluster
+    name: chk-vib-vib
     labels:
       clickhouse-keeper.altinity.com/chk: test
       clickhouse-keeper.altinity.com/cluster: cluster

--- a/.vib/clickhouse-operator/runtime-parameters.yaml
+++ b/.vib/clickhouse-operator/runtime-parameters.yaml
@@ -50,19 +50,6 @@ extraDeploy:
                 env:
                   - name: BITNAMI_DEBUG
                     value: "true"
-                  - name: CLICKHOUSE_HTTP_PORT
-                    value: "8124"
-                  - name: CLICKHOUSE_TCP_PORT
-                    value: "9001"
-                  - name: CLICKHOUSE_INTERSERVER_HTTP_PORT
-                    value: "9010"
-                ports:
-                  - name: http
-                    containerPort: 8124
-                  - name: tcp
-                    containerPort: 9001
-                  - name: interserver
-                    containerPort: 9010
                 resources:
                   requests:
                     memory: "256M"
@@ -117,16 +104,16 @@ extraDeploy:
         dataVolumeClaimTemplate: default-volume-claim
     configuration:
       settings:
-        http_port: 8124
-        tcp_port: 9001
-        interserver_http_port: 9010
+        http_port: 8123
+        tcp_port: 9000
+        interserver_http_port: 9009
       users:
         test_user/networks/ip:
           - 0.0.0.0/0
           - '::/0'
       zookeeper:
         nodes:
-          - host: chk-vib-vib-0-0
+          - host: chk-test-cluster
             port: 2181
       clusters:
         - name: vib
@@ -186,10 +173,6 @@ extraDeploy:
                     value: "true"
                   - name: CLICKHOUSE_KEEPER_SERVER_ID
                     value: "1"
-                  - name: CLICKHOUSE_KEEPER_TCP_PORT
-                    value: "2181"
-                  - name: CLICKHOUSE_KEEPER_RAFT_PORT
-                    value: "9444"
                 resources:
                   requests:
                     memory: "256M"
@@ -231,3 +214,18 @@ extraDeploy:
             resources:
               requests:
                 storage: 8Gi
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: chk-test-cluster
+    labels:
+      clickhouse-keeper.altinity.com/chk: test
+      clickhouse-keeper.altinity.com/cluster: cluster
+  spec:
+    ports:
+      - port: 2181
+        name: client
+    selector:
+      clickhouse-keeper.altinity.com/chk: test
+      clickhouse-keeper.altinity.com/cluster: cluster
+      clickhouse-keeper.altinity.com/ready: "yes"

--- a/bitnami/clickhouse-operator/CHANGELOG.md
+++ b/bitnami/clickhouse-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.4 (2025-04-09)
+## 0.1.5 (2025-04-15)
 
-* [bitnami/clickhouse-operator] Release 0.1.4 ([#32926](https://github.com/bitnami/charts/pull/32926))
+* [bitnami/clickhouse-operator] docs: improve examples on READMEs ([#33020](https://github.com/bitnami/charts/pull/33020))
+
+## <small>0.1.4 (2025-04-09)</small>
+
+* [bitnami/clickhouse-operator] Release 0.1.4 (#32926) ([d73815c](https://github.com/bitnami/charts/commit/d73815c4dad41a121572b0940b78aea96e00e270)), closes [#32926](https://github.com/bitnami/charts/issues/32926)
 
 ## <small>0.1.3 (2025-04-09)</small>
 

--- a/bitnami/clickhouse-operator/CHANGELOG.md
+++ b/bitnami/clickhouse-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.5 (2025-04-15)
+## 0.1.5 (2025-04-16)
 
 * [bitnami/clickhouse-operator] docs: improve examples on READMEs ([#33020](https://github.com/bitnami/charts/pull/33020))
 

--- a/bitnami/clickhouse-operator/Chart.yaml
+++ b/bitnami/clickhouse-operator/Chart.yaml
@@ -36,4 +36,4 @@ name: clickhouse-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse-operator
 - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse-operator
-version: 0.1.4
+version: 0.1.5


### PR DESCRIPTION
### Description of the change

This PR extends the example we have in the README so it doesn't deploy a simple ClickHouse Installation but one that uses a ClickHouse Keeper Installation.

It also simplifies the runtime parameter setup by removing some extra properties that aren't required.

### Benefits

Users understand how to create ClickHouse Keeper Installations.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
