### PR TITLE
[bitnami/nats] Add link to official NATS chart in README

### DIFF
--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -8,6 +8,8 @@ NATS is an open source, lightweight and high-performance messaging system. It is
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+The official NATS Helm Chart is maintained [here](https://github.com/nats-io/k8s/tree/main/helm/charts/nats)
+
 ## TL;DR
 
 ```console


### PR DESCRIPTION
### Description of the change

Updates the README Overview section with a link to the NATS official Helm Chart

### Benefits

Gives users additional context when choosing a helm chart

### Possible drawbacks

None really.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
