### PR TITLE
bitnami/redis: security: update default Redis version to 7.4.3

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20.13.2 (2025-04-23)
+
+* [bitnami/redis] Release 20.13.2 ([#33089](https://github.com/bitnami/charts/pull/33139))
+
 ## 20.13.1 (2025-04-23)
 
 * [bitnami/redis] Release 20.13.1 ([#33089](https://github.com/bitnami/charts/pull/33089))

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -17,7 +17,7 @@ annotations:
     - name: redis-sentinel
       image: docker.io/bitnami/redis-sentinel:7.4.2-debian-12-r11
 apiVersion: v2
-appVersion: 7.4.2
+appVersion: 7.4.3
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -37,4 +37,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.13.1
+version: 20.13.2


### PR DESCRIPTION
### Description of the change

Bumps default appVersion to 7.4.3 per security release: https://github.com/redis/redis/releases/tag/7.4.3

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
