### PR TITLE
[bitnami/cassandra]fix(readinessProbe): Remove path for metrics readinessProbe

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.3.4 (2025-04-22)
+## 12.3.5 (2025-04-22)
 
-* [bitnami/cassandra] Store cassandra-exporter configuration in Secret ([#33069](https://github.com/bitnami/charts/pull/33069))
+* [bitnami/cassandra]fix(readinessProbe): Remove path for metrics readinessProbe ([#33121](https://github.com/bitnami/charts/pull/33121))
+
+## <small>12.3.4 (2025-04-22)</small>
+
+* [bitnami/cassandra] Store cassandra-exporter configuration in Secret (#33069) ([597d759](https://github.com/bitnami/charts/commit/597d7598bf4a6968ed7ec67a840c97677f23fe6d)), closes [#33069](https://github.com/bitnami/charts/issues/33069)
 
 ## <small>12.3.3 (2025-04-21)</small>
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.3.4
+version: 12.3.5

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -566,7 +566,6 @@ spec:
               port: metrics
           readinessProbe:
             httpGet:
-              path: /metrics
               port: metrics
             initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change

Remove path in readinessProbe for the metrics container. Metrics are exposed directly in the root path, there is nothing exposed in `/metrics`

### Benefits

ReadinessProbe work as expected by default.

### Possible drawbacks

None


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
