### PR TITLE
[bitnami/cassandra] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.3.5 (2025-04-22)
+## 12.3.6 (2025-05-06)
 
-* [bitnami/cassandra]fix(readinessProbe): Remove path for metrics readinessProbe ([#33121](https://github.com/bitnami/charts/pull/33121))
+* [bitnami/cassandra] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33341](https://github.com/bitnami/charts/pull/33341))
+
+## <small>12.3.5 (2025-04-23)</small>
+
+* [bitnami/cassandra]fix(readinessProbe): Remove path for metrics readinessProbe (#33121) ([7753e55](https://github.com/bitnami/charts/commit/7753e550cc1fc8941e5ec4bb3d3b4082aa8463f8)), closes [#33121](https://github.com/bitnami/charts/issues/33121)
 
 ## <small>12.3.4 (2025-04-22)</small>
 

--- a/bitnami/cassandra/Chart.lock
+++ b/bitnami/cassandra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-03-05T09:18:46.745709854Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:55:17.85254426+02:00"

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.3.5
+version: 12.3.6


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
