### PR TITLE
[bitnami-postgresql-ha] docs: document security fix on 16.0.0

### DIFF
--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## 16.0.0 (2025-05-08)
 
 * [bitnami/postgresql-ha] feat: Customizable Stream Replication Check credentials (#33552) ([cff2e93](https://github.com/bitnami/charts/commit/cff2e93f9da96f82ad9d97d2d35a7324b54d0931)), closes [#33552](https://github.com/bitnami/charts/issues/33552)
+* Security fix for [GHSA-mx38-x658-5fwj](https://github.com/bitnami/charts/security/advisories/GHSA-mx38-x658-5fwj) and CVE-2025-22248.
 
 ## <small>15.3.17 (2025-05-07)</small>
 

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -1000,6 +1000,8 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 This major version makes it possible to customize the user & password to be used by Pgpool-II for performing Stream Replication Checks and sets the default user to `sr_check_user`. Previously, the user was hardcoded to `repmgr`, reusing the same user used by Repmgr. This change allows for a more flexible & secure configuration, as the user used by Pgpool-II can be different from the one used by Repmgr.
 
+This major version includes a security fix for [GHSA-mx38-x658-5fwj](https://github.com/bitnami/charts/security/advisories/GHSA-mx38-x658-5fwj) and CVE-2025-22248. Upgrading to this or higher versions is recommended.
+
 Given users' creation is skipped when there's existing data, upgrading from `15.x` to `16.x` will fail when persistence is enabled unless the user is created manually or the `pgpool.srCheckUsername` and `pgpool.srCheckPassword` parameters are set to the same values as the `postgresql.repmgrUsername` and `postgresql.repmgrPassword` parameters:
 
 - Manually create the user:


### PR DESCRIPTION
### Description of the change

This PR adds a note on 16.0.0 notes and Changelog warning users about the security issue addressed on this version.
