### PR TITLE
[bitnami/grafana-loki] dataDir value substitution instead of static config

### DIFF
--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.8.9 (2025-05-13)
+## 4.8.9 (2025-05-15)
 
 * [bitnami/grafana-loki] dataDir value substitution instead of static config ([#33668](https://github.com/bitnami/charts/pull/33668))
 

--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 4.8.8 (2025-05-13)
+## 4.8.9 (2025-05-13)
 
-* [bitnami/grafana-loki] :zap: :arrow_up: Update dependency references ([#33632](https://github.com/bitnami/charts/pull/33632))
+* [bitnami/grafana-loki] dataDir value substitution instead of static config ([#33668](https://github.com/bitnami/charts/pull/33668))
+
+## <small>4.8.8 (2025-05-13)</small>
+
+* [bitnami/grafana-loki] :zap: :arrow_up: Update dependency references (#33632) ([3d2c31e](https://github.com/bitnami/charts/commit/3d2c31e50c1c140229b33cb7f43834f1b3ded3a7)), closes [#33632](https://github.com/bitnami/charts/issues/33632)
+* [bitnami/kubeapps] Deprecation followup (#33579) ([77e312c](https://github.com/bitnami/charts/commit/77e312c1772d4d7c4dc5d3ac0e80f4e452e3a062)), closes [#33579](https://github.com/bitnami/charts/issues/33579)
 
 ## <small>4.8.7 (2025-05-07)</small>
 

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -58,4 +58,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.8.8
+version: 4.8.9

--- a/bitnami/grafana-loki/templates/NOTES.txt
+++ b/bitnami/grafana-loki/templates/NOTES.txt
@@ -22,7 +22,7 @@ Access the pod you want to debug by executing
 
 In order to replicate the container startup execute this command:
 
-    loki -config.file=/bitnami/grafana-loki/conf/loki.yaml
+    loki -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
 
 {{- else }}
 

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -155,7 +155,7 @@ spec:
               mountPath: /tmp
               subPath: tmp-dir
             - name: empty-dir
-              mountPath: /bitnami/grafana-loki/chunks
+              mountPath: {{ .Values.loki.dataDir }}/chunks
               subPath: app-chunks-dir
             - name: loki-config
               mountPath: {{ .Values.loki.dataDir }}/conf/loki.yaml


### PR DESCRIPTION
Two occurances of .Values.loki.dataDir that are using the default value /bitnami/grafana-loki instead of substitution of the value.