### PR TITLE
[bitnami/chainloop] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -64,4 +64,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
 - https://github.com/chainloop-dev/chainloop
-version: 3.0.0
+version: 3.0.1

--- a/bitnami/chainloop/templates/cas/hpa.yaml
+++ b/bitnami/chainloop/templates/cas/hpa.yaml
@@ -28,7 +28,6 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.cas.autoscaling.hpa.targetMemory }}
-    {{- end }}
     {{- if .Values.cas.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
@@ -36,5 +35,4 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.cas.autoscaling.hpa.targetCPU }}
-    {{- end }}
 {{- end }}

--- a/bitnami/chainloop/templates/cas/ingress-grpc.yaml
+++ b/bitnami/chainloop/templates/cas/ingress-grpc.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.cas.ingressAPI.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.cas.ingressAPI.ingressClassName }}
   ingressClassName: {{ .Values.cas.ingressAPI.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -33,9 +33,7 @@ spec:
           {{- toYaml .Values.cas.ingressAPI.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.cas.ingressAPI.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.cas.ingressAPI.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "grpc" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.cas.ingressAPI.extraHosts }}
@@ -43,9 +41,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.cas.ingressAPI.extraRules }}

--- a/bitnami/chainloop/templates/cas/ingress.yaml
+++ b/bitnami/chainloop/templates/cas/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.cas.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.cas.ingress.ingressClassName }}
   ingressClassName: {{ .Values.cas.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -33,9 +33,7 @@ spec:
           {{- toYaml .Values.cas.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.cas.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.cas.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.cas.ingress.extraHosts }}
@@ -43,9 +41,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.cas.ingress.extraRules }}

--- a/bitnami/chainloop/templates/controlplane/hpa.yaml
+++ b/bitnami/chainloop/templates/controlplane/hpa.yaml
@@ -28,7 +28,6 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetMemory }}
-    {{- end }}
     {{- if .Values.controlplane.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
@@ -36,5 +35,4 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.controlplane.autoscaling.hpa.targetCPU }}
-    {{- end }}
 {{- end }}

--- a/bitnami/chainloop/templates/controlplane/ingress-grpc.yaml
+++ b/bitnami/chainloop/templates/controlplane/ingress-grpc.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.controlplane.ingressAPI.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.controlplane.ingressAPI.ingressClassName }}
   ingressClassName: {{ .Values.controlplane.ingressAPI.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -33,9 +33,7 @@ spec:
           {{- toYaml .Values.controlplane.ingressAPI.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.controlplane.ingressAPI.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.controlplane.ingressAPI.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "grpc" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.controlplane.ingressAPI.extraHosts }}
@@ -43,9 +41,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.controlplane.ingressAPI.extraRules }}

--- a/bitnami/chainloop/templates/controlplane/ingress.yaml
+++ b/bitnami/chainloop/templates/controlplane/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.controlplane.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.controlplane.ingress.ingressClassName }}
   ingressClassName: {{ .Values.controlplane.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -33,9 +33,7 @@ spec:
           {{- toYaml .Values.controlplane.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.controlplane.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.controlplane.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.controlplane.ingress.extraHosts }}
@@ -43,9 +41,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $fullName "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.controlplane.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
