### PR TITLE
[bitnami/cert-manager] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/cert-manager/CHANGELOG.md
+++ b/bitnami/cert-manager/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.14 (2025-04-24)
+## 1.4.15 (2025-05-06)
 
-* [bitnami/cert-manager] Release 1.4.14 ([#33162](https://github.com/bitnami/charts/pull/33162))
+* [bitnami/cert-manager] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33342](https://github.com/bitnami/charts/pull/33342))
+
+## <small>1.4.14 (2025-04-24)</small>
+
+* [bitnami/cert-manager] Release 1.4.14 (#33162) ([d36389f](https://github.com/bitnami/charts/commit/d36389f096574523cacb5c98a5acccf03b23ccc4)), closes [#33162](https://github.com/bitnami/charts/issues/33162)
 
 ## <small>1.4.13 (2025-04-01)</small>
 

--- a/bitnami/cert-manager/Chart.lock
+++ b/bitnami/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T10:20:38.714816471Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:56:01.504366896+02:00"

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 1.4.14
+version: 1.4.15


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
