### PR TITLE
[bitnami/oauth2-proxy] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/oauth2-proxy/CHANGELOG.md
+++ b/bitnami/oauth2-proxy/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.2.12 (2025-04-28)
+## 6.2.13 (2025-05-06)
 
-* [bitnami/oauth2-proxy] Release 6.2.12 ([#33229](https://github.com/bitnami/charts/pull/33229))
+* [bitnami/oauth2-proxy] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33416](https://github.com/bitnami/charts/pull/33416))
+
+## <small>6.2.12 (2025-04-28)</small>
+
+* [bitnami/oauth2-proxy] Release 6.2.12 (#33229) ([4cda3c6](https://github.com/bitnami/charts/commit/4cda3c63f74239944e3cd4f2ab20f43c2395125e)), closes [#33229](https://github.com/bitnami/charts/issues/33229)
 
 ## <small>6.2.11 (2025-04-02)</small>
 

--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.3
+  version: 20.13.4
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:18a097498fa3a650f93fa7d5ec52713b4d08d8ddfda23dcf039a6fbefdf8e0b4
-generated: "2025-04-28T18:06:48.995285758Z"
+  version: 2.31.0
+digest: sha256:f66e36628e6e3cd92e6f5ecd95854e5e3f8679a19f6e6176a912baa5ef5d2981
+generated: "2025-05-06T10:50:37.877860277+02:00"

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 6.2.12
+version: 6.2.13

--- a/bitnami/oauth2-proxy/templates/ingress.yaml
+++ b/bitnami/oauth2-proxy/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -32,9 +32,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -42,9 +40,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
