### PR TITLE
[bitnami/kubeapps] Deprecate Helm chart

### DIFF
--- a/bitnami/kubeapps/CHANGELOG.md
+++ b/bitnami/kubeapps/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 18.0.1 (2025-05-08)
+
+* [bitnami/kubeapps] Deprecate Helm chart ([#33578](https://github.com/bitnami/charts/pull/33578))
+
 ## 18.0.0 (2025-05-07)
 
-* [bitnami/kubeapps] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 ([#33503](https://github.com/bitnami/charts/pull/33503))
+* [bitnami/kubeapps] feat!: :arrow_up: :boom: Bump Redis(R) to 8.0 (#33503) ([eab4db6](https://github.com/bitnami/charts/commit/eab4db60c2bb1fd7b9e6ad85e41e3f7fc68de6bd)), closes [#33503](https://github.com/bitnami/charts/issues/33503)
 
 ## <small>17.1.7 (2025-05-06)</small>
 

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -38,7 +38,9 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
+# The Kubeapps chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
 keywords:
@@ -47,10 +49,8 @@ keywords:
 - service catalog
 - deployment
 kubeVersion: '>=1.21.0-0'
-maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+maintainers: []
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 18.0.0
+version: 18.0.1

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -6,6 +6,10 @@ Kubeapps is a web-based UI for launching and managing applications on Kubernetes
 
 [Overview of Kubeapps](https://github.com/vmware-tanzu/kubeapps)
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued, therefore, this Helm chart will be deprecated as well.
+
 ## TL;DR
 
 ```console

--- a/bitnami/kubeapps/templates/NOTES.txt
+++ b/bitnami/kubeapps/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued, therefore, this Helm chart will be deprecated as well.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
The upstream project has been discontinued (see notice at https://github.com/vmware-tanzu/kubeapps?tab=readme-ov-file#-kubeapps), therefore, this Helm chart will be deprecated as well.
