### PR TITLE
[bitnami/argo-cd] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.3.6 (2025-04-22)
+## 7.3.7 (2025-05-06)
 
-* [bitnami/argo-cd] Release 7.3.6 ([#33128](https://github.com/bitnami/charts/pull/33128))
+* [bitnami/argo-cd] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33337](https://github.com/bitnami/charts/pull/33337))
+
+## <small>7.3.6 (2025-04-22)</small>
+
+* [bitnami/argo-cd] Release 7.3.6 (#33128) ([5468fc3](https://github.com/bitnami/charts/commit/5468fc3144ea9ccc2733c21b030cf5c0c11474ef)), closes [#33128](https://github.com/bitnami/charts/issues/33128)
 
 ## <small>7.3.5 (2025-04-09)</small>
 

--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.0
+  version: 20.13.4
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:bc64425106f9a9228486b0ffd5fecdb140f2377a8bf253d4ce8dd4cd63f27609
-generated: "2025-04-22T17:17:27.672387804Z"
+  version: 2.31.0
+digest: sha256:f66e36628e6e3cd92e6f5ecd95854e5e3f8679a19f6e6176a912baa5ef5d2981
+generated: "2025-05-06T09:52:22.799690884+02:00"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.3.6
+version: 7.3.7

--- a/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
+++ b/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.applicationSet.webhook.ingress.ingressClassName (eq "true" (include "common.webhook.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.applicationSet.webhook.ingress.ingressClassName }}
   ingressClassName: {{ .Values.applicationSet.webhook.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -35,9 +35,7 @@ spec:
           {{- toYaml .Values.applicationSet.webhook.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.applicationSet.webhook.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.applicationSet.webhook.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" .) "servicePort" (ternary "https" "http" .Values.applicationSet.webhook.ingress.tls) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.applicationSet.webhook.ingress.extraHosts }}
@@ -45,9 +43,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" $) "servicePort" (ternary "https" "http" $.Values.applicationSet.webhook.ingress.tls) "context" $) | nindent 14 }}
     {{- end }}
   tls:

--- a/bitnami/argo-cd/templates/repo-server/hpa.yaml
+++ b/bitnami/argo-cd/templates/repo-server/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.repoServer.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.repoServer.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.repoServer.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.repoServer.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.repoServer.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/argo-cd/templates/server/hpa.yaml
+++ b/bitnami/argo-cd/templates/server/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.server.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/argo-cd/templates/server/ingress-grcp.yaml
+++ b/bitnami/argo-cd/templates/server/ingress-grcp.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.server.ingressGrpc.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.server.ingressGrpc.ingressClassName }}
   ingressClassName: {{ .Values.server.ingressGrpc.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -34,9 +34,7 @@ spec:
           {{- toYaml .Values.server.ingressGrpc.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.server.ingressGrpc.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.server.ingressGrpc.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" .) "servicePort" (ternary "https" "http" .Values.server.ingressGrpc.tls) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.server.ingressGrpc.extraHosts }}
@@ -44,9 +42,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" $) "servicePort" (ternary "https" "http" $.Values.server.ingressGrpc.tls) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.server.ingressGrpc.extraRules }}

--- a/bitnami/argo-cd/templates/server/ingress.yaml
+++ b/bitnami/argo-cd/templates/server/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.server.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -34,9 +34,7 @@ spec:
           {{- toYaml .Values.server.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.server.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.server.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" .) "servicePort" (ternary "https" "http" .Values.server.ingress.tls) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.server.ingress.extraHosts }}
@@ -44,9 +42,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argocd.server" $) "servicePort" (ternary "https" "http" $.Values.server.ingress.tls) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.server.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
