### PR TITLE
[bitnami/kong] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kong/CHANGELOG.md
+++ b/bitnami/kong/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.4.3 (2025-04-30)
+## 15.4.4 (2025-05-06)
 
-* [bitnami/kong] Release 15.4.3 ([#33195](https://github.com/bitnami/charts/pull/33195))
+* [bitnami/kong] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33385](https://github.com/bitnami/charts/pull/33385))
+
+## <small>15.4.3 (2025-04-30)</small>
+
+* [bitnami/kong] Release 15.4.3 (#33195) ([0168f32](https://github.com/bitnami/charts/commit/0168f3282fdbc2dfa3d8021bf1c452a5a5353a88)), closes [#33195](https://github.com/bitnami/charts/issues/33195)
 
 ## <small>15.4.2 (2025-03-27)</small>
 

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 16.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
+  version: 2.31.0
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.3.5
-digest: sha256:2e0c32955b21a7baf6ddaf37cf46aed551c0697bf862a98ddc3cdeef32d7d409
-generated: "2025-04-26T21:32:48.319170354Z"
+digest: sha256:feacf48704e603bf9a6f287d4f42e83672104a16c7022bb97168167fe4437c09
+generated: "2025-05-06T10:27:29.395537221+02:00"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: kong
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.4.3
+version: 15.4.4

--- a/bitnami/kong/templates/ingress.yaml
+++ b/bitnami/kong/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" $backendPort "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" $backendPort "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
