### PR TITLE
[bitnami/gitlab-runner] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/gitlab-runner/CHANGELOG.md
+++ b/bitnami/gitlab-runner/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.4 (2025-05-05)
+## 0.1.5 (2025-05-06)
 
-* [bitnami/gitlab-runner] Release 0.1.4 ([#33325](https://github.com/bitnami/charts/pull/33325))
+* [bitnami/gitlab-runner] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33366](https://github.com/bitnami/charts/pull/33366))
+
+## <small>0.1.4 (2025-05-05)</small>
+
+* [bitnami/gitlab-runner] Release 0.1.4 (#33325) ([8074779](https://github.com/bitnami/charts/commit/8074779bfb292239e7267b80655026b9c61cb156)), closes [#33325](https://github.com/bitnami/charts/issues/33325)
 
 ## <small>0.1.3 (2025-04-17)</small>
 

--- a/bitnami/gitlab-runner/Chart.yaml
+++ b/bitnami/gitlab-runner/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: gitlab-runner
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitlab-runner
-version: 0.1.4
+version: 0.1.5

--- a/bitnami/gitlab-runner/templates/hpa.yaml
+++ b/bitnami/gitlab-runner/templates/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/gitlab-runner/templates/session-server-ingress.yaml
+++ b/bitnami/gitlab-runner/templates/session-server-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.sessionServer.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.sessionServer.ingress.ingressClassName }}
   ingressClassName: {{ .Values.sessionServer.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.sessionServer.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.sessionServer.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.sessionServer.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "gitlab-runner.session-server.fullname" .) "servicePort" "http-session" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.sessionServer.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "gitlab-runner.session-server.fullname" .) "servicePort" "http-session" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.sessionServer.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
