### PR TITLE
[bitnami/redis] Allow grabbing sentinel acl configuration from userSecret

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.0.4 (2025-05-13)
+## 21.1.0 (2025-05-13)
 
-* [bitnami/redis] :zap: :arrow_up: Update dependency references ([#33666](https://github.com/bitnami/charts/pull/33666))
+* [bitnami/redis] Allow grabbing sentinel acl configuration from userSecret ([#33546](https://github.com/bitnami/charts/pull/33546))
+
+## <small>21.0.4 (2025-05-13)</small>
+
+* [bitnami/redis] :zap: :arrow_up: Update dependency references (#33666) ([36dbe42](https://github.com/bitnami/charts/commit/36dbe424f82e0f8b28601ec0bd13610702a8599e)), closes [#33666](https://github.com/bitnami/charts/issues/33666)
 
 ## <small>21.0.3 (2025-05-13)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 21.0.4
+version: 21.1.0

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -83,12 +83,15 @@ data:
       sentinel client-reconfig-script {{ .Values.sentinel.masterSet }} /opt/bitnami/scripts/start-scripts/push-master-label.sh
     {{- end }}
     {{- if .Values.auth.acl.sentinel }}
-    {{- range .Values.auth.acl.users }}
+    {{- $userSecret := .Values.auth.acl.userSecret -}}
     # Sentinel ACL configuration, only for users with password
-    {{ if .password }}
-    user {{ .username }} {{ default "on" .enabled }} {{ if .password }}#{{ sha256sum .password }}{{ else }}nopass{{ end }} ~* &* +@all
+    {{- range .Values.auth.acl.users }}
+    {{- $userPassword := .password | default "" }}
+    {{- $secretPassword := ternary "" (include "common.secrets.get" (dict "secret" $userSecret "key" .username "context" $)) (empty $userSecret) }}
+    {{ if or $userPassword $secretPassword }}
+    user {{ .username }} {{ default "on" .enabled }} #{{ coalesce $secretPassword $userPassword | sha256sum }} ~* &* +@all
     sentinel sentinel-user {{ .username }}
-    sentinel sentinel-pass {{ .password }} 
+    sentinel sentinel-pass {{ coalesce $secretPassword $userPassword }}
     {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allow grabbing sentinel acl configuration from `auth.acl.userSecret`

### Benefits

Sentinel acl is in sync with redis acl

### Possible drawbacks

I'm not sure what the correct way of handling users without passwords would be, so I'm keeping the previous behavior of just excluding users without a password.

This may be wrong, but at least it's _less wrong_ than before.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- extends #32434 which introduced this feature for non-sentinel acl configuration.

### Additional information

<details>
<summary>test values excerpt</summary>

```yaml
auth:
  acl:
    enabled: true
    sentinel: true
    users:
      - username: alice
        # password: asdasd
        commands: +@all
      - username: bob
        # password: asdasd
        commands: +@all
      - username: hasnopass
        commands: +@all
      - username: passinvalues
        password: asd
        commands: +@all
    userSecret: acl-secret
```
</details>

<details>
<summary>resulting `users.acl` in `configuration` configmap</summary>

```yaml
user default on #c6427b12b085ca9963aa14b81f94b01c51848b0fbc065f8a2b6b5489a7a942ed ~* &* +@all
user alice on #2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae ~* &* +@all
user bob on #fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9 ~* &* +@all
user hasnopass on nopass ~* &* +@all
user passinvalues on #688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c6 ~* &* +@all
```
</details>

<details>
<summary>resulting `sentinel.conf` in `configuration` configmap</summary>

```yaml
dir "/tmp"
port 26379
sentinel monitor redis-prod redis-test-node-0.redis-test-headless.redis-test.svc.cluster.local 6379 2
sentinel down-after-milliseconds redis-prod 60000
sentinel failover-timeout redis-prod 180000
sentinel parallel-syncs redis-prod 1# Sentinel ACL configuration, only for users with password

user alice on #2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae ~* &* +@all
sentinel sentinel-user alice
sentinel sentinel-pass foo

user bob on #fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9 ~* &* +@all
sentinel sentinel-user bob
sentinel sentinel-pass bar


user passinvalues on #688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c6 ~* &* +@all
sentinel sentinel-user passinvalues
sentinel sentinel-pass asd
# User-supplied sentinel configuration:
# End of sentinel configuration
```
</details>

ping
* @DSczyrba for hacking this together with me
* @emahdij as author of the previous PR

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] (N/A) Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
