### PR TITLE
[bitnami/logstash] Fix headless service does not include extra ports

### DIFF
--- a/bitnami/logstash/CHANGELOG.md
+++ b/bitnami/logstash/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.4.7 (2025-04-15)
+## 6.4.8 (2025-04-17)
 
-* [bitnami/logstash] Release 6.4.7 ([#33013](https://github.com/bitnami/charts/pull/33013))
+* [bitnami/logstash] Fix headless service does not include extra ports ([#33055](https://github.com/bitnami/charts/pull/33055))
+
+## <small>6.4.7 (2025-04-15)</small>
+
+* [bitnami/logstash] Release 6.4.7 (#33013) ([aee7e22](https://github.com/bitnami/charts/commit/aee7e221de53c9dd8cb455527b4c37b8bda53af2)), closes [#33013](https://github.com/bitnami/charts/issues/33013)
 
 ## <small>6.4.6 (2025-03-25)</small>
 

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: logstash
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 6.4.7
+version: 6.4.8

--- a/bitnami/logstash/templates/headless-svc.yaml
+++ b/bitnami/logstash/templates/headless-svc.yaml
@@ -20,5 +20,10 @@ spec:
     {{- range $port := .Values.service.ports }}
     - {{- omit (include "common.tplvalues.render" ( dict "value" $port "context" $ ) | fromYaml) "nodePort" | toYaml | nindent 6 }}
     {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- range $port := .Values.service.extraPorts }}
+    - {{- omit (include "common.tplvalues.render" ( dict "value" $port "context" $ ) | fromYaml) "nodePort" | toYaml | nindent 6 }}
+    {{- end }}
+    {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/bitnami/logstash/templates/networkpolicy.yaml
+++ b/bitnami/logstash/templates/networkpolicy.yaml
@@ -59,7 +59,7 @@ spec:
           protocol: {{ default "TCP" .protocol }}
         {{- end }}
         {{- range .Values.extraContainerPorts }}
-        - port: {{ . }}
+        - port: {{ .containerPort }}
           protocol: {{ default "TCP" .protocol }}
         {{- end }}
         {{- if .Values.enableMonitoringAPI }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The change includes ports from the `.service.extraPorts` values to the headless service and fixes the invalid handling of the `.extraContainerPorts` values in the generated NetworkPolicy

### Benefits

<!-- What benefits will be realized by the code change? -->
The headless service gets more usable and the NetworkPolicy no longer errors when a additional container port is defined

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #33054

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
