### PR TITLE
[bitnami/jupyterhub] Init containers can be used with external PostgreSQL

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.0.7 (2025-05-07)
+## 9.0.8 (2025-05-09)
 
-* [jupyterhub] Fix singleuser image pull secrets ([#33176](https://github.com/bitnami/charts/pull/33176))
+* [bitnami/jupyterhub] Init containers can be used with external PostgreSQL ([#33582](https://github.com/bitnami/charts/pull/33582))
+
+## <small>9.0.7 (2025-05-07)</small>
+
+* [jupyterhub] Fix singleuser image pull secrets (#33176) ([95a3490](https://github.com/bitnami/charts/commit/95a34900e72996e02e0ba14bea719a6f7747e2c2)), closes [#33176](https://github.com/bitnami/charts/issues/33176)
 
 ## <small>9.0.6 (2025-05-06)</small>
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 9.0.7
+version: 9.0.8

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -74,8 +74,9 @@ spec:
       {{- if .Values.hub.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.hub.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if .Values.postgresql.enabled }} 
+      {{- if or .Values.postgresql.enabled .Values.hub.initContainers }} 
       initContainers:
+        {{- if .Values.postgresql.enabled }} 
         # NOTE: The value postgresql.image is not available unless postgresql.enabled is not set. We could change this to use os-shell if
         # it had the binary wait-for-port.
         # This init container is for avoiding CrashLoopback errors in the Hub container because the PostgreSQL container is not ready
@@ -125,6 +126,7 @@ spec:
                   key: {{ include "jupyterhub.databaseSecretKey" . }}
             - name: POSTGRESQL_CLIENT_POSTGRES_USER
               value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote }}
+        {{- end }}
         {{- if .Values.hub.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.hub.initContainers "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### Description of the change

Use of `hub.initContainers` in the JupyterHub chart is no longer dependent on `postgresql.enabled` being true. 

### Benefits

Can use init containers and an external PostgreSQL instance.

### Possible drawbacks

None

### Applicable issues

- fixes #33524

### Additional information

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
