### PR TITLE
[bitnami/mlflow] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.5 (2025-05-02)
+## 3.0.6 (2025-05-06)
 
-* [bitnami/mlflow] Release 3.0.5 ([#33309](https://github.com/bitnami/charts/pull/33309))
+* [bitnami/mlflow] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33404](https://github.com/bitnami/charts/pull/33404))
+
+## <small>3.0.5 (2025-05-02)</small>
+
+* [bitnami/mlflow] Release 3.0.5 (#33309) ([dbb7a86](https://github.com/bitnami/charts/commit/dbb7a86bddd464ff476173a8c9f55bebd9c70db9)), closes [#33309](https://github.com/bitnami/charts/issues/33309)
 
 ## <small>3.0.4 (2025-05-02)</small>
 

--- a/bitnami/mlflow/Chart.lock
+++ b/bitnami/mlflow/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 16.6.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:2771d4cec1cf5173ef99097ca69308b31a1a25e53330b8c5c645415c5dd6054a
-generated: "2025-05-02T09:29:29.574031329Z"
+  version: 2.31.0
+digest: sha256:59f97b92a02415a272e1c4604bb610108a746032f308b544e45edc533f9eb310
+generated: "2025-05-06T10:41:39.236117033+02:00"

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 3.0.5
+version: 3.0.6

--- a/bitnami/mlflow/templates/tracking/hpa.yaml
+++ b/bitnami/mlflow/templates/tracking/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.tracking.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.tracking.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.tracking.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.tracking.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.tracking.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.tracking.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.tracking.ingress.ingressClassName }}
   ingressClassName: {{ .Values.tracking.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.tracking.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.tracking.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.tracking.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" .) "servicePort" (include "mlflow.v0.tracking.protocol" $)  "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.tracking.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" $) "servicePort" (include "mlflow.v0.tracking.protocol" $) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.tracking.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
