### PR TITLE
[bitnami/apisix] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.2.3 (2025-05-01)
+## 4.2.4 (2025-05-06)
 
-* [bitnami/apisix] Release 4.2.3 ([#33277](https://github.com/bitnami/charts/pull/33277))
+* [bitnami/apisix] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33335](https://github.com/bitnami/charts/pull/33335))
+
+## <small>4.2.3 (2025-05-01)</small>
+
+* [bitnami/apisix] Release 4.2.3 (#33277) ([89b5e15](https://github.com/bitnami/charts/commit/89b5e15a29e6dbdcb8582e951ac9b647fbf96f27)), closes [#33277](https://github.com/bitnami/charts/issues/33277)
 
 ## <small>4.2.2 (2025-04-01)</small>
 

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.3.0
+  version: 11.3.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:807ee24cb1dba72058f000e12e7d90edeb75682b9df74acd589ad80f4c367b8a
-generated: "2025-05-01T09:12:47.894270481Z"
+  version: 2.31.0
+digest: sha256:8d8beef787f2298795fa51532d23c9b5008463801dbeb1921fa93b2284701459
+generated: "2025-05-06T09:50:47.923015451+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -46,4 +46,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 4.2.3
+version: 4.2.4

--- a/bitnami/apisix/templates/control-plane/hpa.yaml
+++ b/bitnami/apisix/templates/control-plane/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.controlPlane.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlPlane.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.controlPlane.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.controlPlane.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlPlane.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/apisix/templates/control-plane/ingress.yaml
+++ b/bitnami/apisix/templates/control-plane/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.controlPlane.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.controlPlane.ingress.ingressClassName }}
   ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -30,9 +30,7 @@ spec:
           {{- toYaml .Values.controlPlane.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.controlPlane.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.controlPlane.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.control-plane.fullname" . | trunc 63 | trimSuffix "-") "servicePort" $servicePort "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.controlPlane.ingress.extraHosts }}
@@ -40,9 +38,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.control-plane.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" $servicePort "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.controlPlane.ingress.extraRules }}

--- a/bitnami/apisix/templates/dashboard/hpa.yaml
+++ b/bitnami/apisix/templates/dashboard/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.dashboard.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.dashboard.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.dashboard.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.dashboard.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.dashboard.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/apisix/templates/dashboard/ingress.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.dashboard.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.dashboard.ingress.ingressClassName }}
   ingressClassName: {{ .Values.dashboard.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.dashboard.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.dashboard.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.dashboard.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.dashboard.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.dashboard.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.dashboard.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.dashboard.ingress.extraRules }}

--- a/bitnami/apisix/templates/data-plane/hpa.yaml
+++ b/bitnami/apisix/templates/data-plane/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.dataPlane.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.dataPlane.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.dataPlane.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.dataPlane.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.dataPlane.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/apisix/templates/data-plane/ingress.yaml
+++ b/bitnami/apisix/templates/data-plane/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.dataPlane.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.dataPlane.ingress.ingressClassName }}
   ingressClassName: {{ .Values.dataPlane.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.dataPlane.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.dataPlane.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.dataPlane.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.data-plane.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.dataPlane.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.data-plane.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.dataPlane.ingress.extraRules }}

--- a/bitnami/apisix/templates/ingress-controller/hpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ingressController.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ingressController.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.ingressController.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ingressController.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ingressController.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/apisix/templates/ingress-controller/ingress.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingressController.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingressController.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingressController.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.ingressController.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingressController.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingressController.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.ingress-controller.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingressController.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "apisix.ingress-controller.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingressController.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
