### PR TITLE
[bitnami/kibana] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kibana/CHANGELOG.md
+++ b/bitnami/kibana/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 12.0.1 (2025-05-06)
+
+* [bitnami/kibana] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33383](https://github.com/bitnami/charts/pull/33383))
+
 ## 12.0.0 (2025-04-29)
 
-* [bitnami/kibana] Release 12.0.0 ([#33244](https://github.com/bitnami/charts/pull/33244))
+* [bitnami/kibana] Release 12.0.0 (#33244) ([389d46f](https://github.com/bitnami/charts/commit/389d46f68a2a84b0239e93d5c361e548c6d0f7c9)), closes [#33244](https://github.com/bitnami/charts/issues/33244)
 
 ## 11.6.0 (2025-04-04)
 

--- a/bitnami/kibana/Chart.lock
+++ b/bitnami/kibana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-03-04T15:02:39.8564055Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:26:44.842993356+02:00"

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/kibana/templates/ingress.yaml
+++ b/bitnami/kibana/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -23,9 +23,7 @@ spec:
     - http:
         paths:
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
       {{- if ne .Values.ingress.hostname "*" }}
       host: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
