### PR TITLE
[bitnami/superset] fix(wait-for-examples): Support 429 errors in examples load

### DIFF
--- a/.vib/superset/goss/goss.yaml
+++ b/.vib/superset/goss/goss.yaml
@@ -5,12 +5,12 @@ http:
   http://superset-web:{{ .Vars.web.service.ports.http }}/health:
     status: 200
     body:
-      - /OK/
+      - OK
   http://127.0.0.1:{{ .Vars.web.containerPorts.http }}/health:
     status: 200
     timeout: 10000
     body:
-      - /OK/
+      - OK
   http://{{ .Vars.flower.auth.username }}:{{ .Vars.flower.auth.password }}@superset-flower:{{ .Vars.flower.service.ports.flower }}:
     status: 200
 file:

--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.1 (2025-04-28)
+## 2.0.2 (2025-05-06)
 
-* [bitnami/superset] Release 2.0.1 ([#33222](https://github.com/bitnami/charts/pull/33222))
+* [bitnami/superset] fix(wait-for-examples): Support 429 errors in examples load ([#33458](https://github.com/bitnami/charts/pull/33458))
+
+## <small>2.0.1 (2025-04-28)</small>
+
+* [bitnami/superset] Release 2.0.1 (#33222) ([20821a5](https://github.com/bitnami/charts/commit/20821a5961f08a9db2dd9ecb2ac62a1cfad60c51)), closes [#33222](https://github.com/bitnami/charts/issues/33222)
 
 ## 2.0.0 (2025-04-04)
 

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
 - https://github.com/bitnami/containers/tree/main/bitnami/superset
 - https://github.com/apache/superset
-version: 2.0.1
+version: 2.0.2

--- a/bitnami/superset/templates/_helpers.tpl
+++ b/bitnami/superset/templates/_helpers.tpl
@@ -405,11 +405,13 @@ Init container definition to wait for Redis
         {{- end }}
 
         check_examples_database() {
-            echo "SELECT dashboard_title FROM dashboards" | postgresql_remote_execute_print_output "$SUPERSET_DATABASE_HOST" "$SUPERSET_DATABASE_PORT_NUMBER" "$SUPERSET_DATABASE_NAME" "$SUPERSET_DATABASE_USER" "$SUPERSET_DATABASE_PASSWORD" | grep "Dashboard"
+            # deck.gl Demo is one of the latest dashboards loaded.
+            echo "SELECT dashboard_title FROM dashboards" | postgresql_remote_execute_print_output "$SUPERSET_DATABASE_HOST" "$SUPERSET_DATABASE_PORT_NUMBER" "$SUPERSET_DATABASE_NAME" "$SUPERSET_DATABASE_USER" "$SUPERSET_DATABASE_PASSWORD" | grep "deck.gl Demo"
         }
 
         info "Checking if the 'examples' database exists at $SUPERSET_DATABASE_HOST:$SUPERSET_DATABASE_PORT_NUMBER"
-        if ! retry_while "check_examples_database"; then
+        # Retry 5 min
+        if ! retry_while "check_examples_database" 60; then
             error "Examples database not ready yet"
             exit 1
         else

--- a/bitnami/superset/templates/init/init-job.yaml
+++ b/bitnami/superset/templates/init/init-job.yaml
@@ -68,6 +68,8 @@ spec:
             {{- include "superset.configure.common" . | nindent 12 }}
             {{- include "superset.configure.database" . | nindent 12 }}
             {{- include "superset.configure.redis" . | nindent 12 }}
+            - name: BITNAMI_DEBUG
+              value: "yes"
             - name: SUPERSET_ROLE
               value: "init"
             - name: SUPERSET_USERNAME

--- a/bitnami/superset/templates/init/init-job.yaml
+++ b/bitnami/superset/templates/init/init-job.yaml
@@ -68,8 +68,6 @@ spec:
             {{- include "superset.configure.common" . | nindent 12 }}
             {{- include "superset.configure.database" . | nindent 12 }}
             {{- include "superset.configure.redis" . | nindent 12 }}
-            - name: BITNAMI_DEBUG
-              value: "yes"
             - name: SUPERSET_ROLE
               value: "init"
             - name: SUPERSET_USERNAME

--- a/bitnami/superset/templates/web/deployment.yaml
+++ b/bitnami/superset/templates/web/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         {{- if .Values.defaultInitContainers.waitForRedis.enabled }}
         {{- include "superset.initContainers.waitForRedis" . | nindent 8 }}
         {{- end }}
-        {{- if and .Values.web.waitForExamples.enabled .Values.loadExamples }}
+        {{- if and .Values.init.enabled .Values.web.waitForExamples.enabled .Values.loadExamples }}
         {{- include "superset.initContainers.waitForExamples" . | nindent 8 }}
         {{- end }}
         {{- if .Values.web.initContainers }}


### PR DESCRIPTION
### Description of the change

The init job is taking too long due to 429 HTTP errors when the value `loadExamples` is set. Examples database is downloaded from github making several requests. The initialization process could take about 5 min.

### Benefits

Superset web pods will start once the examples are completely loaded without errors or retries.

### Possible drawbacks

None

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
