### PR TITLE
[bitnami/flink] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/flink/CHANGELOG.md
+++ b/bitnami/flink/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.1 (2025-04-24)
+## 2.0.2 (2025-05-06)
 
-* [bitnami/flink] Release 2.0.1 ([#33172](https://github.com/bitnami/charts/pull/33172))
+* [bitnami/flink] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33360](https://github.com/bitnami/charts/pull/33360))
+
+## <small>2.0.1 (2025-04-24)</small>
+
+* [bitnami/flink] Release 2.0.1 (#33172) ([8e878d7](https://github.com/bitnami/charts/commit/8e878d711fe5a2b616a2e7cc7cfdf86e3ee0e04b)), closes [#33172](https://github.com/bitnami/charts/issues/33172)
 
 ## 2.0.0 (2025-03-28)
 

--- a/bitnami/flink/Chart.lock
+++ b/bitnami/flink/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T17:24:35.771745221Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:09:26.841232417+02:00"

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 2.0.1
+version: 2.0.2


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
