### PR TITLE
[bitnami/harbor] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 25.0.1 (2025-05-06)
+
+* [bitnami/harbor] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33373](https://github.com/bitnami/charts/pull/33373))
+
 ## 25.0.0 (2025-04-29)
 
-* [bitnami/harbor] Major 25.0.0: Upgrade PostgreSQL to 17.x.x ([#33242](https://github.com/bitnami/charts/pull/33242))
+* [bitnami/harbor] Major 25.0.0: Upgrade PostgreSQL to 17.x.x (#33242) ([461f94e](https://github.com/bitnami/charts/commit/461f94ef15ab2530b1b370f5ca0dd2f5f2a4a894)), closes [#33242](https://github.com/bitnami/charts/issues/33242)
 
 ## <small>24.6.1 (2025-04-28)</small>
 

--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.2
+  version: 20.13.4
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:19ce8ca8f97837d3633203fd7a7fabddf8f9dbb210ffab0c0191276c5b4e18d5
-generated: "2025-04-28T08:37:40.009197105Z"
+  version: 2.31.0
+digest: sha256:4e96e7deb3123f109d43507a618b2b9b45e84cdffece913eb3d85c6a6acd926c
+generated: "2025-05-06T10:19:16.228879443+02:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -54,4 +54,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 25.0.0
+version: 25.0.1

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -50,7 +50,7 @@ spec:
   {{- if eq .Values.ingress.core.controller "ncp" }}
   backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 4 }}
   {{- end }}
-  {{- if and .Values.ingress.core.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.core.ingressClassName }}
   ingressClassName: {{ .Values.ingress.core.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -62,34 +62,22 @@ spec:
           {{- toYaml .Values.ingress.core.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .api_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .service_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .v2_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .chartrepo_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .controller_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
           - path: {{ .portal_path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.core.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.core.extraHosts }}
@@ -97,9 +85,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" $) "servicePort" (ternary "https" "http" $.Values.internalTLS.enabled) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.core.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
