### PR TITLE
[bitnami/mysql] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.3.4 (2025-04-15)
+## 12.3.5 (2025-05-06)
 
-* [bitnami/mysql] Release 12.3.4 ([#33017](https://github.com/bitnami/charts/pull/33017))
+* [bitnami/mysql] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33409](https://github.com/bitnami/charts/pull/33409))
+
+## <small>12.3.4 (2025-04-15)</small>
+
+* [bitnami/mysql] Release 12.3.4 (#33017) ([86aa183](https://github.com/bitnami/charts/commit/86aa183ab6017410cdf02ade4ac9449791e5fb1b)), closes [#33017](https://github.com/bitnami/charts/issues/33017)
 
 ## <small>12.3.3 (2025-04-09)</small>
 

--- a/bitnami/mysql/Chart.lock
+++ b/bitnami/mysql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T23:09:44.390417224Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:45:19.824245888+02:00"

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 12.3.4
+version: 12.3.5


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
