### PR TITLE
[bitnami/valkey-cluster] only use password files if auth is enabled

### DIFF
--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -34,4 +34,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/valkey-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/valkey-cluster/templates/scripts-configmap.yaml
@@ -19,7 +19,7 @@ data:
 
     VALKEY_STATUS_FILE=/tmp/.valkey_cluster_check
 
-    {{- if .Values.usePasswordFiles }}
+    {{- if and .Values.usePassword .Values.usePasswordFiles }}
     password_aux=`cat ${VALKEY_PASSWORD_FILE}`
     export REDISCLI_AUTH=$password_aux
     {{- else }}
@@ -81,7 +81,7 @@ data:
     #!/bin/sh
     set -e
 
-    {{- if .Values.usePasswordFiles }}
+    {{- if and .Values.usePassword .Values.usePasswordFiles }}
     password_aux=`cat ${VALKEY_PASSWORD_FILE}`
     export REDISCLI_AUTH=$password_aux
     {{- else }}

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -274,7 +274,7 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-            {{- if .Values.usePasswordFiles }}
+            {{- if and .Values.usePassword .Values.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
@@ -319,7 +319,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.usePasswordFiles }}
+              {{- if and .Values.usePassword .Values.usePasswordFiles }}
               export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
@@ -356,12 +356,12 @@ spec:
             {{- if .Values.metrics.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.usePasswordFiles .Values.tls.enabled }}
+          {{- if or (and .Values.usePassword .Values.usePasswordFiles) .Values.tls.enabled }}
           volumeMounts:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
-            {{- if .Values.usePasswordFiles }}
+            {{- if and .Values.usePassword .Values.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
@@ -438,7 +438,7 @@ spec:
           configMap:
             name: {{ include "common.names.fullname" . }}-scripts
             defaultMode: 0755
-        {{- if .Values.usePasswordFiles }}
+        {{- if and .Values.usePassword .Values.usePasswordFiles }}
         - name: valkey-password
           secret:
             secretName: {{ include "valkey-cluster.secretName" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Don't mount password files if `usePassword=false` is used. 

### Benefits

<!-- What benefits will be realized by the code change? -->
We don't need to set `usePasswordFiles=false` when using `usePassword=false`

### Possible drawbacks

<!-- Describe any known limitations with your change -->
none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
none

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
same issue as in 
- #32358

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
