### PR TITLE
[bitnami/metrics-server] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/metrics-server/CHANGELOG.md
+++ b/bitnami/metrics-server/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.4.3 (2025-05-02)
+## 7.4.4 (2025-05-06)
 
-* [bitnami/metrics-server] Release 7.4.3 ([#33296](https://github.com/bitnami/charts/pull/33296))
+* [bitnami/metrics-server] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33400](https://github.com/bitnami/charts/pull/33400))
+
+## <small>7.4.3 (2025-05-02)</small>
+
+* [bitnami/metrics-server] Release 7.4.3 (#33296) ([32d8701](https://github.com/bitnami/charts/commit/32d8701105619dced44cb5a8cf981c7d8a91c98b)), closes [#33296](https://github.com/bitnami/charts/issues/33296)
 
 ## <small>7.4.2 (2025-04-09)</small>
 

--- a/bitnami/metrics-server/Chart.lock
+++ b/bitnami/metrics-server/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-02T00:11:58.861944398Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:38:35.726162187+02:00"

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: metrics-server
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
-version: 7.4.3
+version: 7.4.4


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
