### PR TITLE
[binami/kafka] nodePort field explicitly set to null if not provided in the values

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 32.2.0 (2025-04-07)
+## 32.2.1 (2025-04-23)
 
-* [bitnami/kafka] add topologyKey value ([#32792](https://github.com/bitnami/charts/pull/32792))
+* [binami/kafka] nodePort field explicitly set to null if not provided in the values ([#33134](https://github.com/bitnami/charts/pull/33134))
+
+## 32.2.0 (2025-04-15)
+
+* [bitnami/kafka] add topologyKey value (#32792) ([4ba4ac8](https://github.com/bitnami/charts/commit/4ba4ac8fad117ebcd60f87eab03f038d313158ae)), closes [#32792](https://github.com/bitnami/charts/issues/32792)
+* bitnami/kafka Adjust parameters in example of section "Deploying extra resources" in README  (#32445 ([cac0f81](https://github.com/bitnami/charts/commit/cac0f8110af628b25c84cbe916191fa3f8ce21ea)), closes [#32445](https://github.com/bitnami/charts/issues/32445)
 
 ## <small>32.1.3 (2025-04-01)</small>
 

--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
-## 32.2.1 (2025-04-23)
+## 32.2.1 (2025-05-08)
 
 * [binami/kafka] nodePort field explicitly set to null if not provided in the values ([#33134](https://github.com/bitnami/charts/pull/33134))
+
+## <small>32.2.3 (2025-05-06)</small>
+
+* [bitnami/kafka] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references (#33379) ([12ee35a](https://github.com/bitnami/charts/commit/12ee35a7256e3f0872fbaba0c921ffd9a21d3f4a)), closes [#33379](https://github.com/bitnami/charts/issues/33379)
+
+## <small>32.2.2 (2025-04-28)</small>
+
+* [bitnami/kafka] Release 32.2.2 (#33220) ([172a252](https://github.com/bitnami/charts/commit/172a2520dd4da7c43a2451313db54e649ceabed6)), closes [#33220](https://github.com/bitnami/charts/issues/33220)
+
+## <small>32.2.1 (2025-04-24)</small>
+
+* [bitnami/kafka] Release 32.2.1 (#33159) ([c03b265](https://github.com/bitnami/charts/commit/c03b265fd1dc007f70789f8de1f78adc497273d9)), closes [#33159](https://github.com/bitnami/charts/issues/33159)
 
 ## 32.2.0 (2025-04-15)
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.2.0
+version: 32.2.1

--- a/bitnami/kafka/templates/broker/svc-external-access.yaml
+++ b/bitnami/kafka/templates/broker/svc-external-access.yaml
@@ -48,8 +48,6 @@ spec:
       port: {{ $.Values.externalAccess.broker.service.ports.external }}
       {{- if le (add $i 1) (len $.Values.externalAccess.broker.service.nodePorts) }}
       nodePort: {{ index $.Values.externalAccess.broker.service.nodePorts $i }}
-      {{- else }}
-      nodePort: null
       {{- end }}
       targetPort: external
     {{- if $.Values.externalAccess.broker.service.extraPorts }}

--- a/bitnami/kafka/templates/broker/svc-external-access.yaml
+++ b/bitnami/kafka/templates/broker/svc-external-access.yaml
@@ -48,6 +48,8 @@ spec:
       port: {{ $.Values.externalAccess.broker.service.ports.external }}
       {{- if le (add $i 1) (len $.Values.externalAccess.broker.service.nodePorts) }}
       nodePort: {{ index $.Values.externalAccess.broker.service.nodePorts $i }}
+      {{- else if eq $.Values.externalAccess.broker.service.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
       targetPort: external
     {{- if $.Values.externalAccess.broker.service.extraPorts }}

--- a/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
+++ b/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
@@ -49,8 +49,6 @@ spec:
       port: {{ $.Values.externalAccess.controller.service.ports.external }}
       {{- if le (add $i 1) (len $.Values.externalAccess.controller.service.nodePorts) }}
       nodePort: {{ index $.Values.externalAccess.controller.service.nodePorts $i }}
-      {{- else }}
-      nodePort: null
       {{- end }}
       targetPort: external
     {{- if $.Values.externalAccess.controller.service.extraPorts }}

--- a/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
+++ b/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
@@ -49,6 +49,8 @@ spec:
       port: {{ $.Values.externalAccess.controller.service.ports.external }}
       {{- if le (add $i 1) (len $.Values.externalAccess.controller.service.nodePorts) }}
       nodePort: {{ index $.Values.externalAccess.controller.service.nodePorts $i }}
+      {{- else if eq $.Values.externalAccess.broker.service.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
       targetPort: external
     {{- if $.Values.externalAccess.controller.service.extraPorts }}


### PR DESCRIPTION
Signed-off-by: Alexandre Genon <alexgenon@users.noreply.github.com>

### Description of the change

When no `nodePort` value is set for the external access service specific port, the `nodePort` field value is not set (was previously set to null) 

### Benefits

When the chart was deployed using CD solutions relying on GitOps (e.g. ArgoCD), the fact that `nodePort` field was explicitly set to null (and was then assigned by k8s) led to the service appearing as _out of sync_ 

### Possible drawbacks

None identified so far

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Fixes #33037


### Checklist

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
