### PR TITLE
[bitnami/neo4j] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/neo4j/CHANGELOG.md
+++ b/bitnami/neo4j/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.4.1 (2025-05-02)
+## 0.4.2 (2025-05-06)
 
-* [bitnami/neo4j] Release 0.4.1 ([#33307](https://github.com/bitnami/charts/pull/33307))
+* [bitnami/neo4j] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33411](https://github.com/bitnami/charts/pull/33411))
+
+## <small>0.4.1 (2025-05-02)</small>
+
+* [bitnami/neo4j] Release 0.4.1 (#33307) ([e1f95c2](https://github.com/bitnami/charts/commit/e1f95c2e61edb3ab20146965a5c579f1d56a10eb)), closes [#33307](https://github.com/bitnami/charts/issues/33307)
 
 ## 0.4.0 (2025-04-04)
 

--- a/bitnami/neo4j/Chart.lock
+++ b/bitnami/neo4j/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-02T09:32:51.379513758Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:46:45.948970918+02:00"

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/neo4j
 - https://github.com/bitnami/containers/tree/main/bitnami/neo4j
 - https://github.com/neo4j/neo4j
-version: 0.4.1
+version: 0.4.2

--- a/bitnami/neo4j/templates/ingress.yaml
+++ b/bitnami/neo4j/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
