### PR TITLE
[bitnami/matomo] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.3.6 (2025-05-03)
+## 9.3.7 (2025-05-06)
 
-* [bitnami/matomo] Release 9.3.6 ([#33314](https://github.com/bitnami/charts/pull/33314))
+* [bitnami/matomo] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33396](https://github.com/bitnami/charts/pull/33396))
+
+## <small>9.3.6 (2025-05-03)</small>
+
+* [bitnami/matomo] Release 9.3.6 (#33314) ([5976be1](https://github.com/bitnami/charts/commit/5976be1ecb807f0fd3a13b8a889da4054d7c84bf)), closes [#33314](https://github.com/bitnami/charts/issues/33314)
 
 ## <small>9.3.5 (2025-05-03)</small>
 

--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.3.7 (2025-05-06)
+## 9.3.7 (2025-05-07)
 
 * [bitnami/matomo] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33396](https://github.com/bitnami/charts/pull/33396))
 

--- a/bitnami/matomo/Chart.lock
+++ b/bitnami/matomo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 20.5.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:8760b38f9007a64fed5f7bda8c18981abc05f3ab65e1b3cfd692a7277b04dd50
-generated: "2025-05-03T06:16:19.820464572Z"
+  version: 2.31.0
+digest: sha256:b1d1ae0a4554cfeb0f6e1de395261910a0ba101a11ce4566e209e801dc3783b9
+generated: "2025-05-06T10:36:24.266497431+02:00"

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 9.3.6
+version: 9.3.7

--- a/bitnami/matomo/templates/ingress.yaml
+++ b/bitnami/matomo/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
