### PR TITLE
[bitnami/template] chore: :recycle: Remove deprecated APIs (<1.23.0)

### DIFF
--- a/template/CHART_NAME/templates/hpa.yaml
+++ b/template/CHART_NAME/templates/hpa.yaml
@@ -26,24 +26,16 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetMemory  }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetMemory }}
-        {{- end }}
     {{- end }}
     {{- if .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetCPU }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetCPU }}
-        {{- else }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetCPU }}
-        {{- end }}
     {{- end }}
 {{- end }}

--- a/template/CHART_NAME/templates/ingress.yaml
+++ b/template/CHART_NAME/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -28,9 +28,7 @@ spec:
           {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -38,9 +36,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}


### PR DESCRIPTION
### Description of the change

This PR updates the templates to not contain references to unsupported k8s versions 
