### PR TITLE
[bitnami/appsmith] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/appsmith/CHANGELOG.md
+++ b/bitnami/appsmith/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.2.11 (2025-05-06)
+## 6.0.0 (2025-05-07)
 
-* [bitnami/appsmith] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33336](https://github.com/bitnami/charts/pull/33336))
+* [bitnami/appsmith] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33497](https://github.com/bitnami/charts/pull/33497))
+
+## <small>5.2.11 (2025-05-06)</small>
+
+* [bitnami/appsmith] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references (#3333 ([261a251](https://github.com/bitnami/charts/commit/261a2519c584fb942b26ab2dbf5fd230607a9483)), closes [#33336](https://github.com/bitnami/charts/issues/33336)
 
 ## <small>5.2.10 (2025-04-30)</small>
 

--- a/bitnami/appsmith/Chart.lock
+++ b/bitnami/appsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.5.5
+  version: 16.5.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:1566b0b03f6cb35d1e1d48553fc77600de4581715667a9ac08641858e8da9f1a
-generated: "2025-05-06T09:51:34.18454322+02:00"
+digest: sha256:dcc82b34b9f1794f66da1edde5db04aaf9dbb7bc7ed1d7f6a3f0c5da701409ac
+generated: "2025-05-07T11:24:31.961889891+02:00"

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
+  version: 21.x.x
 - condition: mongodb.enabled
   name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -40,4 +40,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 5.2.11
+version: 6.0.0

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -757,6 +757,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 6.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 5.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
