### PR TITLE
[bitnami/wordpress] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.2.4 (2025-04-30)
+## 24.2.5 (2025-05-06)
 
-* [bitnami/wordpress] Release 24.2.4 ([#33275](https://github.com/bitnami/charts/pull/33275))
+* [bitnami/wordpress] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33449](https://github.com/bitnami/charts/pull/33449))
+
+## <small>24.2.4 (2025-04-30)</small>
+
+* [bitnami/wordpress] Release 24.2.4 (#33275) ([91e8cda](https://github.com/bitnami/charts/commit/91e8cda781e3c04f9692cb0e76e2dc76c28e352c)), closes [#33275](https://github.com/bitnami/charts/issues/33275)
 
 ## <small>24.2.3 (2025-04-23)</small>
 

--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 20.5.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.2
-digest: sha256:32dd2d2e7fcb8a049c70cbc3acc187553e0b1810c282bc30c705725d14e063b3
-generated: "2025-04-30T21:39:51.769933982Z"
+  version: 2.31.0
+digest: sha256:8e350eb9cf38dec85c6865b63704751c095a2cd8497973d726b6955d281555c7
+generated: "2025-05-06T11:15:14.599398611+02:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -45,4 +45,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 24.2.4
+version: 24.2.5

--- a/bitnami/wordpress/templates/hpa.yaml
+++ b/bitnami/wordpress/templates/hpa.yaml
@@ -25,24 +25,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/wordpress/templates/ingress-secondary.yaml
+++ b/bitnami/wordpress/templates/ingress-secondary.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.secondaryIngress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.secondaryIngress.ingressClassName }}
   ingressClassName: {{ .Values.secondaryIngress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.secondaryIngress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.secondaryIngress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.secondaryIngress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.secondaryIngress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.secondaryIngress.extraRules }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
