### PR TITLE
[bitnami/kuberay] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.9 (2025-04-14)
+## 1.4.10 (2025-05-06)
 
-* [bitnami/kuberay] match upstream clusterrole ([#32829](https://github.com/bitnami/charts/pull/32829))
+* [bitnami/kuberay] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33390](https://github.com/bitnami/charts/pull/33390))
+
+## <small>1.4.9 (2025-04-14)</small>
+
+* [bitnami/kuberay] match upstream clusterrole (#32829) ([2e22964](https://github.com/bitnami/charts/commit/2e22964831c0891af097e780ff19b41a6883a10a)), closes [#32829](https://github.com/bitnami/charts/issues/32829)
 
 ## <small>1.4.8 (2025-04-09)</small>
 

--- a/bitnami/kuberay/Chart.lock
+++ b/bitnami/kuberay/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T21:40:52.236272905Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:31:54.29213811+02:00"

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.4.9
+version: 1.4.10

--- a/bitnami/kuberay/templates/apiserver/hpa.yaml
+++ b/bitnami/kuberay/templates/apiserver/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.apiserver.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.apiserver.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.apiserver.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.apiserver.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.apiserver.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/kuberay/templates/apiserver/ingress.yaml
+++ b/bitnami/kuberay/templates/apiserver/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.apiserver.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.apiserver.ingress.ingressClassName }}
   ingressClassName: {{ .Values.apiserver.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.apiserver.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.apiserver.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.apiserver.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kuberay.apiserver.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.apiserver.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kuberay.apiserver.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.apiserver.ingress.extraRules }}

--- a/bitnami/kuberay/templates/operator/hpa.yaml
+++ b/bitnami/kuberay/templates/operator/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.operator.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.operator.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.operator.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.operator.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.operator.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/kuberay/templates/operator/ingress.yaml
+++ b/bitnami/kuberay/templates/operator/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.operator.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.operator.ingress.ingressClassName }}
   ingressClassName: {{ .Values.operator.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.operator.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.operator.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.operator.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kuberay.operator.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http-metrics" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.operator.ingress.extraHosts }}
@@ -41,9 +39,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kuberay.operator.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http-metrics" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.operator.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
