### PR TITLE
[bitnami/spring-cloud-dataflow] Update RabbitMQ to major 16

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 35.0.2 (2025-04-01)
+## 36.0.0 (2025-04-24)
 
-* [bitnami/spring-cloud-dataflow] Release 35.0.2 ([#32714](https://github.com/bitnami/charts/pull/32714))
+* [bitnami/spring-cloud-dataflow] Update RabbitMQ to major 16 ([#33163](https://github.com/bitnami/charts/pull/33163))
+
+## <small>35.0.2 (2025-04-01)</small>
+
+* [bitnami/spring-cloud-dataflow] Release 35.0.2 (#32714) ([e82b3be](https://github.com/bitnami/charts/commit/e82b3be8c90675079d8e308e5e8109b0f6a1eb20)), closes [#32714](https://github.com/bitnami/charts/issues/32714)
 
 ## <small>35.0.1 (2025-04-01)</small>
 

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.4.1
+  version: 16.0.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.4.2
+  version: 20.4.3
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 32.1.3
+  version: 32.2.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.30.0
-digest: sha256:a2be57dac6cae5518a8270a267c98b822b7582ba3f40791edee20a85632dbf6d
-generated: "2025-04-01T15:19:09.941418813Z"
+digest: sha256:219cf63ddb27894ff5c6619349a8230a96facc7125ddd0519d5b6a8b3e896fc8
+generated: "2025-04-24T14:24:43.775939+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
 - condition: rabbitmq.enabled
   name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
+  version: 16.x.x
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -54,4 +54,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 35.0.2
+version: 36.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -789,6 +789,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 ## Upgrading
 
+### To 36.0.0
+
+This major updates the RabbitMQ subchart to its newest major, 16.0.0. For more information on this subchart's major, please refer to [RabbitMQ upgrade notes](https://www.rabbitmq.com/docs/4.1/upgrade).
+
 ### To 35.0.0
 
 This major updates the Kafka subchart to its newest major, 32.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3200).


### PR DESCRIPTION
### Description of the change

This PR bumps the chart major version, given we bumped the major version in one of the chart dependencies: RabbitMQ. 

### Benefits

Keep the chart up-to-date with the latest deps changes.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
