### PR TITLE
[bitnami/scylladb] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.0.1 (2025-05-01)
+## 4.0.2 (2025-05-06)
 
-* [bitnami/scylladb] Release 4.0.1 ([#33283](https://github.com/bitnami/charts/pull/33283))
+* [bitnami/scylladb] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33432](https://github.com/bitnami/charts/pull/33432))
+
+## <small>4.0.1 (2025-05-01)</small>
+
+* [bitnami/scylladb] Release 4.0.1 (#33283) ([379064a](https://github.com/bitnami/charts/commit/379064a0cd45ee361b356b558e18e305f687e528)), closes [#33283](https://github.com/bitnami/charts/issues/33283)
 
 ## 4.0.0 (2025-04-15)
 

--- a/bitnami/scylladb/Chart.lock
+++ b/bitnami/scylladb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:85748f67a5f7d7b1d8e36608bb0aae580ed522f65e17def2ccc88a5285992445
-generated: "2025-05-01T14:51:48.177240247Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:02:28.059027106+02:00"

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: scylladb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 4.0.1
+version: 4.0.2

--- a/bitnami/scylladb/templates/hpa.yaml
+++ b/bitnami/scylladb/templates/hpa.yaml
@@ -34,7 +34,6 @@ spec:
         name: cpu
         target:
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPUUtilizationPercentage }}
-          type: Utilization
   {{- end }}
   {{- if .Values.autoscaling.hpa.targetMemoryUtilizationPercentage }}
     - type: Resource
@@ -42,7 +41,6 @@ spec:
         name: memory
         target:
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemoryUtilizationPercentage }}
-          type: Utilization
   {{- end }}
   {{- if .Values.autoscaling.hpa.customRules -}}
     {{- toYaml .Values.autoscaling.hpa.customRules | nindent 4}}

--- a/bitnami/scylladb/templates/hpa.yaml
+++ b/bitnami/scylladb/templates/hpa.yaml
@@ -34,6 +34,7 @@ spec:
         name: cpu
         target:
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPUUtilizationPercentage }}
+          type: Utilization
   {{- end }}
   {{- if .Values.autoscaling.hpa.targetMemoryUtilizationPercentage }}
     - type: Resource
@@ -41,6 +42,7 @@ spec:
         name: memory
         target:
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemoryUtilizationPercentage }}
+          type: Utilization
   {{- end }}
   {{- if .Values.autoscaling.hpa.customRules -}}
     {{- toYaml .Values.autoscaling.hpa.customRules | nindent 4}}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
