### PR TITLE
[bitnami/parse] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/parse/CHANGELOG.md
+++ b/bitnami/parse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 25.1.3 (2025-05-01)
+## 25.1.4 (2025-05-06)
 
-* [bitnami/parse] Release 25.1.3 ([#33280](https://github.com/bitnami/charts/pull/33280))
+* [bitnami/parse] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33419](https://github.com/bitnami/charts/pull/33419))
+
+## <small>25.1.3 (2025-05-01)</small>
+
+* [bitnami/parse] Release 25.1.3 (#33280) ([23c378a](https://github.com/bitnami/charts/commit/23c378a148067ae0f4bbe5a519966d78ef26d425)), closes [#33280](https://github.com/bitnami/charts/issues/33280)
 
 ## <small>25.1.2 (2025-04-28)</small>
 

--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.5.4
+  version: 16.5.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:ee6c56e4038f63befcbcd87cc8e53b190467bda79b3a3d2fac62ba0f03106d9a
-generated: "2025-05-01T12:30:41.439046438Z"
+  version: 2.31.0
+digest: sha256:77415f87229cfa68e5cbd6e6ef9fd5eda54027d4f91eecd757bdead7dc8131b1
+generated: "2025-05-06T10:52:52.797553604+02:00"

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: parse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/parse
-version: 25.1.3
+version: 25.1.4

--- a/bitnami/parse/templates/ingress.yaml
+++ b/bitnami/parse/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.ingress.dashboard.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.dashboard.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.dashboard.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "parse.dashboard.fullname" .) "servicePort" "http-dashboard" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.dashboard.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "parse.dashboard.fullname" .) "servicePort" "http-dashboard" "context" $) | nindent 14 }}
     {{- end }}
   {{- end }}
@@ -52,9 +48,7 @@ spec:
           {{- toYaml .Values.ingress.server.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.server.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.server.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http-server" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.server.extraHosts }}
@@ -62,9 +56,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http-server" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
