### PR TITLE
[bitnami/grafana-mimir] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/grafana-mimir/CHANGELOG.md
+++ b/bitnami/grafana-mimir/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.3 (2025-04-28)
+## 2.0.4 (2025-05-06)
 
-* [bitnami/grafana-mimir] Release 2.0.3 ([#33210](https://github.com/bitnami/charts/pull/33210))
+* [bitnami/grafana-mimir] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33369](https://github.com/bitnami/charts/pull/33369))
+
+## <small>2.0.3 (2025-04-28)</small>
+
+* [bitnami/grafana-mimir] Release 2.0.3 (#33210) ([9b60c4b](https://github.com/bitnami/charts/commit/9b60c4b1690678d834c671139c90cdd69d891d31)), closes [#33210](https://github.com/bitnami/charts/issues/33210)
 
 ## <small>2.0.2 (2025-04-22)</small>
 

--- a/bitnami/grafana-mimir/Chart.lock
+++ b/bitnami/grafana-mimir/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 7.8.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46b40adb1e3eff0a8963868607798353e207455842e0a4cda721f4e4249ed37e
-generated: "2025-04-28T08:37:40.779904586Z"
+  version: 2.31.0
+digest: sha256:539d11e39cbae08ab476cfa184e07584fb169e1ae8f9516f71b858043c44ddfa
+generated: "2025-05-06T10:16:13.358839746+02:00"

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -60,4 +60,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 2.0.3
+version: 2.0.4

--- a/bitnami/grafana-mimir/templates/gateway/ingress.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.gateway.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.gateway.ingress.ingressClassName }}
   ingressClassName: {{ .Values.gateway.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.gateway.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.gateway.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.gateway.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "grafana-mimir.gateway.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.gateway.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "grafana-mimir.gateway.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.gateway.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.gateway.ingress.annotations )) .Values.gateway.ingress.selfSigned)) .Values.gateway.ingress.extraTls }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
