### PR TITLE
[bitnami/argo-workflows] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/argo-workflows/CHANGELOG.md
+++ b/bitnami/argo-workflows/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.13 (2025-04-29)
+## 11.1.14 (2025-05-06)
 
-* [bitnami/argo-workflows] Release 11.1.13 ([#33251](https://github.com/bitnami/charts/pull/33251))
+* [bitnami/argo-workflows] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33338](https://github.com/bitnami/charts/pull/33338))
+
+## <small>11.1.13 (2025-04-29)</small>
+
+* [bitnami/argo-workflows] Release 11.1.13 (#33251) ([3486155](https://github.com/bitnami/charts/commit/348615503d4c72ad09bc8a1e0ba20db2df83823d)), closes [#33251](https://github.com/bitnami/charts/issues/33251)
 
 ## <small>11.1.12 (2025-04-28)</small>
 

--- a/bitnami/argo-workflows/Chart.lock
+++ b/bitnami/argo-workflows/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 12.3.4
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:57f7f9419a71c54889d612636674fa8f28e0af45def0f2d17fcba4612be57415
-generated: "2025-04-28T19:14:48.943339284Z"
+  version: 2.31.0
+digest: sha256:0571a4824e7eeb549019e676eea81956477f39e8513984de40956ff7dc6b193b
+generated: "2025-05-06T09:53:07.790965002+02:00"

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 11.1.13
+version: 11.1.14

--- a/bitnami/argo-workflows/templates/server/ingress.yaml
+++ b/bitnami/argo-workflows/templates/server/ingress.yaml
@@ -26,7 +26,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -38,9 +38,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argo-workflows.server.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -48,9 +46,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "argo-workflows.server.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
