### PR TITLE
[bitnami/clickhouse] bugfix: prometheus.io/scrape label

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 9.1.1 (2025-04-21)
+
+* [bitnami/clickhouse] bugfix: prometheus.io/scrape label ([#33091](https://github.com/bitnami/charts/pull/33091))
+
 ## 9.1.0 (2025-04-15)
 
-* [bitnami/clickhouse] Stops unnecessary logging ([#32988](https://github.com/bitnami/charts/pull/32988))
+* [bitnami/clickhouse] Stops unnecessary logging (#32988) ([24167d1](https://github.com/bitnami/charts/commit/24167d12f4a9b9088ad36b7aa6cacb2e1f458826)), closes [#32988](https://github.com/bitnami/charts/issues/32988)
 
 ## 9.0.0 (2025-04-15)
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 9.1.0
+version: 9.1.1

--- a/bitnami/clickhouse/templates/service.yaml
+++ b/bitnami/clickhouse/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/part-of: clickhouse
     {{- if and .context.Values.metrics.enabled .context.Values.metrics.serviceMonitor.enabled }}
     {{- /* Adding extra selector for the ServiceMonitor object to avoid duplicate targets  */}}
-    prometheus.io/scrape: true
+    prometheus.io/scrape: "true"
     {{- end }}
     {{- if .context.Values.service.perReplicaAccess }}
     pod: {{ $name }}

--- a/bitnami/clickhouse/templates/service.yaml
+++ b/bitnami/clickhouse/templates/service.yaml
@@ -26,7 +26,7 @@ metadata:
     {{- end }}
   {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .context.Values.service.annotations .context.Values.commonAnnotations) "context" .context) }}
   {{- if .context.Values.metrics.enabled }}
-    {{- $defaultMetricsAnnotations := dict "prometheus.io/scrape" "true" "prometheus.io/port" .context.Values.service.ports.metrics "prometheus.io/path" "/metrics" }}
+    {{- $defaultMetricsAnnotations := dict "prometheus.io/scrape" "true" "prometheus.io/port" (.context.Values.service.ports.metrics | toString) "prometheus.io/path" "/metrics" }}
     {{- $annotations = include "common.tplvalues.merge" (dict "values" (list $annotations $defaultMetricsAnnotations) "context" .context) }}
   {{- end }}
   {{- if and .context.Values.service.perReplicaAccess .context.Values.service.loadBalancerAnnotations }}

--- a/bitnami/clickhouse/templates/servicemonitor.yaml
+++ b/bitnami/clickhouse/templates/servicemonitor.yaml
@@ -26,7 +26,7 @@ spec:
       {{- end }}
       app.kubernetes.io/component: clickhouse
       app.kubernetes.io/part-of: clickhouse
-      prometheus.io/scrape: true
+      prometheus.io/scrape: "true"
   endpoints:
     - port: http-metrics
       path: "/metrics"


### PR DESCRIPTION
### Description of the change

This PR fixes the value for `prometheus.io/scrape` label which should be a string.

### Benefits

Metrics integration works as expected.

### Possible drawbacks

None

### Applicable issues

- fixes #33058
- fixes #33057

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
