### PR TITLE
[bitnami/mastodon] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.0.2 (2025-05-06)
+## 12.0.0 (2025-05-07)
 
-* [bitnami/mastodon] Release 11.0.2 ([#33463](https://github.com/bitnami/charts/pull/33463))
+* [bitnami/mastodon] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33505](https://github.com/bitnami/charts/pull/33505))
+
+## <small>11.0.2 (2025-05-06)</small>
+
+* [bitnami/mastodon] Release 11.0.2 (#33463) ([336ac7a](https://github.com/bitnami/charts/commit/336ac7a11f3751e2c1570b084530007e68cc708c)), closes [#33463](https://github.com/bitnami/charts/issues/33463)
 
 ## <small>11.0.1 (2025-05-06)</small>
 

--- a/bitnami/mastodon/Chart.lock
+++ b/bitnami/mastodon/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
+  version: 16.6.7
 - name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 22.0.1
+  version: 22.0.2
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.0.8
 - name: apache
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.3.6
+  version: 11.3.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:dc31c493cd18c5590c24505bafd5a61047f0082b5cbfb294e7c890af075e45c0
-generated: "2025-05-06T10:35:35.476418141+02:00"
+digest: sha256:00f73d6d20301c9e40e3f8eb3670908369df1a3c2f287924bf2f928c89e49233
+generated: "2025-05-07T11:40:39.862482058+02:00"

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
+  version: 21.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -51,4 +51,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 11.0.2
+version: 12.0.0

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -887,6 +887,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 12.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 11.0.0
 
 This major updates the `elasticsearch` subchart to its newest major, 22.0.0, which uses Elasticsearch 9.x. For more information on this subchart's major, please refer to [elasticsearch upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch#to-2200).


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
