### PR TITLE
[bitnami/kubeapps] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kubeapps/CHANGELOG.md
+++ b/bitnami/kubeapps/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.1.6 (2025-04-28)
+## 17.1.7 (2025-05-06)
 
-* [bitnami/kubeapps] Release 17.1.6 ([#33212](https://github.com/bitnami/charts/pull/33212))
+* [bitnami/kubeapps] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33389](https://github.com/bitnami/charts/pull/33389))
+
+## <small>17.1.6 (2025-04-28)</small>
+
+* [bitnami/kubeapps] Release 17.1.6 (#33212) ([1ead8af](https://github.com/bitnami/charts/commit/1ead8af0f7a0c75aba2f13270b3504769c43c987)), closes [#33212](https://github.com/bitnami/charts/issues/33212)
 
 ## <small>17.1.5 (2025-04-21)</small>
 

--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.2
+  version: 20.13.4
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:b07be77b47726027375d667ec052bd1f510d6fb5761a18c610471bf42ac6f886
-generated: "2025-04-28T08:43:32.861279925Z"
+  version: 2.31.0
+digest: sha256:380c7086ef98bd02a751760d24fbfe9347af71827c02af67041d6f0ead00a47c
+generated: "2025-05-06T10:31:08.903047384+02:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 17.1.6
+version: 17.1.7

--- a/bitnami/kubeapps/templates/ingress-api.yaml
+++ b/bitnami/kubeapps/templates/ingress-api.yaml
@@ -22,7 +22,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -34,15 +34,11 @@ spec:
         {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
         {{- end }}
         - path: /apis
-          {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
           pathType: {{ $.Values.ingress.pathType }}
-          {{- end }}
           backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
         {{- if and .Values.ingress.path (ne (quote (trim .Values.ingress.path)) (quote "/")) }}
         - path: {{ .Values.ingress.path }}
-          {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
           pathType: {{ $.Values.ingress.pathType }}
-          {{- end }}
           backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
         {{- end -}}
     {{- end }}
@@ -51,9 +47,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
@@ -82,7 +76,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -91,9 +85,7 @@ spec:
       http:
         paths:
           - path: /
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend:
               service:
                 name: {{ template "kubeapps.kubeappsapis.fullname" . }}

--- a/bitnami/kubeapps/templates/ingress.yaml
+++ b/bitnami/kubeapps/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
