### PR TITLE
[bitnami/keycloak] Fix Keycloak external DB secret keys

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.5.7 (2025-04-21)
+## 24.5.8 (2025-04-22)
 
-* [bitnami/keycloak] Dynamic tpl rendering of the external database port ([#33040](https://github.com/bitnami/charts/pull/33040))
+* [bitnami/keycloak] Fix Keycloak external DB secret keys ([#33117](https://github.com/bitnami/charts/pull/33117))
+
+## <small>24.5.7 (2025-04-22)</small>
+
+* [bitnami/keycloak] Dynamic tpl rendering of the external database port (#33040) ([43e308c](https://github.com/bitnami/charts/commit/43e308c340e6bc97bcda538be220c0866889dfe6)), closes [#33040](https://github.com/bitnami/charts/issues/33040)
 
 ## <small>24.5.6 (2025-04-21)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.5.8 (2025-04-22)
+## 24.5.8 (2025-04-23)
 
 * [bitnami/keycloak] Fix Keycloak external DB secret keys ([#33117](https://github.com/bitnami/charts/pull/33117))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.5.7
+version: 24.5.8

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -398,15 +398,15 @@ spec:
                       path: {{ printf "db-%s" (include "keycloak.databaseSecretHostKey" .) }}
                     {{- end }}
                     {{- if .Values.externalDatabase.existingSecretPortKey }}
-                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                    - key: {{ include "keycloak.databaseSecretPortKey" . }}
                       path: {{ printf "db-%s" (include "keycloak.databaseSecretPortKey" .) }}
                     {{- end }}
                     {{- if .Values.externalDatabase.existingSecretUserKey }}
-                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                    - key: {{ include "keycloak.databaseSecretUserKey" . }}
                       path: {{ printf "db-%s" (include "keycloak.databaseSecretUserKey" .) }}
                     {{- end }}
                     {{- if .Values.externalDatabase.existingSecretDatabaseKey }}
-                    - key: {{ include "keycloak.databaseSecretHostKey" . }}
+                    - key: {{ include "keycloak.databaseSecretDatabaseKey" . }}
                       path: {{ printf "db-%s" (include "keycloak.databaseSecretDatabaseKey" .) }}
                     {{- end }}
               {{- if and .Values.tls.enabled (or .Values.tls.keystorePassword .Values.tls.truststorePassword .Values.tls.passwordsSecret) }}


### PR DESCRIPTION
### Description of the change

Fixes the External DB Secret Keys in the Keycloak Statefulset projected secret volume.

### Benefits

Instead of the DB Host, Port, Username, and DB all being the same (the DB Host), they now are the correct values.
Host == host
Port == port
Username == username
DB == DB

### Possible drawbacks

None

### Applicable issues

Reported by @rblaine95 in #33004
Fixes https://github.com/bitnami/charts/issues/33106

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
