### PR TITLE
[bitnami/common] Prevent release name from breaking DNS naming specification

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.31.1 (2025-05-07)
+## 2.31.2 (2025-05-19)
 
-* [bitnami/common] chore: :recycle: Remove unused helpers ([#33496](https://github.com/bitnami/charts/pull/33496))
+* [bitnami/common] Prevent release name from breaking DNS naming specification ([#33773](https://github.com/bitnami/charts/pull/33773))
+
+## <small>2.31.1 (2025-05-07)</small>
+
+* [bitnami/common] chore: :recycle: Remove unused helpers (#33496) ([d96e16a](https://github.com/bitnami/charts/commit/d96e16aa1e2f1d42de829330f5c0dbc1c4666493)), closes [#33496](https://github.com/bitnami/charts/issues/33496)
 
 ## 2.31.0 (2025-05-05)
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.31.1
+appVersion: 2.31.2
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.31.1
+version: 2.31.2

--- a/bitnami/common/templates/_names.tpl
+++ b/bitnami/common/templates/_names.tpl
@@ -28,10 +28,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $releaseName := regexReplaceAll "(-?[^a-z\\d\\-])+-?" (lower .Release.Name) "-" -}}
+{{- if contains $name $releaseName -}}
+{{- $releaseName | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR fixes an issue in the `bitnami/common` Helm chart templates where the release name could violate DNS naming conventions.  
The fix sanitizes the release name generation logic in `_names.tpl` to ensure it complies with DNS label standards, preventing deployment errors caused by invalid resource names.

### Benefits

- Ensures Helm release names conform to DNS naming specifications.  
- Prevents deployment failures related to invalid resource names.  
- Improves overall chart stability and compatibility with Kubernetes naming requirements.

### Possible drawbacks

- No known drawbacks. This change is backward compatible and does not affect existing functionality aside from improving name validation.

### Applicable issues

- 

### Additional information

Tested locally with various release names to confirm resource names are valid and deployments succeed.

```ruby
    "A-B" => "a-b"
   "A--B" => "a--b"
 "-A--B-" => "-a--b-"
    "A.B" => "a-b"
   "A..B" => "a-b"
 "A-..-B" => "a-b"
"A--..-B" => "a-b"
"A-..--B" => "a-b"
```


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
