### PR TITLE
[bitnami/zipkin] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/zipkin/CHANGELOG.md
+++ b/bitnami/zipkin/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.3.3 (2025-04-27)
+## 1.3.4 (2025-05-06)
 
-* [bitnami/zipkin] Release 1.3.3 ([#33199](https://github.com/bitnami/charts/pull/33199))
+* [bitnami/zipkin] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33450](https://github.com/bitnami/charts/pull/33450))
+
+## <small>1.3.3 (2025-04-27)</small>
+
+* [bitnami/zipkin] Release 1.3.3 (#33199) ([2c6e421](https://github.com/bitnami/charts/commit/2c6e421d6500787ff96e29da085f42abc5ba074c)), closes [#33199](https://github.com/bitnami/charts/issues/33199)
 
 ## <small>1.3.2 (2025-04-17)</small>
 

--- a/bitnami/zipkin/Chart.lock
+++ b/bitnami/zipkin/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.3.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:a2c2e139a194aaa98cecd70f0627d3d793508362b4d7607e3bd6f1e8a8db4d2c
-generated: "2025-04-27T21:01:53.508622981Z"
+  version: 2.31.0
+digest: sha256:1f1fc68c858ff81ca7d67353759854fbdbb358ccf1b0bb613abff48856692dc4
+generated: "2025-05-06T11:16:01.955320193+02:00"

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
 - https://github.com/bitnami/containers/tree/main/bitnami/zipkin
 - https://github.com/openzipkin/zipkin
-version: 1.3.3
+version: 1.3.4

--- a/bitnami/zipkin/templates/hpa.yaml
+++ b/bitnami/zipkin/templates/hpa.yaml
@@ -27,24 +27,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/zipkin/templates/ingress.yaml
+++ b/bitnami/zipkin/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -29,9 +29,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" (ternary "https" "http" .Values.tls.enabled) "context" $)  | nindent 14 }}
     {{- else if .Values.ingress.path }}
     - http:
@@ -40,9 +38,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" (ternary "https" "http" .Values.tls.enabled) "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -50,9 +46,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" (ternary "https" "http" .Values.tls.enabled) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
