### PR TITLE
[bitnami/aspnet-core] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/aspnet-core/CHANGELOG.md
+++ b/bitnami/aspnet-core/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.1 (2025-04-30)
+## 7.0.2 (2025-05-06)
 
-* [bitnami/aspnet-core] Release 7.0.1 ([#33274](https://github.com/bitnami/charts/pull/33274))
+* [bitnami/aspnet-core] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33339](https://github.com/bitnami/charts/pull/33339))
+
+## <small>7.0.1 (2025-04-30)</small>
+
+* [bitnami/aspnet-core] Release 7.0.1 (#33274) ([c5b6ee8](https://github.com/bitnami/charts/commit/c5b6ee87419e3eee26eab38c37bd5bb84df36c98)), closes [#33274](https://github.com/bitnami/charts/issues/33274)
 
 ## 7.0.0 (2025-04-30)
 

--- a/bitnami/aspnet-core/Chart.lock
+++ b/bitnami/aspnet-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-04-30T16:46:03.342010951Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:53:52.124134669+02:00"

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: aspnet-core
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/aspnet-core/templates/health-ingress.yaml
+++ b/bitnami/aspnet-core/templates/health-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.healthIngress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.healthIngress.ingressClassName }}
   ingressClassName: {{ .Values.healthIngress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.healthIngress.extraPaths  "context" $) | nindent 10 }}
           {{- end }}
           - path: {{ .Values.healthIngress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.healthIngress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.healthIngress.extraHosts }}
@@ -44,9 +42,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.healthIngress.extraPaths  "context" $) | nindent 10 }}
           {{- end }}
           - path: {{ .Values.healthIngress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ .Values.healthIngress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.healthIngress.extraRules }}

--- a/bitnami/aspnet-core/templates/hpa.yaml
+++ b/bitnami/aspnet-core/templates/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/aspnet-core/templates/ingress.yaml
+++ b/bitnami/aspnet-core/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
