### PR TITLE
[bitnami/cadvisor] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/cadvisor/CHANGELOG.md
+++ b/bitnami/cadvisor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.2 (2025-04-15)
+## 0.1.3 (2025-05-06)
 
-* [bitnami/cadvisor] Release 0.1.2 ([#33011](https://github.com/bitnami/charts/pull/33011))
+* [bitnami/cadvisor] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33340](https://github.com/bitnami/charts/pull/33340))
+
+## <small>0.1.2 (2025-04-15)</small>
+
+* [bitnami/cadvisor] Release 0.1.2 (#33011) ([ab8bedd](https://github.com/bitnami/charts/commit/ab8bedd06117288192f11747787f287afe212c76)), closes [#33011](https://github.com/bitnami/charts/issues/33011)
 
 ## <small>0.1.1 (2025-04-15)</small>
 

--- a/bitnami/cadvisor/Chart.lock
+++ b/bitnami/cadvisor/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-20T09:19:26.026522991Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:54:35.403333347+02:00"

--- a/bitnami/cadvisor/Chart.yaml
+++ b/bitnami/cadvisor/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: cadvisor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cadvisor
-version: 0.1.2
+version: 0.1.3

--- a/bitnami/cadvisor/templates/ingress.yaml
+++ b/bitnami/cadvisor/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- else if .Values.ingress.path }}
     - http:
@@ -40,9 +38,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -50,9 +46,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
