### PR TITLE
[bitnami/common] chore: :recycle: Remove unused helpers

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.31.1 (2025-05-07)
+
+* [bitnami/common] chore: :recycle: Remove unused helpers ([#33496](https://github.com/bitnami/charts/pull/33496))
+
 ## 2.31.0 (2025-05-05)
 
-* [bitnami/common] chore: :recycle: Remove deprecated APIs (<1.23.0) ([#33320](https://github.com/bitnami/charts/pull/33320))
+* [bitnami/common] chore: :recycle: Remove deprecated APIs (<1.23.0) (#33320) ([3826a9e](https://github.com/bitnami/charts/commit/3826a9e1488c12545f11cf8cb1a11d23daf90602)), closes [#33320](https://github.com/bitnami/charts/issues/33320)
 
 ## <small>2.30.2 (2025-04-30)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.31.0
+appVersion: 2.31.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.31.0
+version: 2.31.1

--- a/bitnami/common/templates/_ingress.tpl
+++ b/bitnami/common/templates/_ingress.tpl
@@ -28,26 +28,6 @@ service:
 {{- end -}}
 
 {{/*
-TODO: Remove as soon it is removed from the rest of the charts
-Print "true" if the API pathType field is supported
-Usage:
-{{ include "common.ingress.supportsPathType" . }}
-*/}}
-{{- define "common.ingress.supportsPathType" -}}
-{{- print "true" -}}
-{{- end -}}
-
-{{/*
-TODO: Remove as soon it is removed from the rest of the charts
-Returns true if the ingressClassname field is supported
-Usage:
-{{ include "common.ingress.supportsIngressClassname" . }}
-*/}}
-{{- define "common.ingress.supportsIngressClassname" -}}
-{{- print "true" -}}
-{{- end -}}
-
-{{/*
 Return true if cert-manager required annotations for TLS signed
 certificates are set in the Ingress annotations
 Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations


### PR DESCRIPTION
### Description of the change

Follow up of https://github.com/bitnami/charts/pull/33320/. We remove these two helpers as they are not being used anymore.

### Benefits

Cleaner code

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
