### PR TITLE
[bitnami/zookeeper] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references

### DIFF
--- a/bitnami/zookeeper/CHANGELOG.md
+++ b/bitnami/zookeeper/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 13.8.1 (2025-04-28)
+## 13.8.2 (2025-05-06)
 
-* [bitnami/zookeeper] Release 13.8.1 ([#33224](https://github.com/bitnami/charts/pull/33224))
+* [bitnami/zookeeper] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33451](https://github.com/bitnami/charts/pull/33451))
+
+## <small>13.8.1 (2025-04-28)</small>
+
+* [bitnami/zookeeper] Release 13.8.1 (#33224) ([b0baf91](https://github.com/bitnami/charts/commit/b0baf91deede6a070a5305a80100d31ec3881f27)), closes [#33224](https://github.com/bitnami/charts/issues/33224)
+* Fix typo mentioning Geode in Solr and Zookeeper (#32987) ([9dd4289](https://github.com/bitnami/charts/commit/9dd42891c2c9f5ed339e5dbc1506a13f29e0d45c)), closes [#32987](https://github.com/bitnami/charts/issues/32987)
 
 ## 13.8.0 (2025-04-07)
 

--- a/bitnami/zookeeper/Chart.lock
+++ b/bitnami/zookeeper/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.30.0
-digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
-generated: "2025-02-27T16:39:44.896564956Z"
+  version: 2.31.0
+digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
+generated: "2025-05-06T11:16:45.906774755+02:00"

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 13.8.1
+version: 13.8.2


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <javier.salmeron@broadcom.com>

### Description of the change

This PR removes references to old, non-supported, Kubernetes versions (<1.23) in the YAML files. The minimum Kubernetes version was bumped to 1.23 a year and a half ago in https://github.com/bitnami/charts/pull/19745, so we do not expect major issues.

### Benefits

Better maintainability of the YAML templates

### Possible drawbacks

Potentially breaking those users that ig

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
