### PR TITLE
[bitnami/dremio] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.1 (2025-04-25)
+## 1.0.2 (2025-05-06)
 
-* [bitnami/dremio] Release 1.0.1 ([#33188](https://github.com/bitnami/charts/pull/33188))
+* [bitnami/dremio] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33353](https://github.com/bitnami/charts/pull/33353))
+
+## <small>1.0.1 (2025-04-25)</small>
+
+* [bitnami/dremio] Release 1.0.1 (#33188) ([5c6123d](https://github.com/bitnami/charts/commit/5c6123db2f98118b67c1fa1e3f42f76c1917efa4)), closes [#33188](https://github.com/bitnami/charts/issues/33188)
 
 ## 1.0.0 (2025-04-01)
 

--- a/bitnami/dremio/Chart.lock
+++ b/bitnami/dremio/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 16.0.8
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.8.0
+  version: 13.8.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:bbf25efba6733b75de99e2ec8f70242e1b75a71d0d9f2ce2a2235727f8f1535b
-generated: "2025-04-25T20:05:50.693507066Z"
+  version: 2.31.0
+digest: sha256:65c5abee7175e746b1ef05dec02124a3cd1bf3eefd5f3b9d2bdcfdfb3b2565d8
+generated: "2025-05-06T10:04:14.969152166+02:00"

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -42,4 +42,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/dremio/templates/coordinator/hpa.yaml
+++ b/bitnami/dremio/templates/coordinator/hpa.yaml
@@ -29,24 +29,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.coordinator.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.coordinator.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.coordinator.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.coordinator.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.coordinator.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/dremio/templates/executor/hpa.yaml
+++ b/bitnami/dremio/templates/executor/hpa.yaml
@@ -40,25 +40,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
-        targetAverageUtilization: {{ $executorValues.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ $executorValues.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if $executorValues.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
-        targetAverageUtilization: {{ $executorValues.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ $executorValues.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/bitnami/dremio/templates/ingress.yaml
+++ b/bitnami/dremio/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -30,9 +30,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -40,9 +38,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}

--- a/bitnami/dremio/templates/master-coordinator/hpa.yaml
+++ b/bitnami/dremio/templates/master-coordinator/hpa.yaml
@@ -29,24 +29,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.masterCoordinator.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.masterCoordinator.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.masterCoordinator.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.masterCoordinator.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.masterCoordinator.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
