### PR TITLE
[bitnami/cloudnative-pg] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/cloudnative-pg/CHANGELOG.md
+++ b/bitnami/cloudnative-pg/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.9 (2025-05-01)
+## 0.1.10 (2025-05-06)
 
-* [bitnami/cloudnative-pg] Release 0.1.9 ([#33288](https://github.com/bitnami/charts/pull/33288))
+* [bitnami/cloudnative-pg] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33347](https://github.com/bitnami/charts/pull/33347))
+
+## <small>0.1.9 (2025-05-01)</small>
+
+* [bitnami/cloudnative-pg] Release 0.1.9 (#33288) ([3f91ddd](https://github.com/bitnami/charts/commit/3f91ddd256a23a12350fe8a8eea7a91dc026bc2a)), closes [#33288](https://github.com/bitnami/charts/issues/33288)
 
 ## <small>0.1.8 (2025-04-30)</small>
 

--- a/bitnami/cloudnative-pg/Chart.lock
+++ b/bitnami/cloudnative-pg/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-01T20:09:47.96644202Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T09:59:45.876114368+02:00"

--- a/bitnami/cloudnative-pg/Chart.yaml
+++ b/bitnami/cloudnative-pg/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: cloudnative-pg
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cloudnative-pg
-version: 0.1.9
+version: 0.1.10

--- a/bitnami/cloudnative-pg/templates/hpa.yaml
+++ b/bitnami/cloudnative-pg/templates/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
