### PR TITLE
[bitnami/flux] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/flux/CHANGELOG.md
+++ b/bitnami/flux/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.10 (2025-05-01)
+## 2.4.11 (2025-05-06)
 
-* [bitnami/flux] Release 2.4.10 ([#33290](https://github.com/bitnami/charts/pull/33290))
+* [bitnami/flux] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33363](https://github.com/bitnami/charts/pull/33363))
+
+## <small>2.4.10 (2025-05-01)</small>
+
+* [bitnami/flux] Release 2.4.10 (#33290) ([a3e199c](https://github.com/bitnami/charts/commit/a3e199cd22b6fd081c7bc1b79ed38a8e6d89d7e9)), closes [#33290](https://github.com/bitnami/charts/issues/33290)
 
 ## <small>2.4.9 (2025-04-01)</small>
 

--- a/bitnami/flux/Chart.lock
+++ b/bitnami/flux/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-01T21:03:52.930289495Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:11:39.344801963+02:00"

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: flux
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 2.4.10
+version: 2.4.11


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
