### PR TITLE
[bitnami/mastodon] major: Upgrade elasticsearch subchart to 22.x.x (ES 9.x)

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 10.1.1 (2025-04-09)
+## 11.0.0 (2025-04-30)
 
-* [bitnami/mastodon] Release 10.1.1 ([#32909](https://github.com/bitnami/charts/pull/32909))
+* [bitnami/mastodon] major: Upgrade elasticsearch subchart to 22.x.x (ES 9.x) ([#33264](https://github.com/bitnami/charts/pull/33264))
+
+## <small>10.1.1 (2025-04-09)</small>
+
+* [bitnami/mastodon] Release 10.1.1 (#32909) ([42032e2](https://github.com/bitnami/charts/commit/42032e24c96811e5809ba6991bd1b59d43c075fb)), closes [#32909](https://github.com/bitnami/charts/issues/32909)
 
 ## 10.1.0 (2025-04-04)
 

--- a/bitnami/mastodon/Chart.lock
+++ b/bitnami/mastodon/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.11.5
+  version: 20.13.4
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.2
+  version: 16.6.6
 - name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.5.0
+  version: 22.0.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.4
+  version: 16.0.8
 - name: apache
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.3.5
+  version: 11.3.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:f37e75e9b4af80d823a52a8a9127902606e24b5b83531061dbd239c65d76c1db
-generated: "2025-04-09T11:43:37.884940353Z"
+  version: 2.30.1
+digest: sha256:43efaa6d221b032d3ef779e3391340356a5bd3204ca76de8e04ee74987a7a0a1
+generated: "2025-04-30T13:12:16.396108+02:00"

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
 - condition: elasticsearch.enabled
   name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
+  version: 22.x.x
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -50,4 +50,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 10.1.1
+version: 11.0.0

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -889,7 +889,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 11.0.0
 
-This major updates the `elasticsearch` subchart to its newest major, 22.0.0. For more information on this subchart's major, please refer to [elasticsearch upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch#to-2200).
+This major updates the `elasticsearch` subchart to its newest major, 22.0.0, which uses Elasticsearch 9.x. For more information on this subchart's major, please refer to [elasticsearch upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch#to-2200).
 
 ### To 10.0.0
 

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -887,6 +887,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 11.0.0
+
+This major updates the `elasticsearch` subchart to its newest major, 22.0.0. For more information on this subchart's major, please refer to [elasticsearch upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch#to-2200).
+
 ### To 10.0.0
 
 This major updates the `minio` subchart to its newest major, 16.0.0. For more information on this subchart's major, please refer to [minio upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/minio#to-1600).


### PR DESCRIPTION
### Description of the change

Upgrade the elasticsearch subchart to its latest version 22.x.x.

This new version upgrades Elasticsearch from version 8.x to 9.x

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
