### PR TITLE
[bitnami/envoy-gateway] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/envoy-gateway/CHANGELOG.md
+++ b/bitnami/envoy-gateway/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.2 (2025-05-05)
+## 0.1.3 (2025-05-06)
 
-* [bitnami/envoy-gateway] Release 0.1.2 ([#33319](https://github.com/bitnami/charts/pull/33319))
+* [bitnami/envoy-gateway] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33357](https://github.com/bitnami/charts/pull/33357))
+
+## <small>0.1.2 (2025-05-05)</small>
+
+* [bitnami/envoy-gateway] Release 0.1.2 (#33319) ([9653f11](https://github.com/bitnami/charts/commit/9653f11546f005c0e51c7589e0d29f2230f3debf)), closes [#33319](https://github.com/bitnami/charts/issues/33319)
 
 ## <small>0.1.1 (2025-05-02)</small>
 

--- a/bitnami/envoy-gateway/Chart.lock
+++ b/bitnami/envoy-gateway/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-02T10:56:57.884823946Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:07:15.708215912+02:00"

--- a/bitnami/envoy-gateway/Chart.yaml
+++ b/bitnami/envoy-gateway/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: envoy-gateway
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/envoy-gateway
-version: 0.1.2
+version: 0.1.3

--- a/bitnami/envoy-gateway/templates/hpa.yaml
+++ b/bitnami/envoy-gateway/templates/hpa.yaml
@@ -24,24 +24,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
