### PR TITLE
[bitnami/mastodon] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 11.0.1 (2025-05-06)
+
+* [bitnami/mastodon] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33395](https://github.com/bitnami/charts/pull/33395))
+
 ## 11.0.0 (2025-04-30)
 
-* [bitnami/mastodon] major: Upgrade elasticsearch subchart to 22.x.x (ES 9.x) ([#33264](https://github.com/bitnami/charts/pull/33264))
+* [bitnami/mastodon] major: Upgrade elasticsearch subchart to 22.x.x (ES 9.x) (#33264) ([ffb165a](https://github.com/bitnami/charts/commit/ffb165a2535d93a78333d01aaea1a37bb7141490)), closes [#33264](https://github.com/bitnami/charts/issues/33264)
 
 ## <small>10.1.1 (2025-04-09)</small>
 

--- a/bitnami/mastodon/Chart.lock
+++ b/bitnami/mastodon/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 16.6.6
 - name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 22.0.0
+  version: 22.0.1
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.0.8
@@ -16,6 +16,6 @@ dependencies:
   version: 11.3.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.1
-digest: sha256:43efaa6d221b032d3ef779e3391340356a5bd3204ca76de8e04ee74987a7a0a1
-generated: "2025-04-30T13:12:16.396108+02:00"
+  version: 2.31.0
+digest: sha256:dc31c493cd18c5590c24505bafd5a61047f0082b5cbfb294e7c890af075e45c0
+generated: "2025-05-06T10:35:35.476418141+02:00"

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -50,4 +50,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 11.0.0
+version: 11.0.1


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
