### PR TITLE
[bitnami/mongodb-sharded] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.2.4 (2025-05-01)
+## 9.2.5 (2025-05-06)
 
-* [bitnami/mongodb-sharded] Release 9.2.4 ([#33285](https://github.com/bitnami/charts/pull/33285))
+* [bitnami/mongodb-sharded] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33406](https://github.com/bitnami/charts/pull/33406))
+
+## <small>9.2.4 (2025-05-01)</small>
+
+* [bitnami/mongodb-sharded] Release 9.2.4 (#33285) ([7f09123](https://github.com/bitnami/charts/commit/7f0912397bd85bef38951545f9fefd1b15a815a0)), closes [#33285](https://github.com/bitnami/charts/issues/33285)
 
 ## <small>9.2.3 (2025-04-14)</small>
 

--- a/bitnami/mongodb-sharded/Chart.lock
+++ b/bitnami/mongodb-sharded/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-01T18:59:50.787127137Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:43:07.61130783+02:00"

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 9.2.4
+version: 9.2.5


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
