### PR TITLE
[bitnami/harbor] Major 25.0.0: Upgrade PostgreSQL to 17.x.x

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -24,8 +24,6 @@ annotations:
       image: docker.io/bitnami/nginx:1.28.0-debian-12-r0
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r43
-    - name: postgresql
-      image: docker.io/bitnami/postgresql:14.17.0-debian-12-r17
 apiVersion: v2
 appVersion: 2.13.0
 dependencies:
@@ -56,4 +54,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 24.6.1
+version: 25.0.0

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -1311,9 +1311,17 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 25.0.0
+
+This version uses the PostgreSQL version provided by the bitnami/postgresql subchart, PostgreSQL 17.x, instead of overriding it with version 14.x.
+
 ### To 24.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
+### To 24.0.1
+
+This version updates the PostgreSQL version to 14.x. Follow the [official instructions](https://www.postgresql.org/docs/14/upgrading.html) to upgrade to 14.x.
 
 ### To 24.0.0
 

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -3793,18 +3793,6 @@ exporter:
 ##
 postgresql:
   enabled: true
-  ## Override PostgreSQL default image as 14.x is not supported https://goharbor.io/docs/2.4.0/install-config/
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql
-  ## @param postgresql.image.registry [default: REGISTRY_NAME] PostgreSQL image registry
-  ## @param postgresql.image.repository [default: REPOSITORY_NAME/postgresql] PostgreSQL image repository
-  ## @skip postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)
-  ## @param postgresql.image.digest PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/postgresql
-    tag: 14.17.0-debian-12-r17
-    digest: ""
   auth:
     enablePostgresUser: true
     postgresPassword: not-secure-database-password


### PR DESCRIPTION
### Description of the change

Updates the `bitnami/harbor` to use the PostgreSQL version defined by the bitnami/postgresql subchart, currently 17.x.x, instead of overriding it with version 14.x.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- closes #31159

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
