### PR TITLE
[bitnami/valkey-cluster] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.4 (2025-04-29)
+## 3.0.5 (2025-05-06)
 
-* [bitnami/valkey-cluster] only use password files if auth is enabled ([#33239](https://github.com/bitnami/charts/pull/33239))
+* [bitnami/valkey-cluster] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33444](https://github.com/bitnami/charts/pull/33444))
+
+## <small>3.0.4 (2025-05-05)</small>
+
+* [bitnami/valkey-cluster] only use password files if auth is enabled (#33239) ([ce60ab6](https://github.com/bitnami/charts/commit/ce60ab65a82c5429d488eaf9fdb805915fd4af0a)), closes [#33239](https://github.com/bitnami/charts/issues/33239)
 
 ## <small>3.0.3 (2025-04-23)</small>
 

--- a/bitnami/valkey-cluster/Chart.lock
+++ b/bitnami/valkey-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-20T08:09:05.133881593Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:11:35.944797693+02:00"

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -34,4 +34,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 3.0.4
+version: 3.0.5

--- a/bitnami/valkey-cluster/templates/_helpers.tpl
+++ b/bitnami/valkey-cluster/templates/_helpers.tpl
@@ -41,28 +41,6 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for networkpolicy.
-*/}}
-{{- define "networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiGroup for PodSecurityPolicy.
-*/}}
-{{- define "podSecurityPolicy.apiGroup" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "policy" -}}
-{{- else -}}
-{{- print "extensions" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return true if a TLS secret object should be created
 */}}
 {{- define "valkey-cluster.createTlsSecret" -}}

--- a/bitnami/valkey-cluster/templates/networkpolicy.yaml
+++ b/bitnami/valkey-cluster/templates/networkpolicy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
-apiVersion: {{ template "networkPolicy.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
