### PR TITLE
[bitnami/superset] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0

### DIFF
--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.3 (2025-05-07)
+## 3.0.0 (2025-05-07)
 
-* [bitnami/superset] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references ([#33439](https://github.com/bitnami/charts/pull/33439))
+* [bitnami/superset] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33512](https://github.com/bitnami/charts/pull/33512))
+
+## <small>2.0.3 (2025-05-07)</small>
+
+* [bitnami/superset] chore: :recycle: :arrow_up: Update common and remove k8s < 1.23 references (#3343 ([579785a](https://github.com/bitnami/charts/commit/579785a27121c71fe803e31fdf1b3071c2cc62a5)), closes [#33439](https://github.com/bitnami/charts/issues/33439) [#33402](https://github.com/bitnami/charts/issues/33402)
 
 ## <small>2.0.2 (2025-05-06)</small>
 

--- a/bitnami/superset/Chart.lock
+++ b/bitnami/superset/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
+  version: 21.0.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
+  version: 16.6.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.0
-digest: sha256:4e96e7deb3123f109d43507a618b2b9b45e84cdffece913eb3d85c6a6acd926c
-generated: "2025-05-06T11:07:51.488851669+02:00"
+digest: sha256:d023829727da5c3e903ce8395aac7b71e772dffdccda5adbd3a7814b95fd6466
+generated: "2025-05-07T12:38:27.091111714+02:00"

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
+  version: 21.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
 - https://github.com/bitnami/containers/tree/main/bitnami/superset
 - https://github.com/apache/superset
-version: 2.0.3
+version: 3.0.0

--- a/bitnami/superset/README.md
+++ b/bitnami/superset/README.md
@@ -742,6 +742,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 3.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 2.0.0
 
 This version replaces the value `flower.auth.usePasswordFiles` with the new value `usePasswordFiles`. When using `usePasswordFiles=true`, , all credentials will be mounted as files instead of using an environment variable.


### PR DESCRIPTION
### Description of the change

This PR bumps the `redis` subchart to its latest version, 21.x.x, which includes Redis&reg; 8.0. No major issues are expected during the upgrade.

### Benefits

Latest version of `redis`, which has significant performance improvements.

### Possible drawbacks

In some specific scenarios, a manual upgrade may be necessary.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
