### PR TITLE
[bitnami/solr] Add persistentvolumeclaim retention on solr statefulset

### DIFF
--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.6.2 (2025-05-02)
+## 9.6.2 (2025-05-05)
 
 * [bitnami/solr] Add persistentvolumeclaim retention on solr statefulset ([#33310](https://github.com/bitnami/charts/pull/33310))
 

--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.6.1 (2025-04-09)
+## 9.6.2 (2025-05-02)
 
-* [bitnami/solr] Release 9.6.1 ([#32893](https://github.com/bitnami/charts/pull/32893))
+* [bitnami/solr] Add persistentvolumeclaim retention on solr statefulset ([#33310](https://github.com/bitnami/charts/pull/33310))
+
+## <small>9.6.1 (2025-04-09)</small>
+
+* [bitnami/solr] Release 9.6.1 (#32893) ([0326481](https://github.com/bitnami/charts/commit/0326481eb281ec144bc172c14ed160bdd6239a25)), closes [#32893](https://github.com/bitnami/charts/issues/32893)
 
 ## 9.6.0 (2025-04-04)
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.6.1
+version: 9.6.2

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -373,6 +373,14 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `persistence.subPathExpr`   | Expanded path within the volume from which                        | `""`                |
 | `persistence.selector`      | Selector to match an existing Persistent Volume for Solr data PVC | `{}`                |
 
+### Persistent Volume Claim Retention Policy
+
+| Name                                               | Description                                                                    | Value    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | -------- |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for Solr Statefulset                 | `false`  |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `Retain` |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `Retain` |
+
 ### Volume Permissions parameters
 
 | Name                                                        | Description                                                                                                                                                                                                                                           | Value                      |

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -431,6 +431,11 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -687,6 +687,20 @@ persistence:
   ##     app: my-app
   ##
   selector: {}
+  
+## @section Persistent Volume Claim Retention Policy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+##
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for Solr Statefulset
+  ##
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  ##
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  ##
+  whenDeleted: Retain
 ## @section Volume Permissions parameters
 ##
 


### PR DESCRIPTION
### Description of the change

Add the persistentvolumeclaim retention on solr statefulset. The other bitnami charters have this configuration.

### Benefits

This chode change permit to delete or not pvc when the sts is scale or deleted.

### Additional information

The others bitnami charts have this configuration.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
