### PR TITLE
[bitnami/valkey] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.3 (2025-04-28)
+## 3.0.4 (2025-05-06)
 
-* [bitnami/valkey] Release 3.0.3 ([#33219](https://github.com/bitnami/charts/pull/33219))
+* [bitnami/valkey] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33443](https://github.com/bitnami/charts/pull/33443))
+
+## <small>3.0.3 (2025-04-28)</small>
+
+* [bitnami/valkey] Release 3.0.3 (#33219) ([d3fe92b](https://github.com/bitnami/charts/commit/d3fe92bf477d3d52bfc92b63fbcecce85ed50c6a)), closes [#33219](https://github.com/bitnami/charts/issues/33219)
 
 ## <small>3.0.2 (2025-04-23)</small>
 

--- a/bitnami/valkey/Chart.lock
+++ b/bitnami/valkey/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-20T08:10:35.25400622Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:10:52.127470134+02:00"

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: valkey
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/valkey/templates/_helpers.tpl
+++ b/bitnami/valkey/templates/_helpers.tpl
@@ -48,17 +48,6 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
-Return the appropriate apiGroup for PodSecurityPolicy.
-*/}}
-{{- define "podSecurityPolicy.apiGroup" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "policy" -}}
-{{- else -}}
-{{- print "extensions" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return true if a TLS secret object should be created
 */}}
 {{- define "valkey.createTlsSecret" -}}
@@ -216,7 +205,6 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "valkey.validateValues" -}}
 {{- $messages := list -}}
-{{- $messages := append $messages (include "valkey.validateValues.topologySpreadConstraints" .) -}}
 {{- $messages := append $messages (include "valkey.validateValues.architecture" .) -}}
 {{- $messages := append $messages (include "valkey.validateValues.podSecurityPolicy.create" .) -}}
 {{- $messages := append $messages (include "valkey.validateValues.tls" .) -}}
@@ -226,15 +214,6 @@ Compile all warnings into a single message, and call fail.
 
 {{- if $message -}}
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
-{{- end -}}
-{{- end -}}
-
-{{/* Validate values of Valkey - spreadConstrainsts K8s version */}}
-{{- define "valkey.validateValues.topologySpreadConstraints" -}}
-{{- if and (semverCompare "<1.16-0" .Capabilities.KubeVersion.GitVersion) .Values.replica.topologySpreadConstraints -}}
-valkey: topologySpreadConstraints
-    Pod Topology Spread Constraints are only available on K8s  >= 1.16
-    Find more information at https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -33,7 +33,7 @@ spec:
   {{- else }}
   updateStrategy: {{- toYaml .Values.primary.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and .Values.primary.minReadySeconds (semverCompare ">= 1.23-0" (include "common.capabilities.kubeVersion" .)) }}
+  {{- if .Values.primary.minReadySeconds }}
   minReadySeconds: {{ .Values.primary.minReadySeconds }}
   {{- end }}
   {{- end }}

--- a/bitnami/valkey/templates/primary/service.yaml
+++ b/bitnami/valkey/templates/primary/service.yaml
@@ -21,9 +21,7 @@ spec:
   {{- if or (eq .Values.primary.service.type "LoadBalancer") (eq .Values.primary.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.primary.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if (semverCompare ">=1.22-0" (include "common.capabilities.kubeVersion" .)) }}
   internalTrafficPolicy: {{ .Values.primary.service.internalTrafficPolicy }}
-  {{- end }}
   {{- if and (eq .Values.primary.service.type "LoadBalancer") (not (empty .Values.primary.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.primary.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.replica.updateStrategy }}
   updateStrategy: {{- toYaml .Values.replica.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and .Values.replica.minReadySeconds (semverCompare ">= 1.23-0" (include "common.capabilities.kubeVersion" .)) }}
+  {{- if .Values.replica.minReadySeconds }}
   minReadySeconds: {{ .Values.replica.minReadySeconds }}
   {{- end }}
   {{- if .Values.replica.podManagementPolicy }}

--- a/bitnami/valkey/templates/replicas/hpa.yaml
+++ b/bitnami/valkey/templates/replicas/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
     {{- if .Values.replica.autoscaling.hpa.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/valkey/templates/replicas/service.yaml
+++ b/bitnami/valkey/templates/replicas/service.yaml
@@ -21,9 +21,7 @@ spec:
   {{- if or (eq .Values.replica.service.type "LoadBalancer") (eq .Values.replica.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.replica.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if (semverCompare ">=1.22-0" (include "common.capabilities.kubeVersion" .)) }}
   internalTrafficPolicy: {{ .Values.replica.service.internalTrafficPolicy }}
-  {{- end }}
   {{- if and (eq .Values.replica.service.type "LoadBalancer") (not (empty .Values.replica.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.replica.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/valkey/templates/role.yaml
+++ b/bitnami/valkey/templates/role.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
   {{- if and (include "common.capabilities.psp.supported" .) .Values.podSecurityPolicy.enabled }}
   - apiGroups:
-      - '{{ template "podSecurityPolicy.apiGroup" . }}'
+      - 'policy'
     resources:
       - 'podsecuritypolicies'
     verbs:

--- a/bitnami/valkey/templates/sentinel/hpa.yaml
+++ b/bitnami/valkey/templates/sentinel/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.hpa.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.replica.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
   {{- if .Values.replica.updateStrategy }}
   updateStrategy: {{- toYaml .Values.replica.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and .Values.replica.minReadySeconds (semverCompare ">= 1.23-0" (include "common.capabilities.kubeVersion" .)) }}
+  {{- if .Values.replica.minReadySeconds }}
   minReadySeconds: {{ .Values.replica.minReadySeconds }}
   {{- end }}
   {{- if .Values.replica.podManagementPolicy }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
