### PR TITLE
Milosikor feat(rabbitmq)/add explicit service type to headless service

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 16.0.2
+version: 16.0.3

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -658,6 +658,7 @@ Because they expose different sets of data, a valid use case is to scrape metric
 | `service.annotations`                   | Service annotations. Evaluated as a template                                                                                     | `{}`                     |
 | `service.annotationsHeadless`           | Headless Service annotations. Evaluated as a template                                                                            | `{}`                     |
 | `service.headless.annotations`          | Annotations for the headless service.                                                                                            | `{}`                     |
+| `service.headless.type`                 | Explicit Kubernetes Service type for the headless service. Needed in clusters with admission policies that require spec.type to be set.
 | `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                             | `None`                   |
 | `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
 | `service.trafficDistribution`           | Traffic Distribution provides another                                                                                            | `PreferClose`            |

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -14,6 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
+  type: {{ .Values.service.headless.type | default "ClusterIP" }}
   clusterIP: None
   ports:
     - name: {{ .Values.service.portNames.epmd }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1160,6 +1160,10 @@ service:
   headless:
     ## @param service.headless.annotations Annotations for the headless service.
     ##
+   # Explicitly set the Service type so clusters with Kyverno “restrict-nodeport”
+   # (which requires spec.type to be present) will accept the manifest.
+   # Do **not** change the default unless you really need something else.
+    type: ClusterIP    
     annotations: {}
   ## @param service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
   ## If "ClientIP", consecutive client requests will be directed to the same Pod


### PR DESCRIPTION
feat(rabbitmq): add explicit Service type to headless service

### What this PR does / why we need it

In clusters where the Kyverno **restrict-nodeport** policy is installed
(e.g. the Pod Security Standards *baseline* or *restricted* policy sets),
every Service **must declare `spec.type`**.  
The Bitnami RabbitMQ chart’s *headless* service omits this field because
Kubernetes defaults it to `ClusterIP`, which causes Kyverno to block the
install/upgrade with: validation error: Services of type NodePort are not allowed.
rule validate-nodeport failed at path /spec/type/

This PR:
* makes the field configurable through `values.yaml`  
  (`service.headless.type`)
* sets the default to `ClusterIP`, preserving the current behaviour
  while satisfying the policy.

### Which issue(s) this PR fixes

No open GH issue – discovered internally when enabling Kyverno baseline
policies.

### Special notes for your reviewer

* No functional change for users who do not override the new value.
* `ClusterIP` continues to work with `clusterIP: None` (headless service).

### Checklist

- [x] DCO signed
- [x] Chart version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. **[rabbitmq]**)