### PR TITLE
[bitnami/etcd] Allow release namespace to be overridden

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 11.3.5 (2025-05-15)
+## 11.3.6 (2025-05-16)
 
-* [bitnami/etcd] fix type of GOMAXPROCS in envs ([#33477](https://github.com/bitnami/charts/pull/33477))
+* [bitnami/etcd] Allow release namespace to be overridden ([#33550](https://github.com/bitnami/charts/pull/33550))
+
+## <small>11.3.5 (2025-05-16)</small>
+
+* [bitnami/etcd] fix type of GOMAXPROCS in envs (#33477) ([0a6e907](https://github.com/bitnami/charts/commit/0a6e907ab91b4ed81541b6243d981289deee636d)), closes [#33477](https://github.com/bitnami/charts/issues/33477)
+* [bitnami/kubeapps] Deprecation followup (#33579) ([77e312c](https://github.com/bitnami/charts/commit/77e312c1772d4d7c4dc5d3ac0e80f4e452e3a062)), closes [#33579](https://github.com/bitnami/charts/issues/33579)
 
 ## <small>11.3.4 (2025-05-08)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 11.3.5
+version: 11.3.6

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -357,6 +357,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`            |
 | `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace template                                     | `""`            |
 | `commonLabels`           | Labels to add to all deployed objects                                                        | `{}`            |
 | `commonAnnotations`      | Annotations to add to all deployed objects                                                   | `{}`            |
 | `clusterDomain`          | Default Kubernetes cluster domain                                                            | `cluster.local` |

--- a/bitnami/etcd/templates/NOTES.txt
+++ b/bitnami/etcd/templates/NOTES.txt
@@ -29,11 +29,11 @@ The chart has been deployed in diagnostic mode. All probes have been disabled an
 
 Get the list of pods by executing:
 
-  kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Access the pod you want to debug by executing
 
-  kubectl exec --namespace {{ .Release.Namespace }} -ti <NAME OF THE POD> -- bash
+  kubectl exec --namespace {{ include "common.names.namespace" . }} -ti <NAME OF THE POD> -- bash
 
 In order to replicate the container startup scripts execute this command:
 
@@ -43,15 +43,15 @@ In order to replicate the container startup scripts execute this command:
 
 etcd can be accessed via port {{ coalesce .Values.service.ports.client .Values.service.port }} on the following DNS name from within your cluster:
 
-    {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+    {{ template "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}
 
 To create a pod that you can use as a etcd client run the following command:
 
-    kubectl run {{ template "common.names.fullname" . }}-client --restart='Never' --image {{ template "etcd.image" . }}{{- if or .Values.auth.rbac.create .Values.auth.rbac.enabled }} --env ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.auth.rbac.existingSecret }}{{ .Values.auth.rbac.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{{ if .Values.auth.rbac.existingSecret }}{.data.{{ .Values.auth.rbac.existingSecretPasswordKey }}}{{ else }}{.data.etcd-root-password}{{ end }}" | base64 -d){{- end }} --env ETCDCTL_ENDPOINTS="{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ coalesce .Values.service.ports.client .Values.service.port }}" --namespace {{ .Release.Namespace }} --command -- sleep infinity
+    kubectl run {{ template "common.names.fullname" . }}-client --restart='Never' --image {{ template "etcd.image" . }}{{- if or .Values.auth.rbac.create .Values.auth.rbac.enabled }} --env ROOT_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.auth.rbac.existingSecret }}{{ .Values.auth.rbac.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{{ if .Values.auth.rbac.existingSecret }}{.data.{{ .Values.auth.rbac.existingSecretPasswordKey }}}{{ else }}{.data.etcd-root-password}{{ end }}" | base64 -d){{- end }} --env ETCDCTL_ENDPOINTS="{{ template "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ coalesce .Values.service.ports.client .Values.service.port }}" --namespace {{ include "common.names.namespace" . }} --command -- sleep infinity
 
 Then, you can set/get a key using the commands below:
 
-    kubectl exec --namespace {{ .Release.Namespace }} -it {{ template "common.names.fullname" . }}-client -- bash
+    kubectl exec --namespace {{ include "common.names.namespace" . }} -it {{ template "common.names.fullname" . }}-client -- bash
     {{- $etcdAuthOptions := include "etcd.authOptions" . }}
     etcdctl {{ $etcdAuthOptions }} put /message Hello
     etcdctl {{ $etcdAuthOptions }} get /message
@@ -60,21 +60,21 @@ To connect to your etcd server from outside the cluster execute the following co
 
 {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
     echo "etcd URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ include "common.names.namespace" . }} -w {{ template "common.names.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
     echo "etcd URL: http://$SERVICE_IP:{{ coalesce .Values.service.ports.client .Values.service.port }}/"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ coalesce .Values.service.ports.client .Values.service.port }}:{{ coalesce .Values.service.ports.client .Values.service.port }} &
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ template "common.names.fullname" . }} {{ coalesce .Values.service.ports.client .Values.service.port }}:{{ coalesce .Values.service.ports.client .Values.service.port }} &
     echo "etcd URL: http://127.0.0.1:{{ coalesce .Values.service.ports.client .Values.service.port }}"
 
 {{- end }}
@@ -82,7 +82,7 @@ To connect to your etcd server from outside the cluster execute the following co
 
  * As rbac is enabled you should add the flag `--user root:$ETCD_ROOT_PASSWORD` to the etcdctl commands. Use the command below to export the password:
 
-    export ETCD_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.auth.rbac.existingSecret }}{{ .Values.auth.rbac.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{{ if .Values.auth.rbac.existingSecret }}{.data.{{ .Values.auth.rbac.existingSecretPasswordKey }}}{{ else }}{.data.etcd-root-password}{{ end }}" | base64 -d)
+    export ETCD_ROOT_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.auth.rbac.existingSecret }}{{ .Values.auth.rbac.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{{ if .Values.auth.rbac.existingSecret }}{.data.{{ .Values.auth.rbac.existingSecretPasswordKey }}}{{ else }}{.data.etcd-root-password}{{ end }}" | base64 -d)
 
 {{- end }}
 {{- if .Values.auth.client.secureTransport }}

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -203,7 +203,7 @@ etcd: disasterRecovery
 
 {{- define "etcd.token.jwtToken" -}}
 {{- if (include "etcd.token.createSecret" .) -}}
-{{- $jwtToken := lookup "v1" "Secret" .Release.Namespace (printf "%s-jwt-token" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" ) -}}
+{{- $jwtToken := lookup "v1" "Secret" (include "common.names.namespace" .) (printf "%s-jwt-token" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" ) -}}
 {{- if $jwtToken -}}
 {{ index $jwtToken "data" "jwt-token.pem" | b64dec }}
 {{- else -}}

--- a/bitnami/etcd/templates/configmap.yaml
+++ b/bitnami/etcd/templates/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   {{- if .Values.commonAnnotations }}

--- a/bitnami/etcd/templates/cronjob-defrag.yaml
+++ b/bitnami/etcd/templates/cronjob-defrag.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ printf "%s-defrag" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.defrag.cronjob.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.defrag.cronjob.annotations .Values.commonAnnotations }}
@@ -115,12 +115,12 @@ spec:
                   cmd="etcdctl --command-timeout=60s ${flags[@]}"
                   {{- $etcdFullname := include "common.names.fullname" . }}
                   {{- $etcdHeadlessServiceName := (printf "%s-%s" $etcdFullname "headless" | trunc 63 | trimSuffix "-") }}
-                  {{- $namespace := .Release.Namespace }}
+                  {{- $namespace := include "common.names.namespace" . }}
                   {{- $clusterDomain := .Values.clusterDomain }}
                   {{- $port := int .Values.service.ports.client }}
                   {{- $endpointStr := "" }}
                   {{- $replicaCount := (int .Values.replicaCount) }}
-                  {{- $releaseNamespace := .Release.Namespace }}
+                  {{- $releaseNamespace := include "common.names.namespace" . }}
                   {{- range $iEndpoint, $e := until $replicaCount }}
                   {{- $endpoint := printf "%s://%s-%d.%s.%s.svc.%s:%d" (include "etcd.peerProtocol" $) $etcdFullname $iEndpoint $etcdHeadlessServiceName $namespace $clusterDomain $port }}
                   {{- $endpointStr = printf "%s%s" $endpointStr $endpoint }}

--- a/bitnami/etcd/templates/cronjob-snapshotter.yaml
+++ b/bitnami/etcd/templates/cronjob-snapshotter.yaml
@@ -9,7 +9,7 @@ apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ printf "%s-snapshotter" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -88,7 +88,7 @@ spec:
                   value: "yes"
                 - name: MY_STS_NAME
                   value: {{ include "common.names.fullname" . | quote }}
-                {{- $releaseNamespace := .Release.Namespace }}
+                {{- $releaseNamespace := include "common.names.namespace" . }}
                 {{- $etcdFullname := include "common.names.fullname" . }}
                 {{- $etcdHeadlessServiceName := (printf "%s-%s" $etcdFullname "headless" | trunc 63 | trimSuffix "-") }}
                 {{- $clusterDomain := .Values.clusterDomain }}

--- a/bitnami/etcd/templates/networkpolicy.yaml
+++ b/bitnami/etcd/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ kind: NetworkPolicy
 apiVersion: {{ template "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   {{- if .Values.commonAnnotations }}

--- a/bitnami/etcd/templates/podmonitor.yaml
+++ b/bitnami/etcd/templates/podmonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ ternary .Values.metrics.podMonitor.namespace .Release.Namespace (not (empty .Values.metrics.podMonitor.namespace)) }}
+  namespace: {{ ternary .Values.metrics.podMonitor.namespace (include "common.names.namespace" .) (not (empty .Values.metrics.podMonitor.namespace)) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.podMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
@@ -38,7 +38,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}

--- a/bitnami/etcd/templates/preupgrade-hook-job.yaml
+++ b/bitnami/etcd/templates/preupgrade-hook-job.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ include "common.capabilities.job.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ include "common.names.fullname" . }}-pre-upgrade
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd-pre-upgrade-job
   {{- $defaultAnnotations := dict "helm.sh/hook" "pre-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation" }}
@@ -64,7 +64,7 @@ spec:
         {{- $replicaCount := int .Values.replicaCount }}
         {{- $clientPort := int .Values.containerPorts.client }}
         {{- $etcdFullname := include "common.names.fullname" . }}
-        {{- $releaseNamespace := .Release.Namespace }}
+        {{- $releaseNamespace := include "common.names.namespace" . }}
         {{- $etcdHeadlessServiceName := (printf "%s-%s" $etcdFullname "headless" | trunc 63 | trimSuffix "-") }}
         {{- $clusterDomain := .Values.clusterDomain }}
         {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}

--- a/bitnami/etcd/templates/prometheusrule.yaml
+++ b/bitnami/etcd/templates/prometheusrule.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/etcd/templates/secrets.yaml
+++ b/bitnami/etcd/templates/secrets.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "etcd.secretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   {{- if .Values.commonAnnotations }}

--- a/bitnami/etcd/templates/serviceaccount.yaml
+++ b/bitnami/etcd/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "etcd.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}  
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/bitnami/etcd/templates/snapshot-pvc.yaml
+++ b/bitnami/etcd/templates/snapshot-pvc.yaml
@@ -8,7 +8,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ printf "%s-snapshotter" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   annotations:
     helm.sh/resource-policy: keep

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   {{- if .Values.commonAnnotations }}
@@ -114,7 +114,7 @@ spec:
         {{- $replicaCount := int .Values.replicaCount }}
         {{- $peerPort := int .Values.containerPorts.peer }}
         {{- $etcdFullname := include "common.names.fullname" . }}
-        {{- $releaseNamespace := .Release.Namespace }}
+        {{- $releaseNamespace := include "common.names.namespace" . }}
         {{- $etcdHeadlessServiceName := (printf "%s-%s" $etcdFullname "headless" | trunc 63 | trimSuffix "-") }}
         {{- $clusterDomain := .Values.clusterDomain }}
         {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
@@ -185,11 +185,11 @@ spec:
               {{- end }}
             {{- end }}
             - name: ETCD_ADVERTISE_CLIENT_URLS
-              value: "{{ $etcdClientProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.client }}{{- if .Values.service.enabled }},{{ $etcdClientProtocol }}://{{ $etcdFullname }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ coalesce .Values.service.ports.client .Values.service.port }}{{- end }}"
+              value: "{{ $etcdClientProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ include "common.names.namespace" . }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.client }}{{- if .Values.service.enabled }},{{ $etcdClientProtocol }}://{{ $etcdFullname }}.{{ include "common.names.namespace" . }}.svc.{{ $clusterDomain }}:{{ coalesce .Values.service.ports.client .Values.service.port }}{{- end }}"
             - name: ETCD_LISTEN_CLIENT_URLS
               value: "{{ $etcdClientProtocol }}://0.0.0.0:{{ .Values.containerPorts.client }}"
             - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
-              value: "{{ $etcdPeerProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.peer }}"
+              value: "{{ $etcdPeerProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ include "common.names.namespace" . }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.peer }}"
             - name: ETCD_LISTEN_PEER_URLS
               value: "{{ $etcdPeerProtocol }}://0.0.0.0:{{ .Values.containerPorts.peer }}"
             {{- if .Values.metrics.useSeparateEndpoint }}

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   annotations:

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: etcd
   {{- if or .Values.service.annotations .Values.commonAnnotations }}

--- a/bitnami/etcd/templates/token-secrets.yaml
+++ b/bitnami/etcd/templates/token-secrets.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "etcd.token.secretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -47,6 +47,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname template
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace template
+##
+namespaceOverride: ""
 ## @param commonLabels [object] Labels to add to all deployed objects
 ##
 commonLabels: {}


### PR DESCRIPTION
### Description of the change

This patch replaces `.Release.Namespace` by `common.names.namespace` that supports overriding namespace by `Values.namespaceOverride`.

### Benefits

It enables deploying the chart in a custom namespace.

### Possible drawbacks

N/A. (The fix is backward-compatible because `common.names.namespace` defaults to `.Release.Namespace` if `Values.namespaceOverride` is not provided.)

### Applicable issues

N/A. (Searched for namespaceOverride, etcd and no related issues found.)

### Additional information

> Please run any tests or examples that can exercise your modified code

Installed the new chart on a k8s cluster with or without namespaceOverride, verified that both works, 

* With namespaceOverride

```console
$ helm dependency build bitnami/etcd

$ kubectl create namespace etcd-system

$ helm upgrade --install etcd-release bitnami/etcd --values test-values.yaml --set namespaceOverride=etcd-system

$ kubectl get all -A --all-namespaces |grep etcd
etcd-system    pod/etcd-release-0    1/1    Running    0    22s
etcd-system    service/etcd-release     ClusterIP   10.100.225.33    <none>    2379/TCP,2380/TCP     23s
etcd-system    service/etcd-release-headless    ClusterIP   None    <none>    2379/TCP,2380/TCP    23s
etcd-system    statefulset.apps/etcd-release    1/1    23s

$ kubectl run etcd-client -it --rm --image docker.io/bitnami/etcd:3.5.21-debian-12-r1 --env ETCDCTL_ENDPOINTS="etcd-release.etcd-system.svc.cluster.local:2379" --command -- bash
I have no name!@etcd-client:/opt/bitnami/etcd$ etcdctl put /message Hello
OK
I have no name!@etcd-client:/opt/bitnami/etcd$ etcdctl get /message
/message
Hello
I have no name!@etcd-client:/opt/bitnami/etcd$ exit

$ helm uninstall etcd-release
$ kubectl delete namespace etcd-system
```

* Without namespaceOverride

```console
$ helm upgrade --install etcd-release bitnami/etcd --values test-values.yaml

$ kubectl get all -A --all-namespaces |grep etcd
default    pod/etcd-release-0    1/1    Running   0    10s
default    service/etcd-release    ClusterIP   10.100.126.230   <none>    2379/TCP,2380/TCP    10s
default    service/etcd-release-headless    ClusterIP   None    <none>    2379/TCP,2380/TCP    10s
default    statefulset.apps/etcd-release   1/1    10s

$ kubectl run etcd-client -it --rm --image docker.io/bitnami/etcd:3.5.21-debian-12-r1 --env ETCDCTL_ENDPOINTS="etcd-release.default.svc.cluster.local:2379" --command -- bash
If you don't see a command prompt, try pressing enter.
I have no name!@etcd-client:/opt/bitnami/etcd$ etcdctl put /message Hello
OK
I have no name!@etcd-client:/opt/bitnami/etcd$ etcdctl get /message
/message
Hello
I have no name!@etcd-client:/opt/bitnami/etcd$ exit
exit

$ helm uninstall etcd-release
```

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
