### PR TITLE
Fix syntax (parameter order) for flaskServerSecretKey in template

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.2 (2025-04-24)
+## 3.0.3 (2025-04-29)
 
-* [bitnami/mlflow] Release 3.0.2 ([#33164](https://github.com/bitnami/charts/pull/33164))
+* Fix syntax (parameter order) for flaskServerSecretKey in template ([#33248](https://github.com/bitnami/charts/pull/33248))
+
+## <small>3.0.2 (2025-04-24)</small>
+
+* [bitnami/mlflow] Release 3.0.2 (#33164) ([c4882c1](https://github.com/bitnami/charts/commit/c4882c117384e928e47c50113acc3c52511153c0)), closes [#33164](https://github.com/bitnami/charts/issues/33164)
 
 ## <small>3.0.1 (2025-04-09)</small>
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 3.0.2
+version: 3.0.3

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Return the MLflow Tracking Secret key for the user
 Return the MLflow Tracking Secret key for the Flask Server secret key
 */}}
 {{- define "mlflow.v0.tracking.flaskServerSecretKey" -}}
-{{- default .Values.tracking.auth.existingSecretFlaskServerSecretKey "flask-server-secret-key" -}}
+{{- default "flask-server-secret-key" .Values.tracking.auth.existingSecretFlaskServerSecretKey -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Fix syntax (parameter order) for flaskServerSecretKey in template


### Description of the change

Fix in template for the `flaskServerSecretKey` definition, that makes it first look for a configured value before falling back to the default (hard-coded) value.

### Benefits

The template definition for `flaskServerSecretKey` works as expected, and doesn't always take the default value.

### Possible drawbacks

None (what I can see).

### Applicable issues

- Fixes #33234

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
