### PR TITLE
[bitnami/redis] fix 32573 - Always announce hostname independent of external service configuration

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.12.1 (2025-04-16)
+## 20.12.2 (2025-04-16)
 
-* [bitnami/redis] Fix sentinel masterService extraPorts not rendered ([#32961](https://github.com/bitnami/charts/pull/32961))
+* [bitnami/redis] fix 32573 - Always announce hostname independent of external service configuration ([#33024](https://github.com/bitnami/charts/pull/33024))
+
+## <small>20.12.1 (2025-04-16)</small>
+
+* [bitnami/redis] Fix sentinel masterService extraPorts not rendered (#32961) ([cbc134f](https://github.com/bitnami/charts/commit/cbc134f26b1f146e2a482a27db72d98c1d1b344e)), closes [#32961](https://github.com/bitnami/charts/issues/32961)
 
 ## 20.12.0 (2025-04-15)
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.12.1
+version: 20.12.2

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -466,8 +466,8 @@ data:
     {{- if not (contains "sentinel announce-port" .Values.sentinel.configuration) }}
     echo "sentinel announce-port $SERVPORT" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
-    {{- if .Values.sentinel.externalAccess.enabled }}
     {{- if not (contains "sentinel announce-ip" .Values.sentinel.configuration) }}
+    {{- if .Values.sentinel.externalAccess.enabled }}
     if [[ -n "${REDIS_CLUSTER_ANNOUNCE_IP}" ]]; then
       echo "sentinel announce-ip $REDIS_CLUSTER_ANNOUNCE_IP" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     else


### PR DESCRIPTION
### Description of the change

Since #32190, using Redis Sentinel means the Redis Sentinels will not announce their hostnames anymore. This is because the `sentinel announce-ip` configuration is only included when `.Values.sentinel.externalAccess.enabled` is set to `true`.

Before #32190, `sentinel announce-ip` was always included with the sentinel configuration, unless it was already included within the custom configuration that can be set through `.Values.sentinel.configuration`.

This change ensures that the old behaviour is restored. As long as `sentinel announce-ip` is not set manually as part of `.Values.sentinel.configuration`, it is always included to ensure that sentinels announce their hostnames to eachother. When external access is enabled, the configuration is changed slightly in correspondence with #32190, such that `REDIS_CLUSTER_ANNOUNCE_IP` is honored.

### Benefits

By announcing the hostnames of sentinels using `sentinel announce-ip`, we will instruct the sentinels to use the hostname only. This prevents sentinels from flapping between IPv4 and IPv6 addresses in fully dual-stack clusters, as described in #32573. Furthermore, it restores the old behavior back in place.

### Possible drawbacks

There is a very small change that users are somehow relying on `sentinel announce-ip` being absent since chart version 20.11.0. I am not sure how that would be an issue, but it is the only thing to put out there.

### Applicable issues

- fixes #32573

### Additional information

n/a

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
