### PR TITLE
[bitnami/kube-prometheus] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kube-prometheus/CHANGELOG.md
+++ b/bitnami/kube-prometheus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.7 (2025-04-30)
+## 11.1.8 (2025-05-06)
 
-* [bitnami/kube-prometheus] Release 11.1.7 ([#33238](https://github.com/bitnami/charts/pull/33238))
+* [bitnami/kube-prometheus] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33387](https://github.com/bitnami/charts/pull/33387))
+
+## <small>11.1.7 (2025-04-30)</small>
+
+* [bitnami/kube-prometheus] Release 11.1.7 (#33238) ([50ade8a](https://github.com/bitnami/charts/commit/50ade8aeceaa7346b83ad037d266a637d8f7439b)), closes [#33238](https://github.com/bitnami/charts/issues/33238)
 
 ## <small>11.1.6 (2025-04-23)</small>
 

--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: node-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 4.5.10
+  version: 4.5.11
 - name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 5.0.5
+  version: 5.0.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
+  version: 2.31.0
 - name: kube-prometheus-crds
   repository: file://./charts/kube-prometheus-crds
   version: 0.1.0
-digest: sha256:12139ab63d538076059cd0e54f44501d831f121a5309e6a91f7a862bdcaab4a7
-generated: "2025-04-17T11:00:30.031672592Z"
+digest: sha256:de42c1e1526b829d9d076246ddf42552463a72055feb50e89cc99646f94763d7
+generated: "2025-05-06T10:29:37.160030815+02:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -50,4 +50,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 11.1.7
+version: 11.1.8

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.alertmanager.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
           {{- toYaml .Values.alertmanager.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.alertmanager.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.alertmanager.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.alertmanager.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
       {{- if ne .Values.alertmanager.ingress.hostname "*" }}
       host: {{ .Values.alertmanager.ingress.hostname }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.alertmanager.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.alertmanager.ingress.extraRules }}

--- a/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.prometheus.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.prometheus.ingress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
           {{- toYaml .Values.prometheus.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.prometheus.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.prometheus.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.prometheus.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
       {{- if ne .Values.prometheus.ingress.hostname "*" }}
       host: {{ .Values.prometheus.ingress.hostname }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.prometheus.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.prometheus.ingress.extraRules }}

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.prometheus.thanos.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.prometheus.thanos.ingress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.thanos.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -28,9 +28,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.ingress.extraPaths "context" $) | nindent 10 }}
           {{- end }}
           - path: {{ .Values.prometheus.thanos.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.prometheus.thanos.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.thanos.fullname" $) "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- range .Values.prometheus.thanos.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.thanos.fullname" $) "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.prometheus.thanos.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
