### PR TITLE
[bitnami/victoriametrics] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/victoriametrics/CHANGELOG.md
+++ b/bitnami/victoriametrics/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.7 (2025-04-28)
+## 0.1.8 (2025-05-06)
 
-* [bitnami/victoriametrics] Release 0.1.7 ([#33227](https://github.com/bitnami/charts/pull/33227))
+* [bitnami/victoriametrics] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33446](https://github.com/bitnami/charts/pull/33446))
+
+## <small>0.1.7 (2025-04-28)</small>
+
+* [bitnami/victoriametrics] Release 0.1.7 (#33227) ([6b82b9e](https://github.com/bitnami/charts/commit/6b82b9ea3a395d422942b1670cd97ec2050294bd)), closes [#33227](https://github.com/bitnami/charts/issues/33227)
 
 ## <small>0.1.6 (2025-04-09)</small>
 

--- a/bitnami/victoriametrics/Chart.lock
+++ b/bitnami/victoriametrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-19T17:49:42.26973044Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:13:02.52964167+02:00"

--- a/bitnami/victoriametrics/Chart.yaml
+++ b/bitnami/victoriametrics/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: victoriametrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/victoriametrics
-version: 0.1.7
+version: 0.1.8

--- a/bitnami/victoriametrics/templates/vmagent/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vmagent/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmagent.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmagent.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vmagent.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmagent.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmagent.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/victoriametrics/templates/vmalert/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vmalert/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmalert.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmalert.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vmalert.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmalert.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmalert.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/victoriametrics/templates/vmauth/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vmauth/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmauth.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmauth.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vmauth.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmauth.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmauth.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/victoriametrics/templates/vmauth/ingress.yaml
+++ b/bitnami/victoriametrics/templates/vmauth/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.vmauth.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.vmauth.ingress.ingressClassName }}
   ingressClassName: {{ .Values.vmauth.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.vmauth.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.vmauth.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.vmauth.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vmauth.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.vmauth.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vmauth.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.vmauth.ingress.extraRules }}

--- a/bitnami/victoriametrics/templates/vminsert/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vminsert/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vminsert.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vminsert.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vminsert.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vminsert.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vminsert.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/victoriametrics/templates/vminsert/ingress.yaml
+++ b/bitnami/victoriametrics/templates/vminsert/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.vminsert.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.vminsert.ingress.ingressClassName }}
   ingressClassName: {{ .Values.vminsert.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.vminsert.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.vminsert.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.vminsert.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vminsert.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.vminsert.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vminsert.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.vminsert.ingress.extraRules }}

--- a/bitnami/victoriametrics/templates/vmselect/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vmselect/hpa.yaml
@@ -32,24 +32,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmselect.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmselect.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vmselect.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmselect.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmselect.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/victoriametrics/templates/vmselect/ingress.yaml
+++ b/bitnami/victoriametrics/templates/vmselect/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.vmselect.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.vmselect.ingress.ingressClassName }}
   ingressClassName: {{ .Values.vmselect.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.vmselect.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.vmselect.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.vmselect.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vmselect.fullname" . | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.vmselect.ingress.extraHosts }}
@@ -39,9 +37,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "victoriametrics.vmselect.fullname" $ | trunc 63 | trimSuffix "-") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.vmselect.ingress.extraRules }}

--- a/bitnami/victoriametrics/templates/vmstorage/hpa.yaml
+++ b/bitnami/victoriametrics/templates/vmstorage/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmstorage.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmstorage.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.vmstorage.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.vmstorage.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.vmstorage.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
