### PR TITLE
[bitnami/kubeapps] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/kubeapps/CHANGELOG.md
+++ b/bitnami/kubeapps/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.1.7 (2025-05-06)
+## 18.0.0 (2025-05-07)
 
-* [bitnami/kubeapps] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33389](https://github.com/bitnami/charts/pull/33389))
+* [bitnami/kubeapps] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33503](https://github.com/bitnami/charts/pull/33503))
+
+## <small>17.1.7 (2025-05-06)</small>
+
+* [bitnami/kubeapps] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references (#3338 ([4041a6e](https://github.com/bitnami/charts/commit/4041a6ea2e1c7fac693ce41beb3a0c997725570d)), closes [#33389](https://github.com/bitnami/charts/issues/33389)
 
 ## <small>17.1.6 (2025-04-28)</small>
 

--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
+  version: 16.6.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:380c7086ef98bd02a751760d24fbfe9347af71827c02af67041d6f0ead00a47c
-generated: "2025-05-06T10:31:08.903047384+02:00"
+digest: sha256:30702f92dde84a443aac153d020956fd890e59a321a79ca550388b06c4b785d3
+generated: "2025-05-07T11:39:19.157297651+02:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
 - condition: packaging.flux.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
+  version: 21.x.x
 - condition: packaging.helm.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -53,4 +53,4 @@ maintainers:
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 17.1.7
+version: 18.0.0

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -1017,6 +1017,10 @@ Feel free to [open an issue](https://github.com/vmware-tanzu/kubeapps/issues/new
 
 ## Upgrading
 
+### To 18.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 17.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850). Kubeapps


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

