### PR TITLE
[clickhouse-operator] ci: remove hack on runtime parameters

### DIFF
--- a/.vib/clickhouse-operator/runtime-parameters.yaml
+++ b/.vib/clickhouse-operator/runtime-parameters.yaml
@@ -184,12 +184,6 @@ extraDeploy:
                   - name: default-volume-claim
                     mountPath: /bitnami/clickhouse-keeper
                   # Hack required for read-only fs
-                  - name: chk-vib-deploy-confd-vib-0-0
-                    mountPath: /opt/bitnami/clickhouse-keeper/etc/conf.d
-                  - name: chk-vib-common-configd
-                    mountPath: /opt/bitnami/clickhouse-keeper/etc/keeper_config.d
-                  - name: chk-vib-common-usersd
-                    mountPath: /opt/bitnami/clickhouse-keeper/etc/users.d
                   - name: empty-dir
                     mountPath: /opt/bitnami/clickhouse-keeper/etc
                     subPath: app-conf-dir

--- a/bitnami/clickhouse-operator/CHANGELOG.md
+++ b/bitnami/clickhouse-operator/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 0.2.2 (2025-05-13)
+## 0.2.4 (2025-05-16)
 
-* [bitnami/clickhouse-operator] :zap: :arrow_up: Update dependency references ([#33631](https://github.com/bitnami/charts/pull/33631))
+* [clickhouse-operator] ci: remove hack on runtime parameters ([#33753](https://github.com/bitnami/charts/pull/33753))
+
+## <small>0.2.3 (2025-05-15)</small>
+
+* [bitnami/clickhouse-operator] :zap: :arrow_up: Update dependency references (#33720) ([855e5a0](https://github.com/bitnami/charts/commit/855e5a022177e138a7dbf5fe31f7bbab2dc66209)), closes [#33720](https://github.com/bitnami/charts/issues/33720)
+
+## <small>0.2.2 (2025-05-15)</small>
+
+* [bitnami/clickhouse-operator] :zap: :arrow_up: Update dependency references (#33631) ([6b0af73](https://github.com/bitnami/charts/commit/6b0af73be803ed24dff8a04315f05670ba7ae3ef)), closes [#33631](https://github.com/bitnami/charts/issues/33631)
 
 ## <small>0.2.1 (2025-05-13)</small>
 

--- a/bitnami/clickhouse-operator/Chart.yaml
+++ b/bitnami/clickhouse-operator/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
     - name: clickhouse
       image: docker.io/bitnami/clickhouse:25.4.4-debian-12-r0
     - name: clickhouse-keeper
-      image: docker.io/bitnami/clickhouse-keeper:25.4.4-debian-12-r0
+      image: docker.io/bitnami/clickhouse-keeper:25.4.4-debian-12-r1
     - name: clickhouse-operator
       image: docker.io/bitnami/clickhouse-operator:0.24.5-debian-12-r4
     - name: clickhouse-operator-metrics-exporter
@@ -38,4 +38,4 @@ name: clickhouse-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse-operator
 - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse-operator
-version: 0.2.3
+version: 0.2.4

--- a/bitnami/clickhouse-operator/values.yaml
+++ b/bitnami/clickhouse-operator/values.yaml
@@ -136,7 +136,7 @@ clickHouseImage:
 keeperImage:
   registry: docker.io
   repository: bitnami/clickhouse-keeper
-  tag: 25.4.4-debian-12-r0
+  tag: 25.4.4-debian-12-r1
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
### Description of the change

This PR removes a hack we included on runtime parameters to make Keeper image compatible with the Operator by modifying mount points for custom configuration. With the latest Keeper image, this hack is no longer required.

### Benefits

Hacks not required on read-only-fs environments.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
