### PR TITLE
[bitnami/elasticsearch] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/elasticsearch/CHANGELOG.md
+++ b/bitnami/elasticsearch/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.0.1 (2025-04-30)
+## 22.0.2 (2025-05-06)
 
-* [bitnami/elasticsearch] Update kibana subchart ([#33256](https://github.com/bitnami/charts/pull/33256))
+* [bitnami/elasticsearch] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33356](https://github.com/bitnami/charts/pull/33356))
+
+## <small>22.0.1 (2025-04-30)</small>
+
+* [bitnami/elasticsearch] Update kibana subchart (#33256) ([628723c](https://github.com/bitnami/charts/commit/628723c5629d638280f4e69af6ef6bf0e6f3539c)), closes [#33256](https://github.com/bitnami/charts/issues/33256)
 
 ## 22.0.0 (2025-04-29)
 

--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:8b1895a821594f85102b856599021da7608c88ef72dcda0ee5fc8a8f34bff31c
-generated: "2025-04-30T08:10:34.441431+02:00"
+  version: 2.31.0
+digest: sha256:8e6ec6c9c224301cd1051019f6c7c78341449ced9b180f721d6f24460d183182
+generated: "2025-05-06T10:06:30.835035193+02:00"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 22.0.1
+version: 22.0.2

--- a/bitnami/elasticsearch/templates/coordinating/hpa.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.coordinating.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.coordinating.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.coordinating.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.coordinating.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.coordinating.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/data/hpa.yaml
+++ b/bitnami/elasticsearch/templates/data/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.data.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.data.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.data.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.data.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.data.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingest/hpa.yaml
+++ b/bitnami/elasticsearch/templates/ingest/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ingest.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ingest.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.ingest.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ingest.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ingest.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingest/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingest/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingest.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingest.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingest.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.ingest.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingest.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingest.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.ingest.fullname" .) "servicePort" "tcp-rest-api" "context" $)  | nindent 14 }}
       {{- if ne .Values.ingest.ingress.hostname "*" }}
       host: {{ .Values.ingest.ingress.hostname }}
@@ -40,9 +38,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.ingest.fullname" $) "servicePort" "tcp-rest-api" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingest.ingress.extraRules }}

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.service.name" .) "servicePort" "tcp-rest-api" "context" $)  | nindent 14 }}
       {{- if ne .Values.ingress.hostname "*" }}
       host: {{ .Values.ingress.hostname }}
@@ -40,9 +38,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.service.name" $) "servicePort" "tcp-rest-api" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}

--- a/bitnami/elasticsearch/templates/master/hpa.yaml
+++ b/bitnami/elasticsearch/templates/master/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.master.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.master.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.master.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.master.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.master.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
