### PR TITLE
[bitnami/janusgraph] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/janusgraph/CHANGELOG.md
+++ b/bitnami/janusgraph/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.2 (2025-04-25)
+## 1.4.3 (2025-05-06)
 
-* [bitnami/janusgraph] Release 1.4.2 ([#33174](https://github.com/bitnami/charts/pull/33174))
+* [bitnami/janusgraph] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33376](https://github.com/bitnami/charts/pull/33376))
+
+## <small>1.4.2 (2025-04-25)</small>
+
+* [bitnami/janusgraph] Release 1.4.2 (#33174) ([1113c4d](https://github.com/bitnami/charts/commit/1113c4d507d6ce746fe5f773cdd1c7559be359fe)), closes [#33174](https://github.com/bitnami/charts/issues/33174)
 
 ## <small>1.4.1 (2025-03-26)</small>
 

--- a/bitnami/janusgraph/Chart.lock
+++ b/bitnami/janusgraph/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.3.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:608b375ffcf671f72ad149930036d5b12bc02d217219f8e8185aaeb8a85ba193
-generated: "2025-04-25T10:13:24.490368409Z"
+  version: 2.31.0
+digest: sha256:f4634566a68df244963c77f717c661b7567637e28c31437b19b35f1038fa4c6c
+generated: "2025-05-06T10:21:34.915754684+02:00"

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -39,4 +39,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/janusgraph
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 1.4.2
+version: 1.4.3

--- a/bitnami/janusgraph/templates/hpa.yaml
+++ b/bitnami/janusgraph/templates/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
