### PR TITLE
[bitnami/whereabouts] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/whereabouts/CHANGELOG.md
+++ b/bitnami/whereabouts/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.2.9 (2025-04-09)
+## 1.2.10 (2025-05-06)
 
-* [bitnami/whereabouts] Release 1.2.9 ([#32923](https://github.com/bitnami/charts/pull/32923))
+* [bitnami/whereabouts] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33447](https://github.com/bitnami/charts/pull/33447))
+
+## <small>1.2.9 (2025-04-09)</small>
+
+* [bitnami/whereabouts] Release 1.2.9 (#32923) ([b2da8b0](https://github.com/bitnami/charts/commit/b2da8b0769f2569f2d1afa16ea0d63c68ed98f08)), closes [#32923](https://github.com/bitnami/charts/issues/32923)
 
 ## <small>1.2.8 (2025-04-03)</small>
 

--- a/bitnami/whereabouts/Chart.lock
+++ b/bitnami/whereabouts/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-20T09:19:26.026522991Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:13:46.576737243+02:00"

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: whereabouts
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/whereabouts
-version: 1.2.9
+version: 1.2.10


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
