### PR TITLE
[bitnami/ejbca] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/ejbca/CHANGELOG.md
+++ b/bitnami/ejbca/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.1.1 (2025-04-23)
+## 17.1.2 (2025-05-06)
 
-* [bitnami/ejbca] Release 17.1.1 ([#33136](https://github.com/bitnami/charts/pull/33136))
+* [bitnami/ejbca] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33355](https://github.com/bitnami/charts/pull/33355))
+
+## <small>17.1.1 (2025-04-23)</small>
+
+* [bitnami/ejbca] Release 17.1.1 (#33136) ([30e4c1d](https://github.com/bitnami/charts/commit/30e4c1d01245b09dc537d1a3c54acbec6f15d8b3)), closes [#33136](https://github.com/bitnami/charts/issues/33136)
 
 ## 17.1.0 (2025-04-04)
 

--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.4.3
+  version: 20.5.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:20b344e0d7478c3dccef2f60ac66a4fef086d1ed7376ecd1bc9128c10bf733bd
-generated: "2025-04-23T07:55:58.446627282Z"
+  version: 2.31.0
+digest: sha256:419a59fc2d3b081c7ec5406089239a514f34399bfa1155802bc8b0dd4b256562
+generated: "2025-05-06T10:05:45.242274912+02:00"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 17.1.1
+version: 17.1.2

--- a/bitnami/ejbca/templates/_helpers.tpl
+++ b/bitnami/ejbca/templates/_helpers.tpl
@@ -55,17 +55,6 @@ Return the correct EJBCA secret.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "ejbca.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/bitnami/ejbca/templates/ingress.yaml
+++ b/bitnami/ejbca/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -33,9 +33,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "https" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -43,9 +41,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "https" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
