### PR TITLE
[bitnami/redis-cluster] Switch shell from /bin/sh to /bin/bash to improve process handling

### DIFF
--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.5.3 (2025-04-24)
+## 11.5.4 (2025-04-29)
 
-* [bitnami/redis-cluster] Release 11.5.3 ([#33156](https://github.com/bitnami/charts/pull/33156))
+* [bitnami/redis-cluster] Switch shell from /bin/sh to /bin/bash to improve process handling ([#33250](https://github.com/bitnami/charts/pull/33250))
+
+## <small>11.5.3 (2025-04-24)</small>
+
+* [bitnami/redis-cluster] Release 11.5.3 (#33156) ([44c8d3c](https://github.com/bitnami/charts/commit/44c8d3c58a252e4a292fbf5f22febe1f8897c648)), closes [#33156](https://github.com/bitnami/charts/issues/33156)
 
 ## <small>11.5.2 (2025-04-21)</small>
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 11.5.3
+version: 11.5.4

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -236,8 +236,8 @@ spec:
             failureThreshold: {{ .Values.redis.livenessProbe.failureThreshold }}
             exec:
               command:
-                - sh
-                - -c
+                - /bin/bash
+                - -ec
                 - /scripts/ping_liveness_local.sh {{ .Values.redis.livenessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.redis.customReadinessProbe }}
@@ -252,8 +252,8 @@ spec:
             failureThreshold: {{ .Values.redis.readinessProbe.failureThreshold }}
             exec:
               command:
-                - sh
-                - -c
+                - /bin/bash
+                - -ec
                 - /scripts/ping_readiness_local.sh {{ .Values.redis.readinessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.redis.customStartupProbe }}

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 data:
   ping_readiness_local.sh: |-
-    #!/bin/sh
+    #!/bin/bash
     set -e
 
     REDIS_STATUS_FILE=/tmp/.redis_cluster_check
@@ -75,7 +75,7 @@ data:
     fi
 {{- end }}
   ping_liveness_local.sh: |-
-    #!/bin/sh
+    #!/bin/bash
     set -e
 
     {{- if .Values.usePassword }}


### PR DESCRIPTION
### Description of the change

This change replaces the default shell from /bin/sh to /bin/bash in scripts executed by the container.

### Benefits

Using /bin/bash allows for more reliable process management and advanced signal handling. This change is aimed at mitigating issues related to defunct (zombie) processes observed in certain server environments.

### Applicable issues

fixes:
    - https://github.com/bitnami/charts/issues/9654
    - https://github.com/bitnami/charts/issues/8475
    - https://github.com/bitnami/charts/issues/5328
    - https://github.com/bitnami/charts/issues/2441


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
