### PR TITLE
[bitnami/pinniped] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/pinniped/CHANGELOG.md
+++ b/bitnami/pinniped/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.14 (2025-04-22)
+## 2.4.15 (2025-05-06)
 
-* [bitnami/pinniped] Release 2.4.14 ([#33118](https://github.com/bitnami/charts/pull/33118))
+* [bitnami/pinniped] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33421](https://github.com/bitnami/charts/pull/33421))
+
+## <small>2.4.14 (2025-04-22)</small>
+
+* [bitnami/pinniped] Release 2.4.14 (#33118) ([c5b0aa0](https://github.com/bitnami/charts/commit/c5b0aa03e762ba34ef1128066a2cd83ad179ae6e)), closes [#33118](https://github.com/bitnami/charts/issues/33118)
 
 ## <small>2.4.13 (2025-04-02)</small>
 

--- a/bitnami/pinniped/Chart.lock
+++ b/bitnami/pinniped/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-03-05T04:15:35.931235278Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T10:54:21.399255498+02:00"

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.4.14
+version: 2.4.15

--- a/bitnami/pinniped/templates/supervisor/ingress.yaml
+++ b/bitnami/pinniped/templates/supervisor/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.supervisor.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.supervisor.ingress.ingressClassName }}
   ingressClassName: {{ .Values.supervisor.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.supervisor.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.supervisor.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.supervisor.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "pinniped.supervisor.fullname" .) "servicePort" "https" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.supervisor.ingress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "pinniped.supervisor.fullname" $) "servicePort" "https" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.supervisor.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
