### PR TITLE
[bitnami/grafana] Grafana uniq dashboard volumes

### DIFF
--- a/bitnami/grafana/CHANGELOG.md
+++ b/bitnami/grafana/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 12.0.1 (2025-05-14)
+
+* [bitnami/grafana] Grafana uniq dashboard volumes ([#33689](https://github.com/bitnami/charts/pull/33689))
+
 ## 12.0.0 (2025-05-12)
 
-* [bitnami/grafana] :zap: :arrow_up: Update dependency references ([#33604](https://github.com/bitnami/charts/pull/33604))
+* [bitnami/grafana] :zap: :arrow_up: Update dependency references (#33604) ([4229d77](https://github.com/bitnami/charts/commit/4229d7766abffbc8cf3f299016d1dc4d0be8796c)), closes [#33604](https://github.com/bitnami/charts/issues/33604)
+* [bitnami/kubeapps] Deprecation followup (#33579) ([77e312c](https://github.com/bitnami/charts/commit/77e312c1772d4d7c4dc5d3ac0e80f4e452e3a062)), closes [#33579](https://github.com/bitnami/charts/issues/33579)
 
 ## <small>11.6.7 (2025-05-07)</small>
 

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -355,10 +355,14 @@ spec:
             name: {{ include "common.names.fullname" . }}-provider
             {{- end }}
         {{- end }}
-        {{- range .Values.dashboardsConfigMaps }}
-        - name: {{ include "common.tplvalues.render" ( dict "value" .configMapName "context" $ ) }}
+{{- $dashboardConfigMapNames := list }}
+{{- range .Values.dashboardsConfigMaps }}
+  {{- $dashboardConfigMapNames = append $dashboardConfigMapNames .configMapName }}
+{{- end }}
+        {{- range $dashboardConfigMapNames | uniq }}
+        - name: {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) }}
           configMap:
-            name: {{ include "common.tplvalues.render" ( dict "value" .configMapName "context" $ ) }}
+            name: {{ include "common.tplvalues.render" ( dict "value" . "context" $ ) }}
         {{- end }}
         {{- if .Values.datasources.secretName }}
         - name: datasources


### PR DESCRIPTION
When using grafana dashboard configMap feature (.Values.dashboardsConfigMaps) and mapping multiple dashboards to the same configMapName, the deployment will fail becaues the templating will try to mount same volume twice or more, We have to make the .spec.template.spec.volumes Uniq.