### PR TITLE
[bitnami/discourse] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.1.15 (2025-05-06)
+## 16.0.0 (2025-05-07)
 
-* [bitnami/discourse] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33352](https://github.com/bitnami/charts/pull/33352))
+* [bitnami/discourse] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33501](https://github.com/bitnami/charts/pull/33501))
+
+## <small>15.1.15 (2025-05-06)</small>
+
+* [bitnami/discourse] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references (#333 ([7947c69](https://github.com/bitnami/charts/commit/7947c69dd2d9a0a262e430cbb48683d8ee95ef45)), closes [#33352](https://github.com/bitnami/charts/issues/33352)
+* [bitnami/discourse] Release 15.1.14 (#33241) ([bceff0f](https://github.com/bitnami/charts/commit/bceff0fcc3f5c0091ba103662bc540cf6ccdd3a4)), closes [#33241](https://github.com/bitnami/charts/issues/33241)
 
 ## <small>15.1.13 (2025-04-09)</small>
 

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
+  version: 16.6.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:5c3c11245a8023df821d6dd5a25713838d25f09ef494759c8459d30f1f841a2e
-generated: "2025-05-06T10:03:28.512733692+02:00"
+digest: sha256:d3803d9c5e0e8a6fe50d8dbc85d72ce33beb9fb574a21ad5940b5e8dd830534e
+generated: "2025-05-07T11:33:52.653405646+02:00"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.X.X
+  version: 21.X.X
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -42,4 +42,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 15.1.15
+version: 16.0.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -577,6 +577,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 16.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 15.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
