### PR TITLE
[bitnami/airflow] Fix svc name for Ingress backend

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 23.0.2 (2025-05-01)
+## 23.0.3 (2025-05-05)
 
-* [bitnami/airflow] Minor performance improvements ([#33276](https://github.com/bitnami/charts/pull/33276))
+* [bitnami/airflow] Fix svc name for Ingress backend ([#33316](https://github.com/bitnami/charts/pull/33316))
+
+## <small>23.0.2 (2025-05-01)</small>
+
+* [bitnami/airflow] Minor performance improvements (#33276) ([be6729e](https://github.com/bitnami/charts/commit/be6729e5675d0bd77ab21211dad18b6ab6b7efea)), closes [#33276](https://github.com/bitnami/charts/issues/33276)
 
 ## <small>23.0.1 (2025-04-29)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 23.0.2
+version: 23.0.3

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -6,7 +6,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 {{- $releaseNamespace := include "common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
-{{- $fullname := include "common.names.fullname" . }}
+{{- $airflowWebServiceName := include "airflow.web.fullname" . }}
 {{- $airflowSecretName := include "airflow.secretName" . }}
 {{- $baseUrl := (include "airflow.baseUrl" .) }}
 
@@ -46,14 +46,14 @@ host. To configure Airflow with the URL of your service:
   {{- if eq "NodePort" .Values.service.type }}
 
     export AIRFLOW_HOST=$(kubectl get nodes --namespace {{ $releaseNamespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export AIRFLOW_PORT=$(kubectl get --namespace {{ $releaseNamespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $fullname }})
+    export AIRFLOW_PORT=$(kubectl get --namespace {{ $releaseNamespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ $airflowWebServiceName }})
 
   {{- else if eq "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ $releaseNamespace }} -w {{ $fullname }}'
+        Watch the status with: 'kubectl get svc --namespace {{ $releaseNamespace }} -w {{ $airflowWebServiceName }}'
 
-    export AIRFLOW_HOST=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    export AIRFLOW_HOST=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $airflowWebServiceName }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
     export AIRFLOW_PORT=80
 
   {{- end }}
@@ -74,7 +74,7 @@ host. To configure Airflow with the URL of your service:
 
 Airflow can be accessed via port {{ .Values.service.ports.http }} on the following DNS name from within your cluster:
 
-    {{ printf "%s.%s.svc.%s" $fullname $releaseNamespace $clusterDomain }}
+    {{ printf "%s.%s.svc.%s" $airflowWebServiceName $releaseNamespace $clusterDomain }}
 
 To connect to Airflow from outside the cluster, perform the following steps:
 
@@ -90,7 +90,7 @@ To connect to Airflow from outside the cluster, perform the following steps:
 
 1.  Create a port-forward to the service:
 
-    kubectl port-forward --namespace {{ $releaseNamespace }} svc/{{ $fullname }} {{ .Values.service.ports.http }}:{{ .Values.service.ports.http }} &
+    kubectl port-forward --namespace {{ $releaseNamespace }} svc/{{ $airflowWebServiceName }} {{ .Values.service.ports.http }}:{{ .Values.service.ports.http }} &
     echo "Airflow URL: http{{ if .Values.web.tls }}s{{ end }}://127.0.0.1:{{ .Values.service.ports.http }}"
 
 {{- else if eq .Values.service.type "NodePort" }}
@@ -98,7 +98,7 @@ To connect to Airflow from outside the cluster, perform the following steps:
 1. Obtain the NodePort IP and port:
 
     export NODE_IP=$(kubectl get nodes --namespace {{ $releaseNamespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname }} -o jsonpath="{.spec.ports[0].nodePort}")
+    export NODE_PORT=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $airflowWebServiceName }} -o jsonpath="{.spec.ports[0].nodePort}")
     echo "Airflow URL: http{{ if .Values.web.tls }}s{{ end }}://${NODE_IP}:$NODE_PORT"
 
 {{- else if eq .Values.service.type "LoadBalancer" }}
@@ -106,9 +106,9 @@ To connect to Airflow from outside the cluster, perform the following steps:
 1. Obtain the LoadBalancer IP:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ $fullname }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ $airflowWebServiceName }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ $fullname }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ $airflowWebServiceName }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
     echo "Airflow URL: http{{ if .Values.web.tls }}s{{ end }}://${SERVICE_IP}:{{ .Values.service.ports.http }}"
 
 {{- end }}

--- a/bitnami/airflow/templates/web/ingress.yaml
+++ b/bitnami/airflow/templates/web/ingress.yaml
@@ -30,7 +30,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "airflow.web.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
@@ -40,7 +40,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "airflow.web.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

Fix `airflow-web` service references in Ingress resource. This error is related to the `23.0.0` major release. 

### Applicable issues

- fixes #33302

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
