### PR TITLE
[bitnami/chainloop] chore!: :recycle: :boom: :arrow_up: Bump k8s requirements to 1.23

### DIFF
--- a/bitnami/chainloop/CHANGELOG.md
+++ b/bitnami/chainloop/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.24 (2025-04-24)
+## 3.0.0 (2025-05-05)
 
-* [bitnami/chainloop] Release 2.2.24 ([#33154](https://github.com/bitnami/charts/pull/33154))
+* [bitnami/chainloop] chore!: :recycle: :boom: :arrow_up: Bump k8s requirements to 1.23 ([#33322](https://github.com/bitnami/charts/pull/33322))
+
+## <small>2.2.24 (2025-04-24)</small>
+
+* [bitnami/chainloop] Release 2.2.24 (#33154) ([b0dcaf6](https://github.com/bitnami/charts/commit/b0dcaf6f4452fd21550adfe50805e6748e3fa07d)), closes [#33154](https://github.com/bitnami/charts/issues/33154)
 
 ## <small>2.2.23 (2025-04-01)</small>
 

--- a/bitnami/chainloop/Chart.lock
+++ b/bitnami/chainloop/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
+  version: 2.31.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.4
+  version: 16.6.6
 - name: vault
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 1.7.5
-digest: sha256:dedd5038531540959ea261afa754565da9714bb621f9115734d912d504c1d1cf
-generated: "2025-04-24T07:05:41.969623631Z"
+  version: 1.7.6
+digest: sha256:4060518eadc535b64bbe157b97bdb791f6e01a1101a97a163915fe5d3e92151d
+generated: "2025-05-05T12:32:54.997080186+02:00"

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -64,4 +64,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
 - https://github.com/chainloop-dev/chainloop
-version: 2.2.24
+version: 3.0.0

--- a/bitnami/chainloop/README.md
+++ b/bitnami/chainloop/README.md
@@ -22,7 +22,7 @@ This chart bootstraps a [Chainloop](https://github.com/chainloop-dev/chainloop) 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
+- Kubernetes 1.23+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure (If built-in PostgreSQL is enabled)
 
@@ -1027,6 +1027,10 @@ service_registration "kubernetes" {}` |
 | `dex.pdb.maxUnavailable`                                | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `dex.pdb.minAvailable` and `dex.pdb.maxUnavailable` are empty.                                                                    | `""`                                                                                     |
 
 ## Upgrading
+
+### To 3.0.0
+
+This version increases minimum Kubernetes version to 1.23. Follow the [official docs](https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/) to upgrade your Kubernetes cluster. If the Kubernetes version is already >=1.23 no major issues are expected during the upgrade operation.
 
 ### To 2.1.0
 

--- a/bitnami/chainloop/templates/cas/hpa.yaml
+++ b/bitnami/chainloop/templates/cas/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.cas.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.cas.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.cas.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.cas.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.cas.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/chainloop/templates/controlplane/hpa.yaml
+++ b/bitnami/chainloop/templates/controlplane/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.controlplane.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
BREAKING CHANGE

### Description of the change

This PR bumps the required k8s version to 1.23 and removes unnecessary YAML

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
