### PR TITLE
[bitnami/thanos] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.0.4 (2025-04-22)
+## 16.0.5 (2025-05-06)
 
-* [bitnami/thanos] Release 16.0.4 ([#33109](https://github.com/bitnami/charts/pull/33109))
+* [bitnami/thanos] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33441](https://github.com/bitnami/charts/pull/33441))
+
+## <small>16.0.4 (2025-04-22)</small>
+
+* [bitnami/thanos] Release 16.0.4 (#33109) ([e88eeed](https://github.com/bitnami/charts/commit/e88eeed2db08e09cb06ba2cdbbaa5ab1a8d8f4fc)), closes [#33109](https://github.com/bitnami/charts/issues/33109)
 
 ## <small>16.0.3 (2025-04-09)</small>
 

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.7
+  version: 16.0.8
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:629cfbc3a12e63f2792f06ae97ea2f5657b5ad28a12cd368e53c0529733a1498
-generated: "2025-04-22T11:25:05.880492597Z"
+  version: 2.31.0
+digest: sha256:83ce41b46a870af4158fd69e1c160ee072ca5be3aaa7f4998a8dbf51a14ea0c2
+generated: "2025-05-06T11:09:24.602423833+02:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 16.0.4
+version: 16.0.5

--- a/bitnami/thanos/templates/bucketweb/hpa.yaml
+++ b/bitnami/thanos/templates/bucketweb/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.bucketweb.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.bucketweb.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.bucketweb.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.bucketweb.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.bucketweb.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.bucketweb.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.bucketweb.ingress.ingressClassName }}
   ingressClassName: {{ .Values.bucketweb.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.bucketweb.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.bucketweb.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "bucketweb") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.bucketweb.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "bucketweb") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.bucketweb.ingress.extraRules }}

--- a/bitnami/thanos/templates/compactor/ingress.yaml
+++ b/bitnami/thanos/templates/compactor/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.compactor.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.compactor.ingress.ingressClassName }}
   ingressClassName: {{ .Values.compactor.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.compactor.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.compactor.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "compactor") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.compactor.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "compactor") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.compactor.ingress.extraRules }}

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.queryFrontend.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.queryFrontend.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.queryFrontend.ingress.ingressClassName }}
   ingressClassName: {{ .Values.queryFrontend.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.queryFrontend.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.queryFrontend.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query-frontend") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.queryFrontend.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query-frontend") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.queryFrontend.ingress.extraRules }}

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -26,25 +26,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.query.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.query.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.query.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.query.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.query.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- range $targetPodMetric := .Values.query.autoscaling.targetPodMetrics }}
     - type: Pods

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.query.ingress.grpc.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.query.ingress.grpc.ingressClassName }}
   ingressClassName: {{ .Values.query.ingress.grpc.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -25,9 +25,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.query.ingress.grpc.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.query.ingress.grpc.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query-grpc") "servicePort" "grpc" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.query.ingress.grpc.extraHosts }}
@@ -35,9 +33,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query-grpc") "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.query.ingress.grpc.extraRules }}

--- a/bitnami/thanos/templates/query/ingress.yaml
+++ b/bitnami/thanos/templates/query/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.query.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.query.ingress.ingressClassName }}
   ingressClassName: {{ .Values.query.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.query.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.query.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.query.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.query.ingress.extraRules }}

--- a/bitnami/thanos/templates/receive-distributor/hpa.yaml
+++ b/bitnami/thanos/templates/receive-distributor/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.receiveDistributor.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.receiveDistributor.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.receiveDistributor.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.receiveDistributor.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.receiveDistributor.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.receive.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.receive.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.receive.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.receive.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.receive.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/ingress.yaml
+++ b/bitnami/thanos/templates/receive/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.receive.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.receive.ingress.ingressClassName }}
   ingressClassName: {{ .Values.receive.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,15 +26,11 @@ spec:
       http:
         paths:
           - path: /api/v1/receive
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.receive.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "remote" "context" $)  | nindent 14 }}
 
           - path: {{ .Values.receive.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.receive.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.receive.ingress.extraHosts }}
@@ -42,9 +38,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "receive") "servicePort" (default "http" .portName) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.receive.ingress.extraRules }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -317,12 +317,10 @@ spec:
         - name: data
           emptyDir: {}
   {{- else if and .Values.receive.persistence.enabled (not .Values.receive.persistence.existingClaim) }}
-  {{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" .) -}}
   {{- if .Values.receive.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.receive.persistentVolumeClaimRetentionPolicy.whenDeleted }}
     whenScaled: {{ .Values.receive.persistentVolumeClaimRetentionPolicy.whenScaled }}
-  {{- end }}
   {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/bitnami/thanos/templates/ruler/hpa.yaml
+++ b/bitnami/thanos/templates/ruler/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ruler.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ruler.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.ruler.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.ruler.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.ruler.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/ruler/ingress.yaml
+++ b/bitnami/thanos/templates/ruler/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ruler.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.ruler.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ruler.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.ruler.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ruler.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "ruler") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ruler.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "ruler") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ruler.ingress.extraRules }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -295,12 +295,10 @@ spec:
         - name: data
           emptyDir: {}
   {{- else if and .Values.ruler.persistence.enabled (not .Values.ruler.persistence.existingClaim) }}
-  {{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" .) -}}
   {{- if .Values.ruler.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.ruler.persistentVolumeClaimRetentionPolicy.whenDeleted }}
     whenScaled: {{ .Values.ruler.persistentVolumeClaimRetentionPolicy.whenScaled }}
-  {{- end }}
   {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
@@ -40,25 +40,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
-        targetAverageUtilization: {{ $.Values.storegateway.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ $.Values.storegateway.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if $.Values.storegateway.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" $) }}
-        targetAverageUtilization: {{ $.Values.storegateway.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ $.Values.storegateway.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 ---
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.storegateway.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.storegateway.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/storegateway/ingress-grpc.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.storegateway.ingress.grpc.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.storegateway.ingress.grpc.ingressClassName }}
   ingressClassName: {{ .Values.storegateway.ingress.grpc.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -25,9 +25,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.storegateway.ingress.grpc.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.storegateway.ingress.grpc.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "storegateway") "servicePort" "grpc" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.storegateway.ingress.grpc.extraHosts }}
@@ -35,9 +33,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "storegateway") "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.storegateway.ingress.grpc.extraRules }}

--- a/bitnami/thanos/templates/storegateway/ingress.yaml
+++ b/bitnami/thanos/templates/storegateway/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.storegateway.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.storegateway.ingress.ingressClassName }}
   ingressClassName: {{ .Values.storegateway.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.storegateway.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.storegateway.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "storegateway") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.storegateway.ingress.extraHosts }}
@@ -36,9 +34,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "storegateway") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.storegateway.ingress.extraRules }}

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -342,12 +342,10 @@ spec:
         - name: data
           emptyDir: {}
   {{- else if and $.Values.storegateway.persistence.enabled (not $.Values.storegateway.persistence.existingClaim) }}
-  {{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" $) -}}
   {{- if $.Values.storegateway.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ $.Values.storegateway.persistentVolumeClaimRetentionPolicy.whenDeleted }}
     whenScaled: {{ $.Values.storegateway.persistentVolumeClaimRetentionPolicy.whenScaled }}
-  {{- end }}
   {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -288,12 +288,10 @@ spec:
         - name: data
           emptyDir: {}
   {{- else if and .Values.storegateway.persistence.enabled (not .Values.storegateway.persistence.existingClaim) }}
-  {{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" .) -}}
   {{- if .Values.storegateway.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.storegateway.persistentVolumeClaimRetentionPolicy.whenDeleted }}
     whenScaled: {{ .Values.storegateway.persistentVolumeClaimRetentionPolicy.whenScaled }}
-  {{- end }}
   {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
