### PR TITLE
[bitnami/postgresql-ha] Update POSTGRES_POSTGRES_PASSWORD condition

### DIFF
--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.3.12 (2025-04-09)
+## 15.3.13 (2025-04-22)
 
-* [bitnami/postgresql-ha] Release 15.3.12 ([#32914](https://github.com/bitnami/charts/pull/32914))
+* [bitnami/postgresql-ha] Update POSTGRES_POSTGRES_PASSWORD condition ([#33102](https://github.com/bitnami/charts/pull/33102))
+
+## <small>15.3.12 (2025-04-09)</small>
+
+* [bitnami/postgresql-ha] Release 15.3.12 (#32914) ([48864eb](https://github.com/bitnami/charts/commit/48864eb4b488e4e7121531c3bbeb878dc47be1bd)), closes [#32914](https://github.com/bitnami/charts/issues/32914)
 
 ## <small>15.3.11 (2025-04-07)</small>
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 15.3.12
+version: 15.3.13

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -187,7 +187,7 @@ spec:
               value: {{ .Values.persistence.mountPath | quote }}
             - name: PGDATA
               value: {{ printf "%s/%s" .Values.persistence.mountPath "data" | quote }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (include "postgresql-ha.postgresqlCreateSecret" .) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
             {{- if .Values.postgresql.usePasswordFiles }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
               value: "/opt/bitnami/postgresql/secrets/postgres-password"


### PR DESCRIPTION
### Description of the change

Updates `POSTGRES_POSTGRES_PASSWORD` condition that is now preventing to add a custom user during initialization with the next sample values:

```yaml
postgresql:
  username: user1
  password: 123456
```

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/25671

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* 
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
