### PR TITLE
[bitnami/keycloak] Deterministric Password Generation + Doesnt change while upgrading

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 24.6.7 (2025-05-13)
+## 24.6.8 (2025-05-13)
 
-* [bitnami/keycloak] :zap: :arrow_up: Update dependency references ([#33671](https://github.com/bitnami/charts/pull/33671))
+* [bitnami/keycloak] Deterministric Password Generation + Doesnt change while upgrading ([#33677](https://github.com/bitnami/charts/pull/33677))
+
+## <small>24.6.7 (2025-05-13)</small>
+
+* [bitnami/keycloak] :zap: :arrow_up: Update dependency references (#33671) ([15a8f8a](https://github.com/bitnami/charts/commit/15a8f8a55a365316236d089a3f802f7364a4d060)), closes [#33671](https://github.com/bitnami/charts/issues/33671)
+* [bitnami/kubeapps] Deprecation followup (#33579) ([77e312c](https://github.com/bitnami/charts/commit/77e312c1772d4d7c4dc5d3ac0e80f4e452e3a062)), closes [#33579](https://github.com/bitnami/charts/issues/33579)
 
 ## <small>24.6.6 (2025-05-08)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.6.7
+version: 24.6.8

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -17,5 +17,5 @@ metadata:
 type: Opaque
 data:
 {{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") }}
-  admin-password: {{ coalesce .Values.auth.adminPassword ($previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
+  admin-password: {{ coalesce .Values.auth.adminPassword (default "" $previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -16,6 +16,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") }}
-  admin-password: {{ coalesce .Values.auth.adminPassword (default "" $previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
+{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") | mergeOverwrite (dict "data" (dict "admin-password" "")) }}
+  admin-password: {{ coalesce .Values.auth.adminPassword ($previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -16,6 +16,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") | mergeOverwrite (dict "data" (dict "admin-password" "")) }}
-  admin-password: {{ coalesce .Values.auth.adminPassword (index $previous.data "admin-password" | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
+{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") | mergeOverwrite (dict "data" dict) }}
+  admin-password: {{ coalesce .Values.auth.adminPassword (default "" (index $previous.data "admin-password") | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -16,6 +16,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") | mergeOverwrite (dict "data" dict) }}
-  admin-password: {{ coalesce .Values.auth.adminPassword (default "" (index $previous.data "admin-password") | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
+{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") }}
+  admin-password: {{ coalesce .Values.auth.adminPassword (dig "data" "admin-password" "" $previous | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -17,5 +17,5 @@ metadata:
 type: Opaque
 data:
 {{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") | mergeOverwrite (dict "data" (dict "admin-password" "")) }}
-  admin-password: {{ coalesce .Values.auth.adminPassword ($previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
+  admin-password: {{ coalesce .Values.auth.adminPassword (index $previous.data "admin-password" | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "common.names.fullname" . | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
     app.kubernetes.io/component: keycloak
@@ -16,5 +16,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  admin-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") "key" "admin-password" "length" 10 "providedValues" (list "auth.adminPassword") "context" $) }}
+{{- $previous := lookup "v1" "Secret" (include "common.names.namespace" .) (include "common.names.fullname" . | trunc 63 | trimSuffix "-") }}
+  admin-password: {{ coalesce .Values.auth.adminPassword ($previous.data.admin-password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 10) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
There is a problem with the common passwords function, it is not deterministic and when using checksum annotation its just not representing the hash of the resource because of double different random outputs. I have explained it further here.

#33672 

Same Solution.
Thanks.