### PR TITLE
[bitnami/redis] fix pod-monitor podTargetLabels conditional 

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 21.0.1 (2025-05-06)
+
+* [bitnami/redis] fix pod-monitor podTargetLabels conditional  ([#33459](https://github.com/bitnami/charts/pull/33459))
+
 ## 21.0.0 (2025-05-06)
 
-* [bitnami/redis] Release 21.0.0 ([#33455](https://github.com/bitnami/charts/pull/33455))
+* [bitnami/redis] Release 21.0.0 (#33455) ([41b5013](https://github.com/bitnami/charts/commit/41b5013934cca7b8ab2c301bdc680fa770a1684d)), closes [#33455](https://github.com/bitnami/charts/issues/33455)
 
 ## <small>20.13.4 (2025-04-30)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 21.0.0
+version: 21.0.1

--- a/bitnami/redis/templates/podmonitor.yaml
+++ b/bitnami/redis/templates/podmonitor.yaml
@@ -64,7 +64,7 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-  {{- if .Values.metrics.serviceMonitor.podTargetLabels }}
+  {{- if .Values.metrics.podMonitor.podTargetLabels }}
   podTargetLabels: {{- toYaml .Values.metrics.podMonitor.podTargetLabels | nindent 4 }}
   {{- end }}
   {{- with .Values.metrics.podMonitor.sampleLimit -}}


### PR DESCRIPTION
### Description of the change
The PodMonitor template was mistakenly checking for
```
.Values.metrics.serviceMonitor.podTargetLabels
```
instead of
```
.Values.metrics.podMonitor.podTargetLabels
```
As a result, any podTargetLabels defined under metrics.podMonitor were ignored.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
