### PR TITLE
[bitnami/common] chore: :recycle: Remove deprecated APIs (<1.23.0)

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.30.2 (2025-04-30)
+## 2.31.0 (2025-05-05)
 
-* [bitnami/common] add namespaces to extraPodAffinityTerms for affinities ([#33173](https://github.com/bitnami/charts/pull/33173))
+* [bitnami/common] chore: :recycle: Remove deprecated APIs (<1.23.0) ([#33320](https://github.com/bitnami/charts/pull/33320))
+
+## <small>2.30.2 (2025-04-30)</small>
+
+* [bitnami/common] add namespaces to extraPodAffinityTerms for affinities (#33173) ([4e35d60](https://github.com/bitnami/charts/commit/4e35d6016945db7b9fd4eef72b177d4826d69ece)), closes [#33173](https://github.com/bitnami/charts/issues/33173)
 
 ## <small>2.30.1 (2025-04-30)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.30.2
+appVersion: 2.31.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.30.2
+version: 2.31.0

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -30,136 +30,77 @@ Usage:
 Return the appropriate apiVersion for poddisruptionbudget.
 */}}
 {{- define "common.capabilities.policy.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
 {{- print "policy/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "common.capabilities.networkPolicy.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.7-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "networking.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for job.
 */}}
 {{- define "common.capabilities.job.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "batch/v1beta1" -}}
-{{- else -}}
 {{- print "batch/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for cronjob.
 */}}
 {{- define "common.capabilities.cronjob.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "batch/v1beta1" -}}
-{{- else -}}
 {{- print "batch/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for daemonset.
 */}}
 {{- define "common.capabilities.daemonset.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "apps/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if (.Values.ingress).apiVersion -}}
-{{- .Values.ingress.apiVersion -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "networking.k8s.io/v1" -}}
-{{- end }}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for RBAC resources.
 */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.17-0" $kubeVersion) -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "rbac.authorization.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for CRDs.
 */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
-{{- print "apiextensions.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "apiextensions.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for APIService.
 */}}
 {{- define "common.capabilities.apiService.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.10-0" $kubeVersion) -}}
-{{- print "apiregistration.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "apiregistration.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -167,15 +108,7 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 */}}
 {{- define "common.capabilities.hpa.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- if .beta2 -}}
-{{- print "autoscaling/v2beta2" -}}
-{{- else -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- end -}}
-{{- else -}}
 {{- print "autoscaling/v2" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -183,9 +116,7 @@ Return the appropriate apiVersion for Vertical Pod Autoscaler.
 */}}
 {{- define "common.capabilities.vpa.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.11-0" $kubeVersion) -}}
-{{- print "autoscaling/v1beta1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "autoscaling/v1beta2" -}}
 {{- else -}}
 {{- print "autoscaling/v1" -}}
@@ -207,9 +138,7 @@ Returns true if AdmissionConfiguration is supported
 */}}
 {{- define "common.capabilities.admissionConfiguration.supported" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if or (empty $kubeVersion) (not (semverCompare "<1.23-0" $kubeVersion)) -}}
   {{- true -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -217,9 +146,7 @@ Return the appropriate apiVersion for AdmissionConfiguration.
 */}}
 {{- define "common.capabilities.admissionConfiguration.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- print "apiserver.config.k8s.io/v1alpha1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "apiserver.config.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "apiserver.config.k8s.io/v1" -}}
@@ -231,9 +158,7 @@ Return the appropriate apiVersion for PodSecurityConfiguration.
 */}}
 {{- define "common.capabilities.podSecurityConfiguration.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- print "pod-security.admission.config.k8s.io/v1alpha1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "pod-security.admission.config.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "pod-security.admission.config.k8s.io/v1" -}}

--- a/bitnami/common/templates/_ingress.tpl
+++ b/bitnami/common/templates/_ingress.tpl
@@ -17,11 +17,6 @@ Params:
   - context - Dict - Required. The context for the template evaluation.
 */}}
 {{- define "common.ingress.backend" -}}
-{{- $apiVersion := (include "common.capabilities.ingress.apiVersion" .context) -}}
-{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
-serviceName: {{ .serviceName }}
-servicePort: {{ .servicePort }}
-{{- else -}}
 service:
   name: {{ .serviceName }}
   port:
@@ -31,32 +26,25 @@ service:
     number: {{ .servicePort | int }}
     {{- end }}
 {{- end -}}
-{{- end -}}
 
 {{/*
+TODO: Remove as soon it is removed from the rest of the charts
 Print "true" if the API pathType field is supported
 Usage:
 {{ include "common.ingress.supportsPathType" . }}
 */}}
 {{- define "common.ingress.supportsPathType" -}}
-{{- if (semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- print "false" -}}
-{{- else -}}
 {{- print "true" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
+TODO: Remove as soon it is removed from the rest of the charts
 Returns true if the ingressClassname field is supported
 Usage:
 {{ include "common.ingress.supportsIngressClassname" . }}
 */}}
 {{- define "common.ingress.supportsIngressClassname" -}}
-{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "false" -}}
-{{- else -}}
 {{- print "true" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

This PR removes the APIs we deprecated a year a half ago when forcing the Kubernetes version to 1.23

### Benefits

More readable code
### Possible drawbacks

Potentially breaking the installations of those that were not complying with the pre-requisites
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
