### PR TITLE
[bitnami/oauth2-proxy] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/oauth2-proxy/CHANGELOG.md
+++ b/bitnami/oauth2-proxy/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.2.14 (2025-05-07)
+## 7.0.0 (2025-05-07)
 
-* [bitnami/oauth2-proxy] Release 6.2.14 ([#33487](https://github.com/bitnami/charts/pull/33487))
+* [bitnami/oauth2-proxy] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33507](https://github.com/bitnami/charts/pull/33507))
+
+## <small>6.2.14 (2025-05-07)</small>
+
+* [bitnami/oauth2-proxy] Release 6.2.14 (#33487) ([a4f0f8d](https://github.com/bitnami/charts/commit/a4f0f8d94ef4b7efc07f32c6a83eb9b72904718c)), closes [#33487](https://github.com/bitnami/charts/issues/33487)
 
 ## <small>6.2.13 (2025-05-06)</small>
 

--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:f66e36628e6e3cd92e6f5ecd95854e5e3f8679a19f6e6176a912baa5ef5d2981
-generated: "2025-05-06T10:50:37.877860277+02:00"
+digest: sha256:8d2509e8c5d53598707d3a9ab4ae5bac2ce85f5c1c52aeb8397f1f08534921f4
+generated: "2025-05-07T11:42:09.670278992+02:00"

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
+  version: 21.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -38,4 +38,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 6.2.14
+version: 7.0.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -381,6 +381,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 7.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 6.2.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
