### PR TITLE
[bitnami/airflow] Fix baseUrl generation with ingress enabled

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 23.0.3
+version: 23.0.4

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -397,7 +397,7 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- $host := default (include "airflow.serviceIP" .) .Values.web.baseUrl -}}
 {{- $port := printf ":%d" (int .Values.service.ports.http) -}}
 {{- $schema := ternary "https://" "http://" (or .Values.web.tls.enabled (and .Values.ingress.enabled .Values.ingress.tls)) -}}
-{{- if regexMatch "^https?://" .Values.web.baseUrl -}}
+{{- if and (regexMatch "^https?://" .Values.web.baseUrl) (not .Values.ingress.enabled) -}}
   {{- $schema = "" -}}
 {{- end -}}
 {{- if or (regexMatch ":\\d+$" .Values.web.baseUrl) (eq $port ":80") (eq $port ":443") -}}
@@ -405,6 +405,7 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- end -}}
 {{- if and .Values.ingress.enabled .Values.ingress.hostname -}}
   {{- $host = .Values.ingress.hostname -}}
+  {{- $port = "" -}}
 {{- end -}}
 {{- printf "%s%s%s" $schema $host $port -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Fix issues rendering `base_url` parameter with ingress enabled. Previous logic was adding the `.Values.service.ports.http` value in all cases.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
