### PR TITLE
[bitnami/fluentd] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/fluentd/CHANGELOG.md
+++ b/bitnami/fluentd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.1.5 (2025-04-12)
+## 7.1.6 (2025-05-06)
 
-* [bitnami/fluentd] Release 7.1.5 ([#32979](https://github.com/bitnami/charts/pull/32979))
+* [bitnami/fluentd] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33362](https://github.com/bitnami/charts/pull/33362))
+
+## <small>7.1.5 (2025-04-12)</small>
+
+* [bitnami/fluentd] Release 7.1.5 (#32979) ([9a1c7f2](https://github.com/bitnami/charts/commit/9a1c7f211c61ba26f3c2d447a1db9a1136e6df17)), closes [#32979](https://github.com/bitnami/charts/issues/32979)
 
 ## <small>7.1.4 (2025-03-13)</small>
 

--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T17:34:06.835995269Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:10:55.58584285+02:00"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 7.1.5
+version: 7.1.6

--- a/bitnami/fluentd/templates/ingress.yaml
+++ b/bitnami/fluentd/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.aggregator.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.aggregator.ingress.ingressClassName }}
   ingressClassName: {{ .Values.aggregator.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -34,9 +34,7 @@ spec:
           {{- toYaml .Values.aggregator.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.aggregator.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.aggregator.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.aggregator.ingress.extraHosts }}
@@ -44,9 +42,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.aggregator.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
