### PR TITLE
[bitnami/kafka][bitnami/charts/issues/32851] Update controller and broker configuration when enabling controller.controllerOnly

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 32.2.6 (2025-05-16)
+## 32.2.7 (2025-05-19)
 
-* [bitnami/kafka] :zap: :arrow_up: Update dependency references ([#33762](https://github.com/bitnami/charts/pull/33762))
+* [bitnami/kafka][bitnami/charts/issues/32851] Update controller and broker configuration when enabling controller.controllerOnly ([#33740](https://github.com/bitnami/charts/pull/33740))
+
+## <small>32.2.6 (2025-05-17)</small>
+
+* [bitnami/*] Update CNAB tip (#33741) ([2bc74f3](https://github.com/bitnami/charts/commit/2bc74f3f539481ceaa12833c114047583912b748)), closes [#33741](https://github.com/bitnami/charts/issues/33741)
+* [bitnami/kafka] :zap: :arrow_up: Update dependency references (#33762) ([3053762](https://github.com/bitnami/charts/commit/30537620a0291f4875304761c5f43da61b9a4c5f)), closes [#33762](https://github.com/bitnami/charts/issues/33762)
 
 ## <small>32.2.5 (2025-05-15)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.2.6
+version: 32.2.7

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -138,9 +138,11 @@ externalAccess.enabled=true
 externalAccess.broker.service.type=LoadBalancer
 externalAccess.controller.service.type=LoadBalancer
 externalAccess.broker.service.ports.external=9094
-externalAccess.controller.service.containerPorts.external=9094
+externalAccess.controller.service.ports.external=9094
 defaultInitContainers.autoDiscovery.enabled=true
 serviceAccount.create=true
+broker.automountServiceAccountToken=true
+controller.automountServiceAccountToken=true
 rbac.create=true
 ```
 

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -485,23 +485,16 @@ Returns the value listener.security.protocol.map based on the values of 'listene
 {{- if .context.Values.listeners.securityProtocolMap -}}
   {{- print .context.Values.listeners.securityProtocolMap -}}
 {{- else -}}
-  {{- $listeners := list .context.Values.listeners.client .context.Values.listeners.interbroker -}}
-  {{- if .isController -}}
-    {{- if .context.Values.controller.controllerOnly -}}
-      {{- $listeners = list .context.Values.listeners.controller -}}
-    {{- else -}}
-      {{- $listeners = append $listeners .context.Values.listeners.controller -}}
-      {{- range $i := .context.Values.listeners.extraListeners -}}
-      {{- $listeners = append $listeners $i -}}
-      {{- end -}}
-    {{- end -}}
+  {{- $listeners := list .context.Values.listeners.controller .context.Values.listeners.client .context.Values.listeners.interbroker -}}
+  {{- if and .isController .context.Values.controller.controllerOnly -}}
+    {{- $listeners = list .context.Values.listeners.controller  -}}
   {{- else -}}
     {{- range $i := .context.Values.listeners.extraListeners -}}
     {{- $listeners = append $listeners $i -}}
     {{- end -}}
   {{- end -}}
-  {{- if and .context.Values.externalAccess.enabled -}}
-  {{- $listeners = append $listeners .context.Values.listeners.external -}}
+  {{- if .context.Values.externalAccess.enabled -}}
+    {{- $listeners = append $listeners .context.Values.listeners.external -}}
   {{- end -}}
   {{- $res := list -}}
   {{- range $listener := $listeners -}}
@@ -546,69 +539,72 @@ Returns the controller quorum bootstrap servers based on the number of controlle
 Section of the server.properties shared by both controller-eligible and broker nodes
 */}}
 {{- define "kafka.commonConfig" -}}
-inter.broker.listener.name: {{ .Values.listeners.interbroker.name }}
-controller.listener.names: {{ .Values.listeners.controller.name }}
-controller.quorum.bootstrap.servers: {{ include "kafka.controller.quorumBootstrapServers" . }}
-{{- if include "kafka.sslEnabled" . }}
+{{- if (not (and .isController .context.Values.controller.controllerOnly)) -}}
+inter.broker.listener.name: {{ .context.Values.listeners.interbroker.name }}
+{{- end }}
+controller.listener.names: {{ .context.Values.listeners.controller.name }}
+controller.quorum.bootstrap.servers: {{ include "kafka.controller.quorumBootstrapServers" .context }}
+{{- if include "kafka.sslEnabled" .context }}
 # TLS configuration
 ssl.keystore.type: JKS
 ssl.truststore.type: JKS
 ssl.keystore.location: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
 ssl.truststore.location: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
-ssl.client.auth: {{ .Values.tls.sslClientAuth }}
-ssl.endpoint.identification.algorithm: {{ .Values.tls.endpointIdentificationAlgorithm }}
+ssl.client.auth: {{ .context.Values.tls.sslClientAuth }}
+ssl.endpoint.identification.algorithm: {{ .context.Values.tls.endpointIdentificationAlgorithm }}
 {{- end }}
-{{- if (include "kafka.saslEnabled" .) }}
+{{- if (include "kafka.saslEnabled" .context) }}
 # Listeners SASL JAAS configuration
-sasl.enabled.mechanisms: {{ upper .Values.sasl.enabledMechanisms }}
-{{- if regexFind "SASL" (upper .Values.listeners.interbroker.protocol) }}
-sasl.mechanism.inter.broker.protocol: {{ upper .Values.sasl.interBrokerMechanism }}
+sasl.enabled.mechanisms: {{ upper .context.Values.sasl.enabledMechanisms }}
+{{- if regexFind "SASL" (upper .context.Values.listeners.interbroker.protocol) }}
+sasl.mechanism.inter.broker.protocol: {{ upper .context.Values.sasl.interBrokerMechanism }}
 {{- end }}
-{{- if regexFind "SASL" (upper .Values.listeners.controller.protocol) }}
-sasl.mechanism.controller.protocol: {{ upper .Values.sasl.controllerMechanism }}
+{{- if regexFind "SASL" (upper .context.Values.listeners.controller.protocol) }}
+sasl.mechanism.controller.protocol: {{ upper .context.Values.sasl.controllerMechanism }}
 {{- end }}
-{{- $listeners := list .Values.listeners.client .Values.listeners.interbroker .Values.listeners.controller }}
-{{- range $i := .Values.listeners.extraListeners }}
+{{- $listeners := list .context.Values.listeners.client .context.Values.listeners.interbroker .context.Values.listeners.controller }}
+{{- range $i := .context.Values.listeners.extraListeners }}
 {{- $listeners = append $listeners $i }}
 {{- end }}
-{{- if .Values.externalAccess.enabled }}
-{{- $listeners = append $listeners .Values.listeners.external }}
+{{- if .context.Values.externalAccess.enabled }}
+{{- $listeners = append $listeners .context.Values.listeners.external }}
 {{- end }}
+{{- $context := .context }}
 {{- range $listener := $listeners }}
   {{- if and $listener.sslClientAuth (regexFind "SSL" (upper $listener.protocol)) }}
 listener.name.{{lower $listener.name}}.ssl.client.auth: {{ $listener.sslClientAuth }}
   {{- end }}
   {{- if regexFind "SASL" (upper $listener.protocol) }}
-    {{- range $mechanism := splitList "," $.Values.sasl.enabledMechanisms }}
+    {{- range $mechanism := splitList "," $context.Values.sasl.enabledMechanisms }}
       {{- $securityModule := include "kafka.saslSecurityModule" (dict "mechanism" (upper $mechanism)) }}
-      {{- if and (eq (upper $mechanism) "OAUTHBEARER") (or (eq $listener.name $.Values.listeners.interbroker.name) (eq $listener.name $.Values.listeners.controller.name)) }}
+      {{- if and (eq (upper $mechanism) "OAUTHBEARER") (or (eq $listener.name $context.Values.listeners.interbroker.name) (eq $listener.name $context.Values.listeners.controller.name)) }}
 listener.name.{{lower $listener.name}}.oauthbearer.sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
       {{- end }}
       {{- $saslJaasConfig := list $securityModule }}
-      {{- if eq $listener.name $.Values.listeners.interbroker.name }}
+      {{- if eq $listener.name $context.Values.listeners.interbroker.name }}
         {{- if (eq (upper $mechanism) "OAUTHBEARER") }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "clientId=\"%s\"" $.Values.sasl.interbroker.clientId) }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "clientId=\"%s\"" $context.Values.sasl.interbroker.clientId) }}
           {{- $saslJaasConfig = append $saslJaasConfig (print "clientSecret=\"interbroker-client-secret-placeholder\"") }}
         {{- else }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "username=\"%s\"" $.Values.sasl.interbroker.user) }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "username=\"%s\"" $context.Values.sasl.interbroker.user) }}
           {{- $saslJaasConfig = append $saslJaasConfig (print "password=\"interbroker-password-placeholder\"") }}
         {{- end }}
-      {{- else if eq $listener.name $.Values.listeners.controller.name }}
+      {{- else if eq $listener.name $context.Values.listeners.controller.name }}
         {{- if (eq (upper $mechanism) "OAUTHBEARER") }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "clientId=\"%s\"" $.Values.sasl.controller.clientId) }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "clientId=\"%s\"" $context.Values.sasl.controller.clientId) }}
           {{- $saslJaasConfig = append $saslJaasConfig (print "clientSecret=\"controller-client-secret-placeholder\"") }}
         {{- else }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "username=\"%s\"" $.Values.sasl.controller.user) }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "username=\"%s\"" $context.Values.sasl.controller.user) }}
           {{- $saslJaasConfig = append $saslJaasConfig (print "password=\"controller-password-placeholder\"") }}
         {{- end }}
       {{- end }}
       {{- if eq (upper $mechanism) "PLAIN" }}
-        {{- if eq $listener.name $.Values.listeners.interbroker.name }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"interbroker-password-placeholder\"" $.Values.sasl.interbroker.user) }}
-        {{- else if eq $listener.name $.Values.listeners.controller.name }}
-          {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"controller-password-placeholder\"" $.Values.sasl.controller.user) }}
+        {{- if eq $listener.name $context.Values.listeners.interbroker.name }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"interbroker-password-placeholder\"" $context.Values.sasl.interbroker.user) }}
+        {{- else if eq $listener.name $context.Values.listeners.controller.name }}
+          {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"controller-password-placeholder\"" $context.Values.sasl.controller.user) }}
         {{- end }}
-        {{- range $i, $user := $.Values.sasl.client.users }}
+        {{- range $i, $user := $context.Values.sasl.client.users }}
           {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"password-placeholder-%d\"" $user (int $i)) }}
         {{- end }}
       {{- end }}
@@ -619,11 +615,11 @@ listener.name.{{lower $listener.name}}.oauthbearer.sasl.server.callback.handler.
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if regexFind "OAUTHBEARER" .Values.sasl.enabledMechanisms }}
-sasl.oauthbearer.token.endpoint.url: {{ .Values.sasl.oauthbearer.tokenEndpointUrl }}
-sasl.oauthbearer.jwks.endpoint.url: {{ .Values.sasl.oauthbearer.jwksEndpointUrl }}
-sasl.oauthbearer.expected.audience: {{ .Values.sasl.oauthbearer.expectedAudience }}
-sasl.oauthbearer.sub.claim.name: {{ .Values.sasl.oauthbearer.subClaimName }}
+{{- if regexFind "OAUTHBEARER" .context.Values.sasl.enabledMechanisms }}
+sasl.oauthbearer.token.endpoint.url: {{ .context.Values.sasl.oauthbearer.tokenEndpointUrl }}
+sasl.oauthbearer.jwks.endpoint.url: {{ .context.Values.sasl.oauthbearer.jwksEndpointUrl }}
+sasl.oauthbearer.expected.audience: {{ .context.Values.sasl.oauthbearer.expectedAudience }}
+sasl.oauthbearer.sub.claim.name: {{ .context.Values.sasl.oauthbearer.subClaimName }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/bitnami/kafka/templates/broker/configmap.yaml
+++ b/bitnami/kafka/templates/broker/configmap.yaml
@@ -15,6 +15,7 @@ ref: https://kafka.apache.org/documentation/#configuration
 listeners: {{ include "kafka.listeners" (dict "isController" false "context" .) }}
 listener.security.protocol.map: {{ include "kafka.securityProtocolMap" (dict "isController" false "context" .) }}
 advertised.listeners: {{ include "kafka.advertisedListeners" . }}
+inter.broker.listener.name: {{ .Values.listeners.interbroker.name }}
 # Kafka data logs directory
 log.dir: {{ printf "%s/data" .Values.broker.persistence.mountPath }}
 # Kafka application logs directory
@@ -22,7 +23,7 @@ logs.dir: {{ .Values.broker.logPersistence.mountPath }}
 # KRaft node role
 process.roles: broker
 # Common Kafka Configuration
-{{ include "kafka.commonConfig" (dict "isController" false "context" .) }}
+{{ include "kafka.commonConfig" . }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kafka/templates/broker/configmap.yaml
+++ b/bitnami/kafka/templates/broker/configmap.yaml
@@ -22,7 +22,7 @@ logs.dir: {{ .Values.broker.logPersistence.mountPath }}
 # KRaft node role
 process.roles: broker
 # Common Kafka Configuration
-{{ include "kafka.commonConfig" . }}
+{{ include "kafka.commonConfig" (dict "isController" false "context" .) }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kafka/templates/controller-eligible/configmap.yaml
+++ b/bitnami/kafka/templates/controller-eligible/configmap.yaml
@@ -24,7 +24,7 @@ logs.dir: {{ .Values.controller.logPersistence.mountPath }}
 # KRaft node role
 process.roles: {{ ternary "controller" "controller,broker" .Values.controller.controllerOnly }}
 # Common Kafka Configuration
-{{ include "kafka.commonConfig" . }}
+{{ include "kafka.commonConfig" (dict "isController" true "context" .) }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kafka/templates/controller-eligible/configmap.yaml
+++ b/bitnami/kafka/templates/controller-eligible/configmap.yaml
@@ -16,6 +16,7 @@ listeners: {{ include "kafka.listeners" (dict "isController" true "context" .) }
 listener.security.protocol.map: {{ include "kafka.securityProtocolMap" (dict "isController" true "context" .) }}
 {{- if not .Values.controller.controllerOnly }}
 advertised.listeners: {{ include "kafka.advertisedListeners" . }}
+inter.broker.listener.name: {{ .Values.listeners.interbroker.name }}
 {{- end }}
 # Kafka data logs directory
 log.dir: {{ printf "%s/data" .Values.controller.persistence.mountPath }}
@@ -24,7 +25,7 @@ logs.dir: {{ .Values.controller.logPersistence.mountPath }}
 # KRaft node role
 process.roles: {{ ternary "controller" "controller,broker" .Values.controller.controllerOnly }}
 # Common Kafka Configuration
-{{ include "kafka.commonConfig" (dict "isController" true "context" .) }}
+{{ include "kafka.commonConfig" . }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

Controller was failing to start when separating brokers and controller due to the configuration 

```
diff --git a/bitnami/kafka/values.yaml b/bitnami/kafka/values.yaml
index accc647aed..4ef074ec86 100644
--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -113,7 +113,7 @@ image:
   pullSecrets: []
   ## Set to true if you would like to see extra information on logs
   ##
-  debug: false
+  debug: true
 
 ## @param clusterId Kafka Kraft cluster ID (ignored if existingKraftSecret is set). A random cluster ID will be generated the 1st time Kraft is initialized if not set.
 ## NOTE: Already initialized Kafka nodes will use cluster ID stored in their persisted storage.
@@ -671,7 +671,7 @@ controller:
   replicaCount: 3
   ## @param controller.controllerOnly If set to true, controller nodes will be deployed as dedicated controllers, instead of controller+broker processes.
   ##
-  controllerOnly: false
+  controllerOnly: true
   ## @param controller.quorumBootstrapServers Override the Kafka controller quorum bootstrap servers of the Kafka Kraft cluster. If not set, it will be automatically configured to use all controller-eligible nodes.
   ##
   quorumBootstrapServers: ""
@@ -1134,7 +1134,7 @@ controller:
 broker:
   ## @param broker.replicaCount Number of Kafka broker-only nodes
   ##
-  replicaCount: 0
+  replicaCount: 3
   ## @param broker.minId Minimal node.id values for broker-only nodes. Do not change after first initialization.
   ## Broker-only id increment their ID starting at this minimal value.
   ## We recommend setting this this value high enough, as IDs under this value will be used by controller-eligible nodes
```

```
➜  kafka git:(main) k logs -p kafka-controller-2
Defaulted container "kafka" out of: kafka, prepare-config (init)
kafka 08:02:06.51 INFO  ==> 
kafka 08:02:06.51 INFO  ==> Welcome to the Bitnami kafka container
kafka 08:02:06.51 INFO  ==> Subscribe to project updates by watching https://github.com/bitnami/containers
kafka 08:02:06.51 INFO  ==> Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami/ for more information.
kafka 08:02:06.52 INFO  ==> 
kafka 08:02:06.52 INFO  ==> ** Starting Kafka setup **
kafka 08:02:17.08 INFO  ==> Initializing KRaft storage metadata
kafka 08:02:17.09 INFO  ==> Adding KRaft SCRAM users at storage bootstrap
kafka 08:02:20.69 INFO  ==> Formatting storage directories to add metadata...
Picked up JAVA_TOOL_OPTIONS: 
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Listener with name INTERNAL defined in inter.broker.listener.name not found in listener.security.protocol.map.
        at kafka.server.KafkaConfig.$anonfun$getInterBrokerListenerNameAndSecurityProtocol$1(KafkaConfig.scala:570)
        at scala.collection.mutable.HashMap.getOrElse(HashMap.scala:451)
        at kafka.server.KafkaConfig.getInterBrokerListenerNameAndSecurityProtocol(KafkaConfig.scala:570)
        at kafka.server.KafkaConfig.interBrokerListenerName(KafkaConfig.scala:437)
        at kafka.server.KafkaConfig.validateValues(KafkaConfig.scala:704)
        at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:613)
        at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:158)
```

I also updated the documentation regarding how to enable external access.

### Benefits

You can now separate brokers and controllers

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/32851

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
