### PR TITLE
[bitnami/jupyterhub] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.0.5 (2025-05-02)
+## 9.0.6 (2025-05-06)
 
-* [bitnami/jupyterhub] Release 9.0.5 ([#33304](https://github.com/bitnami/charts/pull/33304))
+* [bitnami/jupyterhub] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33378](https://github.com/bitnami/charts/pull/33378))
+
+## <small>9.0.5 (2025-05-02)</small>
+
+* [bitnami/jupyterhub] Release 9.0.5 (#33304) ([18bc5da](https://github.com/bitnami/charts/commit/18bc5da4bfc5c0b02874b4c13b4f226a00759608)), closes [#33304](https://github.com/bitnami/charts/issues/33304)
 
 ## <small>9.0.4 (2025-05-02)</small>
 

--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 16.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:6d3a0d03aa61caccf74b405c157b30d095335e15a664c28b4623349efdd4efc5
-generated: "2025-05-02T08:14:29.547212662Z"
+  version: 2.31.0
+digest: sha256:1b5577724d7ca3aec34781d6c3e9f3cb866d81a7fc077746aa83a84b2bdd95c0
+generated: "2025-05-06T10:23:03.610375199+02:00"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 9.0.5
+version: 9.0.6

--- a/bitnami/jupyterhub/templates/proxy/ingress.yaml
+++ b/bitnami/jupyterhub/templates/proxy/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.proxy.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.proxy.ingress.ingressClassName }}
   ingressClassName: {{ .Values.proxy.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -34,9 +34,7 @@ spec:
           {{- toYaml .Values.proxy.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.proxy.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.proxy.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-proxy-public" (include "common.names.fullname" . )) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.proxy.ingress.extraHosts }}
@@ -44,9 +42,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.proxy.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
