### PR TITLE
[bitnami/clickhouse-operator] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/clickhouse-operator/CHANGELOG.md
+++ b/bitnami/clickhouse-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.6 (2025-04-29)
+## 0.1.7 (2025-05-06)
 
-* [bitnami/clickhouse-operator] fix: :bug: Change default operator user ([#33247](https://github.com/bitnami/charts/pull/33247))
+* [bitnami/clickhouse-operator] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33346](https://github.com/bitnami/charts/pull/33346))
+
+## <small>0.1.6 (2025-04-29)</small>
+
+* [bitnami/clickhouse-operator] fix: :bug: Change default operator user (#33247) ([f46836c](https://github.com/bitnami/charts/commit/f46836c1d5afef413e950e731d55cb4a445d4f50)), closes [#33247](https://github.com/bitnami/charts/issues/33247)
 
 ## <small>0.1.5 (2025-04-16)</small>
 

--- a/bitnami/clickhouse-operator/Chart.lock
+++ b/bitnami/clickhouse-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-04-04T12:34:48.003599+02:00"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:59:02.257782271+02:00"

--- a/bitnami/clickhouse-operator/Chart.yaml
+++ b/bitnami/clickhouse-operator/Chart.yaml
@@ -36,4 +36,4 @@ name: clickhouse-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse-operator
 - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse-operator
-version: 0.1.6
+version: 0.1.7

--- a/bitnami/clickhouse-operator/templates/hpa.yaml
+++ b/bitnami/clickhouse-operator/templates/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
