### PR TITLE
[bitnami/postgresql-ha] ci: improve stability on Ginkgo tests

### DIFF
--- a/.vib/postgresql-ha/ginkgo/postgresql_suite_test.go
+++ b/.vib/postgresql-ha/ginkgo/postgresql_suite_test.go
@@ -30,7 +30,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
 	flag.StringVar(&username, "username", "", "database user")
 	flag.StringVar(&password, "password", "", "database password for username")
-	flag.IntVar(&timeoutSeconds, "timeout", 200, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 300, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/.vib/postgresql-ha/vib-verify.json
+++ b/.vib/postgresql-ha/vib-verify.json
@@ -80,7 +80,8 @@
               "namespace": "{{namespace}}",
               "name": "postgresql-ha",
               "username": "postgres",
-              "password": "psqlPassword123!4"
+              "password": "psqlPassword123!4",
+              "timeoutSeconds": 300
             }
           }
         },

--- a/.vib/postgresql-ha/vib-verify.json
+++ b/.vib/postgresql-ha/vib-verify.json
@@ -80,8 +80,7 @@
               "namespace": "{{namespace}}",
               "name": "postgresql-ha",
               "username": "postgres",
-              "password": "psqlPassword123!4",
-              "timeoutSeconds": 300
+              "password": "psqlPassword123!4"
             }
           }
         },

--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 16.0.1 (2025-05-08)
+
+* [bitnami/postgresql-ha] ci: improve stability on Ginkgo tests ([#33567](https://github.com/bitnami/charts/pull/33567))
+
 ## 16.0.0 (2025-05-08)
 
-* [bitnami/postgresql-ha] feat: Customizable Stream Replication Check credentials ([#33552](https://github.com/bitnami/charts/pull/33552))
+* [bitnami/postgresql-ha] feat: Customizable Stream Replication Check credentials (#33552) ([cff2e93](https://github.com/bitnami/charts/commit/cff2e93f9da96f82ad9d97d2d35a7324b54d0931)), closes [#33552](https://github.com/bitnami/charts/issues/33552)
 
 ## <small>15.3.17 (2025-05-07)</small>
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 16.0.0
+version: 16.0.1


### PR DESCRIPTION
### Description of the change

This PR attempt to improve stability on Ginkgo tests by increasing timeout for operations such as scaling up/down PostgreSQL replicas.

### Benefits

More stable CI

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
