### PR TITLE
[bitnami/grafana-loki] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.8.5 (2025-04-29)
+## 4.8.6 (2025-05-06)
 
-* [bitnami/grafana-loki] add /otlp/v1/logs as gateway-endpoint for distributor via gateway ([#33190](https://github.com/bitnami/charts/pull/33190))
+* [bitnami/grafana-loki] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33368](https://github.com/bitnami/charts/pull/33368))
+
+## <small>4.8.5 (2025-04-30)</small>
+
+* [bitnami/grafana-loki] add /otlp/v1/logs as gateway-endpoint for distributor via gateway (#33190) ([130ffd1](https://github.com/bitnami/charts/commit/130ffd163382dffd5762034291203a3ac2792fba)), closes [#33190](https://github.com/bitnami/charts/issues/33190)
 
 ## <small>4.8.4 (2025-04-28)</small>
 

--- a/bitnami/grafana-loki/Chart.lock
+++ b/bitnami/grafana-loki/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 7.8.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:b964bbf9aa6718ca537d204bf575f505da30e020e7310bf15a1339d3084d808c
-generated: "2025-04-23T01:16:30.549974173Z"
+  version: 2.31.0
+digest: sha256:0312bce29b111de7f20dce7ff94982ee396abbfcb8cf8c4f8ac00cdc35463768
+generated: "2025-05-06T10:15:24.566828533+02:00"

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -56,4 +56,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.8.5
+version: 4.8.6

--- a/bitnami/grafana-loki/templates/gateway/ingress.yaml
+++ b/bitnami/grafana-loki/templates/gateway/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.gateway.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.gateway.ingress.ingressClassName }}
   ingressClassName: {{ .Values.gateway.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.gateway.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.gateway.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.gateway.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "grafana-loki.gateway.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.gateway.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "grafana-loki.gateway.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.gateway.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.gateway.ingress.annotations )) .Values.gateway.ingress.selfSigned)) .Values.gateway.ingress.extraTls }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
