### PR TITLE
[bitnami/ghost] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/ghost/CHANGELOG.md
+++ b/bitnami/ghost/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.2.15 (2025-04-25)
+## 22.2.16 (2025-05-06)
 
-* [bitnami/ghost] Release 22.2.15 ([#33187](https://github.com/bitnami/charts/pull/33187))
+* [bitnami/ghost] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33364](https://github.com/bitnami/charts/pull/33364))
+
+## <small>22.2.15 (2025-04-25)</small>
+
+* [bitnami/ghost] Release 22.2.15 (#33187) ([019ff0a](https://github.com/bitnami/charts/commit/019ff0ab43d28fe671817c899857fef90b48c746)), closes [#33187](https://github.com/bitnami/charts/issues/33187)
 
 ## <small>22.2.14 (2025-04-18)</small>
 

--- a/bitnami/ghost/Chart.lock
+++ b/bitnami/ghost/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.3.4
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:2ccfd16724aa5430fbf3d1226e9e2b590e030103b688aa0390c34f7aaa00e2b7
-generated: "2025-04-18T18:25:26.984150782Z"
+  version: 2.31.0
+digest: sha256:6576509a555a2eff2a0154377ac40deda22e3b3ea6a09f73adfa6aac4cdb7c45
+generated: "2025-05-06T10:12:24.773486642+02:00"

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: ghost
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ghost
-version: 22.2.15
+version: 22.2.16

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" (ternary "https" "http" $.Values.ghostEnableHttps) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" (ternary "https" "http" $.Values.ghostEnableHttps) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
