### PR TITLE
[bitnami/spring-cloud-dataflow] Major 37.0.0: Upgrade MariaDB to 11.4.x

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -8,8 +8,6 @@ annotations:
   images: |
     - name: kubectl
       image: docker.io/bitnami/kubectl:1.33.0-debian-12-r0
-    - name: mariadb
-      image: docker.io/bitnami/mariadb:10.11.11-debian-12-r11
     - name: prometheus-rsocket-proxy
       image: docker.io/bitnami/prometheus-rsocket-proxy:1.5.3-debian-12-r43
     - name: spring-cloud-dataflow
@@ -54,4 +52,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 36.0.1
+version: 37.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -789,6 +789,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 ## Upgrading
 
+### To 37.0.0
+
+This version uses the MariaDB version provided by the bitnami/mariadb subchart, PostgreSQL 11.4.x, instead of overriding it with version 10.11.x.
+
 ### To 36.0.0
 
 This major updates the RabbitMQ subchart to its newest major, 16.0.0. For more information on this subchart's major, please refer to [RabbitMQ upgrade notes](https://www.rabbitmq.com/docs/4.1/upgrade).

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -119,5 +119,5 @@ WARNING: Review values for the following password in the command, if they are co
   {{- end -}}
 {{- end -}}
 {{- include "common.warnings.resources" (dict "sections" (list "deployer" "metrics" "server" "skipper" "waitForBackends") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.server.image .Values.server.composedTaskRunner.image .Values.skipper.image .Values.metrics.image .Values.waitForBackends.image .Values.mariadb.image) "context" $) }}
-{{- include "common.errors.insecureImages" (dict "images" (list .Values.server.image .Values.server.composedTaskRunner.image .Values.skipper.image .Values.metrics.image .Values.waitForBackends.image .Values.mariadb.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.server.image .Values.server.composedTaskRunner.image .Values.skipper.image .Values.metrics.image .Values.waitForBackends.image) "context" $) }}
+{{- include "common.errors.insecureImages" (dict "images" (list .Values.server.image .Values.server.composedTaskRunner.image .Values.skipper.image .Values.metrics.image .Values.waitForBackends.image) "context" $) }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1816,17 +1816,6 @@ mariadb:
   jdbcParameter:
     ## @param mariadb.jdbcParameter.useMysqlMetadata Use MariaDB useMysqlMetadata parameter.
     useMysqlMetadata: true
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb
-  ## @param mariadb.image.registry [default: REGISTRY_NAME] MariaDB image registry
-  ## @param mariadb.image.repository [default: REPOSITORY_NAME/mariadb] MariaDB image repository
-  ## @skip mariadb.image.tag MariaDB image tag (immutable tags are recommended)
-  ## @param mariadb.image.digest MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/mariadb
-    tag: 10.11.11-debian-12-r11
-    digest: ""
   ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
   ##
   architecture: standalone


### PR DESCRIPTION
### Description of the change

Updates the `bitnami/spring-cloud-dataflow` to use the MariaDB version defined by the bitnami/mariadb subchart, currently 11.4.x, instead of overriding it with version 10.11.x.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- related #18053

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
