### PR TITLE
[bitnami/redis] feat: :sparkles: Disable empty-dirs when readOnlyRootFS is disabled

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.12.2 (2025-04-16)
+## 20.13.0 (2025-04-22)
 
-* [bitnami/redis] fix 32573 - Always announce hostname independent of external service configuration ([#33024](https://github.com/bitnami/charts/pull/33024))
+* [bitnami/redis] feat: :sparkles: Disable empty-dirs when readOnlyRootFS is disabled ([#33108](https://github.com/bitnami/charts/pull/33108))
+
+## <small>20.12.2 (2025-04-21)</small>
+
+* [bitnami/redis] fix 32573 - Always announce hostname independent of external service configuration ( ([282ae5c](https://github.com/bitnami/charts/commit/282ae5c01b12f4a0ad72e6cd0463f5f941244f3d)), closes [#33024](https://github.com/bitnami/charts/issues/33024)
 
 ## <small>20.12.1 (2025-04-16)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -11,11 +11,11 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r40
     - name: redis
-      image: docker.io/bitnami/redis:7.4.2-debian-12-r6
+      image: docker.io/bitnami/redis:7.4.2-debian-12-r11
     - name: redis-exporter
       image: docker.io/bitnami/redis-exporter:1.69.0-debian-12-r1
     - name: redis-sentinel
-      image: docker.io/bitnami/redis-sentinel:7.4.2-debian-12-r6
+      image: docker.io/bitnami/redis-sentinel:7.4.2-debian-12-r11
 apiVersion: v2
 appVersion: 7.4.2
 dependencies:
@@ -37,4 +37,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.12.2
+version: 20.12.3

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.12.3
+version: 20.13.0

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -481,7 +481,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
-        {{- if or (and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
+        {{- if or (and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.enabled .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.master.persistence.medium .Values.master.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -481,7 +481,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
-        {{- if and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem }}
+        {{- if or (and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.master.persistence.medium .Values.master.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -258,12 +258,14 @@ spec:
               {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis/mounted-etc
+            {{- if and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /opt/bitnami/redis/etc/
               subPath: app-conf-dir
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
@@ -365,9 +367,11 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
+            {{- end }}
             {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /secrets/
@@ -418,9 +422,6 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
             - name: redis-data
               mountPath: {{ .Values.master.persistence.path }}
               {{- if .Values.master.persistence.subPath }}
@@ -446,9 +447,6 @@ spec:
           {{- end }}
           {{- if .Values.sysctl.mountHostSys }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
             - name: host-sys
               mountPath: /host-sys
           {{- end }}
@@ -483,6 +481,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
+        {{- if and .Values.master.containerSecurityContext.enabled .Values.master.containerSecurityContext.readOnlyRootFilesystem }}
         - name: empty-dir
           {{- if or .Values.master.persistence.medium .Values.master.persistence.sizeLimit }}
           emptyDir:
@@ -495,6 +494,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: redis-certificates
           secret:

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -501,7 +501,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
-        {{- if or (and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
+        {{- if or (and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.enabled .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.replica.persistence.medium .Values.replica.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -501,7 +501,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
-        {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
+        {{- if or (and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.replica.persistence.medium .Values.replica.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -278,12 +278,14 @@ spec:
               {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis/mounted-etc
+            {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /opt/bitnami/redis/etc
               subPath: app-conf-dir
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
@@ -385,9 +387,11 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /secrets/
@@ -438,9 +442,6 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
             - name: redis-data
               mountPath: {{ .Values.replica.persistence.path }}
               {{- if .Values.replica.persistence.subPath }}
@@ -466,9 +467,6 @@ spec:
           {{- end }}
           {{- if .Values.sysctl.mountHostSys }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
             - name: host-sys
               mountPath: /host-sys
           {{- end }}
@@ -503,6 +501,7 @@ spec:
           hostPath:
             path: /sys
         {{- end }}
+        {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
         - name: empty-dir
           {{- if or .Values.replica.persistence.medium .Values.replica.persistence.sizeLimit }}
           emptyDir:
@@ -515,6 +514,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: redis-certificates
           secret:

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -319,12 +319,14 @@ spec:
               {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis/mounted-etc
+            {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /opt/bitnami/redis/etc
               subPath: app-conf-dir
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
@@ -494,9 +496,11 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.sentinel.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if and .Values.sentinel.containerSecurityContext.enabled .Values.sentinel.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             - name: start-scripts
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
@@ -619,9 +623,11 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /secrets/
@@ -695,9 +701,11 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if and .Values.volumePermissions.containerSecurityContext.enabled .Values.volumePermissions.containerSecurityContext.readOnlyRootFilesystem }}
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- end }}
             - name: redis-data
               mountPath: {{ .Values.replica.persistence.path }}
               {{- if .Values.replica.persistence.subPath }}
@@ -723,9 +731,6 @@ spec:
           {{- end }}
           {{- if .Values.sysctl.mountHostSys }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
             - name: host-sys
               mountPath: /host-sys
           {{- end }}
@@ -782,6 +787,7 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+        {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
         - name: empty-dir
           {{- if or .Values.sentinel.persistence.medium .Values.sentinel.persistence.sizeLimit }}
           emptyDir:
@@ -794,6 +800,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- if .Values.replica.extraVolumes }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.replica.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -787,7 +787,7 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- if and .Values.replica.containerSecurityContext.enabled .Values.replica.containerSecurityContext.readOnlyRootFilesystem }}
+        {{- if or (and .Values.sentinel.containerSecurityContext.enabled .Values.sentinel.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.sentinel.persistence.medium .Values.sentinel.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -787,7 +787,7 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- if or (and .Values.sentinel.containerSecurityContext.enabled .Values.sentinel.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
+        {{- if or (and .Values.sentinel.containerSecurityContext.enabled .Values.sentinel.containerSecurityContext.readOnlyRootFilesystem) (and .Values.metrics.enabled .Values.metrics.containerSecurityContext.enabled .Values.metrics.containerSecurityContext.readOnlyRootFilesystem) }}
         - name: empty-dir
           {{- if or .Values.sentinel.persistence.medium .Values.sentinel.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -114,7 +114,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/redis
-  tag: 7.4.2-debian-12-r6
+  tag: 7.4.2-debian-12-r11
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -1186,7 +1186,7 @@ sentinel:
   image:
     registry: docker.io
     repository: bitnami/redis-sentinel
-    tag: 7.4.2-debian-12-r6
+    tag: 7.4.2-debian-12-r11
     digest: ""
     ## Specify a imagePullPolicy
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images


### PR DESCRIPTION
### Description of the change

This PR disables the use of emptyDirs when readOnlyRootFS is disabled. This helps reducing the host filesystem exhaustion in certain use cases.

### Benefits
Remove unnecessary mounts when not applicable
### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
