### PR TITLE
[bitnami/jaeger] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.1.14 (2025-04-15)
+## 5.1.15 (2025-05-06)
 
-* [bitnami/jaeger] Release 5.1.14 ([#33010](https://github.com/bitnami/charts/pull/33010))
+* [bitnami/jaeger] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33375](https://github.com/bitnami/charts/pull/33375))
+
+## <small>5.1.14 (2025-04-15)</small>
+
+* [bitnami/jaeger] Release 5.1.14 (#33010) ([c200116](https://github.com/bitnami/charts/commit/c200116294bcb06831957c334a07580ecba1fc4a)), closes [#33010](https://github.com/bitnami/charts/issues/33010)
 
 ## <small>5.1.13 (2025-04-02)</small>
 

--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.15 (2025-05-06)
+## 5.1.15 (2025-05-07)
 
 * [bitnami/jaeger] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33375](https://github.com/bitnami/charts/pull/33375))
 

--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
+  version: 2.31.0
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.3.1
-digest: sha256:ea9d866337f105c5efb0b0ec019e62e7c6b75b5633a7841fc547bc265c231211
-generated: "2025-04-15T10:56:51.308113837Z"
+  version: 12.3.5
+digest: sha256:3f7c4b1323a7203e37b9805f42d381b160c9dd9945eb0ef08fe7a24013562be2
+generated: "2025-05-06T10:20:45.471830227+02:00"

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 5.1.14
+version: 5.1.15


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
