### PR TITLE
[bitnami/solr] Add persistentvolumeclaim retention on solr statefulset

### DIFF
--- a/bitnami/jenkins/CHANGELOG.md
+++ b/bitnami/jenkins/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 13.6.3 (2025-04-09)
+## 13.6.4 (2025-04-30)
 
-* [bitnami/jenkins] Release 13.6.3 ([#32938](https://github.com/bitnami/charts/pull/32938))
+* [bitnami/jenkins] Release 13.6.4 ([#33268](https://github.com/bitnami/charts/pull/33268))
+
+## <small>13.6.3 (2025-04-09)</small>
+
+* [bitnami/jenkins] Release 13.6.3 (#32938) ([1969e59](https://github.com/bitnami/charts/commit/1969e598ddb228691f4933350ece5212fca0a3cc)), closes [#32938](https://github.com/bitnami/charts/issues/32938)
 
 ## <small>13.6.2 (2025-04-09)</small>
 

--- a/bitnami/jenkins/Chart.lock
+++ b/bitnami/jenkins/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T19:38:15.036645696Z"
+  version: 2.30.1
+digest: sha256:02441ebe442cc4ffe4ed44998734a60d6745bb0f5ea0423663ed3c18a099255f
+generated: "2025-04-30T14:51:18.648808293Z"

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -7,13 +7,13 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: jenkins
-      image: docker.io/bitnami/jenkins:2.492.3-debian-12-r3
+      image: docker.io/bitnami/jenkins:2.504.1-debian-12-r0
     - name: jenkins-agent
-      image: docker.io/bitnami/jenkins-agent:0.3301.0-debian-12-r2
+      image: docker.io/bitnami/jenkins-agent:0.3307.0-debian-12-r1
     - name: os-shell
-      image: docker.io/bitnami/os-shell:12-debian-12-r42
+      image: docker.io/bitnami/os-shell:12-debian-12-r43
 apiVersion: v2
-appVersion: 2.492.3
+appVersion: 2.504.1
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -36,4 +36,4 @@ maintainers:
 name: jenkins
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jenkins
-version: 13.6.3
+version: 13.6.4

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -92,7 +92,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/jenkins
-  tag: 2.492.3-debian-12-r3
+  tag: 2.504.1-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -388,7 +388,7 @@ agent:
   image:
     registry: docker.io
     repository: bitnami/jenkins-agent
-    tag: 0.3301.0-debian-12-r2
+    tag: 0.3307.0-debian-12-r1
     digest: ""
     ## Specify a imagePullPolicy
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -1043,7 +1043,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 12-debian-12-r42
+    tag: 12-debian-12-r43
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.5.3 (2025-04-28)
+## 16.5.4 (2025-04-30)
 
-* [bitnami/mongodb] Release 16.5.3 ([#33211](https://github.com/bitnami/charts/pull/33211))
+* [bitnami/mongodb] Remove extra volumeClaimTemplates fields ([#33236](https://github.com/bitnami/charts/pull/33236))
+
+## <small>16.5.3 (2025-04-28)</small>
+
+* [bitnami/mongodb] Release 16.5.3 (#33211) ([8ec0951](https://github.com/bitnami/charts/commit/8ec095186aa934f76bd311a7d734a5eb77f98b58)), closes [#33211](https://github.com/bitnami/charts/issues/33211)
 
 ## <small>16.5.2 (2025-04-25)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.5.3
+version: 16.5.4

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -579,9 +579,7 @@ spec:
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
+    - metadata:
         name: datadir
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.6.1 (2025-04-09)
+## 9.6.2 (2025-04-30)
 
-* [bitnami/solr] Release 9.6.1 ([#32893](https://github.com/bitnami/charts/pull/32893))
+* [bitnami/solr] Add persistentvolumeclaim retention on solr statefulset ([#33272](https://github.com/bitnami/charts/pull/33272))
+
+## <small>9.6.1 (2025-04-09)</small>
+
+* [bitnami/solr] Release 9.6.1 (#32893) ([0326481](https://github.com/bitnami/charts/commit/0326481eb281ec144bc172c14ed160bdd6239a25)), closes [#32893](https://github.com/bitnami/charts/issues/32893)
 
 ## 9.6.0 (2025-04-04)
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.6.1
+version: 9.6.2

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -360,18 +360,21 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ### Persistence parameters
 
-| Name                        | Description                                                       | Value               |
-| --------------------------- | ----------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`       | Use a PVC to persist data.                                        | `true`              |
-| `persistence.existingClaim` | A manually managed Persistent Volume and Claim                    | `""`                |
-| `persistence.storageClass`  | Storage class of backing PVC                                      | `""`                |
-| `persistence.accessModes`   | Persistent Volume Access Modes                                    | `["ReadWriteOnce"]` |
-| `persistence.size`          | Size of data volume                                               | `8Gi`               |
-| `persistence.annotations`   | Persistence annotations for Solr                                  | `{}`                |
-| `persistence.mountPath`     | Persistence mount path for Solr                                   | `/bitnami/solr`     |
-| `persistence.subPath`       | Path within the volume from which the container's                 | `""`                |
-| `persistence.subPathExpr`   | Expanded path within the volume from which                        | `""`                |
-| `persistence.selector`      | Selector to match an existing Persistent Volume for Solr data PVC | `{}`                |
+| Name                                               | Description                                                                    | Value               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------- |
+| `persistence.enabled`                              | Use a PVC to persist data.                                                     | `true`              |
+| `persistence.existingClaim`                        | A manually managed Persistent Volume and Claim                                 | `""`                |
+| `persistence.storageClass`                         | Storage class of backing PVC                                                   | `""`                |
+| `persistence.accessModes`                          | Persistent Volume Access Modes                                                 | `["ReadWriteOnce"]` |
+| `persistence.size`                                 | Size of data volume                                                            | `8Gi`               |
+| `persistence.annotations`                          | Persistence annotations for Solr                                               | `{}`                |
+| `persistence.mountPath`                            | Persistence mount path for Solr                                                | `/bitnami/solr`     |
+| `persistence.subPath`                              | Path within the volume from which the container's                              | `""`                |
+| `persistence.subPathExpr`                          | Expanded path within the volume from which                                     | `""`                |
+| `persistence.selector`                             | Selector to match an existing Persistent Volume for Solr data PVC              | `{}`                |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for Solr Statefulset                 | `false`             |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `Retain`            |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `Retain`            |
 
 ### Volume Permissions parameters
 

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -431,6 +431,11 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -687,6 +687,19 @@ persistence:
   ##     app: my-app
   ##
   selector: {}
+## Persistent Volume Claim Retention Policy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+##
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for Solr Statefulset
+  ##
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  ##
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  ##
+  whenDeleted: Retain
 ## @section Volume Permissions parameters
 ##
 


### PR DESCRIPTION
### Description of the change

Add the persistentvolumeclaim retention on solr statefulset. The other bitnami charters have this configuration.

### Benefits

This chode change permit to delete or not pvc when the sts is scale or deleted.

### Additional information

The others bitnami charts have this configuration.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
