### PR TITLE
[bitnami/nginx-ingress-controller] chore: :recycle: Remove extra unnecessary k8s version checks

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 11.6.18
+version: 11.6.19

--- a/bitnami/nginx-ingress-controller/templates/_helpers.tpl
+++ b/bitnami/nginx-ingress-controller/templates/_helpers.tpl
@@ -67,23 +67,3 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiGroup for PodSecurityPolicy.
-*/}}
-{{- define "nginx-ingress-controller.podSecurityPolicy.apiGroup" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "policy" -}}
-{{- else -}}
-{{- print "extensions" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Require extensions API group based on Kubernetes version
-*/}}
-{{- define "nginx-ingress-controller.role.extensions.apiGroup" -}}
-{{- if semverCompare "<1.16-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "- extensions" -}}
-{{- end -}}
-{{- end -}}

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -60,7 +60,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      {{- include "nginx-ingress-controller.role.extensions.apiGroup" . | nindent 6 }}
       - networking.k8s.io
     resources:
       - ingresses
@@ -76,14 +75,12 @@ rules:
       - create
       - patch
   - apiGroups:
-      {{- include "nginx-ingress-controller.role.extensions.apiGroup" . | nindent 6 }}
       - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
       - update
   - apiGroups:
-      {{- include "nginx-ingress-controller.role.extensions.apiGroup" . | nindent 6 }}
       - networking.k8s.io
     resources:
       - ingressclasses

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -41,7 +41,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      {{- include "nginx-ingress-controller.role.extensions.apiGroup" . | nindent 6 }}
       - networking.k8s.io
     resources:
       - ingresses
@@ -50,7 +49,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      {{- include "nginx-ingress-controller.role.extensions.apiGroup" . | nindent 6 }}
       - networking.k8s.io
     resources:
       - ingresses/status
@@ -91,7 +89,7 @@ rules:
   {{- end }}
   {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
   {{- if and $pspAvailable .Values.podSecurityPolicy.enabled }}
-  - apiGroups: [{{ template "nginx-ingress-controller.podSecurityPolicy.apiGroup" . }}]
+  - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames: [{{ template "common.names.fullname" . }}]


### PR DESCRIPTION
### Description of the change

This PR is a follow up of https://github.com/bitnami/charts/pull/33414, adding extra k8s version check removals
