### PR TITLE
[bitnami/spring-cloud-dataflow] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 37.0.1 (2025-05-06)
+
+* [bitnami/spring-cloud-dataflow] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33438](https://github.com/bitnami/charts/pull/33438))
+
 ## 37.0.0 (2025-04-29)
 
-* [bitnami/spring-cloud-dataflow] Major 37.0.0: Upgrade MariaDB to 11.4.x ([#33243](https://github.com/bitnami/charts/pull/33243))
+* [bitnami/spring-cloud-dataflow] Major 37.0.0: Upgrade MariaDB to 11.4.x (#33243) ([f3400ee](https://github.com/bitnami/charts/commit/f3400eecb2f39db9aec724fdd61cb279b4c9e6d3)), closes [#33243](https://github.com/bitnami/charts/issues/33243)
 
 ## <small>36.0.1 (2025-04-28)</small>
 

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.0
+  version: 16.0.1
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.5.3
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 32.2.1
+  version: 32.2.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:6d31b38885cd491a0b5fbbf102b986b7043c1811df8850edce74de154af57435
-generated: "2025-04-28T08:50:44.204869788Z"
+  version: 2.31.0
+digest: sha256:4da3111ba700f9c4b4fc9a9a6f7dba1386a0ca5ed5f73fb38b3d342ce35af10a
+generated: "2025-05-06T11:07:03.915688194+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -52,4 +52,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 37.0.0
+version: 37.0.1

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.metrics.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.metrics.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.metrics.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.metrics.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.metrics.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.server.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.server.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.server.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.server.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.server.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-server" (include "common.names.fullname" .)) "servicePort" "http" "context" $)  | nindent 14 }}
           {{- if .Values.server.ingress.extraPaths }}
           {{- include "common.tplvalues.render" (dict "value" .Values.server.ingress.extraPaths "context" $) | nindent 10 }}
@@ -42,9 +40,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-server" (include "common.names.fullname" $)) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.server.ingress.extraRules }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
@@ -28,24 +28,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.skipper.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.skipper.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.skipper.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.skipper.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.skipper.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
