### PR TITLE
[bitnami/kiam] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kiam/CHANGELOG.md
+++ b/bitnami/kiam/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.3.9 (2025-05-01)
+## 2.3.10 (2025-05-06)
 
-* [bitnami/kiam] Release 2.3.9 ([#33294](https://github.com/bitnami/charts/pull/33294))
+* [bitnami/kiam] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33382](https://github.com/bitnami/charts/pull/33382))
+
+## <small>2.3.9 (2025-05-01)</small>
+
+* [bitnami/kiam] Release 2.3.9 (#33294) ([dbf3c59](https://github.com/bitnami/charts/commit/dbf3c5933390bf9e46eb21810b193ad60f1dda36)), closes [#33294](https://github.com/bitnami/charts/issues/33294)
 
 ## <small>2.3.8 (2025-04-01)</small>
 

--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-01T23:28:07.187457133Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:26:00.984345817+02:00"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: kiam
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 2.3.9
+version: 2.3.10


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
