### PR TITLE
bitnami/envoy-gateway: fix template hpa

### DIFF
--- a/bitnami/envoy-gateway/CHANGELOG.md
+++ b/bitnami/envoy-gateway/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.4 (2025-05-07)
+## 0.1.5 (2025-05-12)
 
-* [bitnami/envoy-gateway] Release 0.1.4 ([#33541](https://github.com/bitnami/charts/pull/33541))
+* bitnami/envoy-gateway: fix template hpa ([#33621](https://github.com/bitnami/charts/pull/33621))
+
+## <small>0.1.4 (2025-05-07)</small>
+
+* [bitnami/envoy-gateway] Release 0.1.4 (#33541) ([68c37dc](https://github.com/bitnami/charts/commit/68c37dcf1363b40e1a14e7b76a46dbc5e7d5b0a1)), closes [#33541](https://github.com/bitnami/charts/issues/33541)
 
 ## <small>0.1.3 (2025-05-06)</small>
 

--- a/bitnami/envoy-gateway/Chart.yaml
+++ b/bitnami/envoy-gateway/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: envoy-gateway
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/envoy-gateway
-version: 0.1.4
+version: 0.1.5

--- a/bitnami/envoy-gateway/templates/hpa.yaml
+++ b/bitnami/envoy-gateway/templates/hpa.yaml
@@ -7,6 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

Fixes template hpa, address error:

Error: UPGRADE FAILED: Unable to continue with update: could not get information about the resource HorizontalPodAutoscaler "" in namespace "envoy-gateway": resource name may not be empty

### Benefits

:)

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
