### PR TITLE
[bitnami/grafana-tempo] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/grafana-tempo/CHANGELOG.md
+++ b/bitnami/grafana-tempo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.0.3 (2025-05-01)
+## 4.0.4 (2025-05-06)
 
-* [bitnami/grafana-tempo] Release 4.0.3 ([#33291](https://github.com/bitnami/charts/pull/33291))
+* [bitnami/grafana-tempo] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33371](https://github.com/bitnami/charts/pull/33371))
+
+## <small>4.0.3 (2025-05-01)</small>
+
+* [bitnami/grafana-tempo] Release 4.0.3 (#33291) ([010e8c6](https://github.com/bitnami/charts/commit/010e8c6e33b5c0cb0c1cf429f17d8b05cae97c59)), closes [#33291](https://github.com/bitnami/charts/issues/33291)
 
 ## <small>4.0.2 (2025-04-01)</small>
 

--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 7.8.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:5f5bef921c389545748f87c3129732047829f4529862eb1bfc70e22722d49a48
-generated: "2025-05-01T22:53:48.703967558Z"
+  version: 2.31.0
+digest: sha256:79f30de11dbb4923acd27efb48dd3d49a205494acca97b14920898273833ecb8
+generated: "2025-05-06T10:17:47.273294603+02:00"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 4.0.3
+version: 4.0.4


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
