### PR TITLE
[bitnami/postgresql-ha] bugfix: missing password for 'postgres' user when using custom user/db

### DIFF
--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 16.0.5 (2025-05-15)
+## 16.0.6 (2025-05-20)
 
-* [bitnami/postgresql-ha] :zap: :arrow_up: Update dependency references ([#33705](https://github.com/bitnami/charts/pull/33705))
+* [bitnami/postgresql-ha] bugfix: missing password for 'postgres' user when using custom user/db ([#33786](https://github.com/bitnami/charts/pull/33786))
+
+## <small>16.0.5 (2025-05-15)</small>
+
+* [bitnami-postgresql-ha] docs: document security fix on 16.0.0 (#33659) ([9d71b3a](https://github.com/bitnami/charts/commit/9d71b3ad0c5598932670d59c7d118d7a0c496d54)), closes [#33659](https://github.com/bitnami/charts/issues/33659)
+* [bitnami/postgresql-ha] :zap: :arrow_up: Update dependency references (#33705) ([a2fac0d](https://github.com/bitnami/charts/commit/a2fac0de6560264e16c1632a4795a1b111630f0b)), closes [#33705](https://github.com/bitnami/charts/issues/33705)
 
 ## <small>16.0.4 (2025-05-12)</small>
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 16.0.5
+version: 16.0.6

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -87,15 +87,6 @@ Return the PostgreSQL database to create
 {{- end -}}
 
 {{/*
-Return true if PostgreSQL postgres user password has been provided
-*/}}
-{{- define "postgresql-ha.postgresqlPasswordProvided" -}}
-{{- if not (empty (coalesce ((.Values.global).postgresql).postgresPassword .Values.postgresql.postgresPassword) | default "") -}}
-    {{- true -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the Pgpool Admin username
 */}}
 {{- define "postgresql-ha.pgpoolAdminUsername" -}}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -188,7 +188,7 @@ spec:
               value: {{ .Values.persistence.mountPath | quote }}
             - name: PGDATA
               value: {{ printf "%s/%s" .Values.persistence.mountPath "data" | quote }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (include "postgresql-ha.postgresqlCreateSecret" .) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
             {{- if .Values.postgresql.usePasswordFiles }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
               value: "/opt/bitnami/postgresql/secrets/postgres-password"
@@ -488,8 +488,8 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if .Values.postgresql.usePasswordFiles }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (include "postgresql-ha.postgresqlCreateSecret" .) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
-            - name: postgres-password
+            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            - name: postgresql-creds
               mountPath: /opt/bitnami/postgresql/secrets/postgres-password
               subPath: postgres-password
             {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -188,7 +188,7 @@ spec:
               value: {{ .Values.persistence.mountPath | quote }}
             - name: PGDATA
               value: {{ printf "%s/%s" .Values.persistence.mountPath "data" | quote }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            {{- if not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres") }}
             {{- if .Values.postgresql.usePasswordFiles }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
               value: "/opt/bitnami/postgresql/secrets/postgres-password"
@@ -488,7 +488,7 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if .Values.postgresql.usePasswordFiles }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            {{- if not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres") }}
             - name: postgresql-creds
               mountPath: /opt/bitnami/postgresql/secrets/postgres-password
               subPath: postgres-password

--- a/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
@@ -179,7 +179,7 @@ spec:
               value: {{ .Values.persistence.mountPath | quote }}
             - name: PGDATA
               value: {{ printf "%s/%s" .Values.persistence.mountPath "data" | quote }}
-            {{- if and (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) }}
+            {{- if not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres") }}
             {{- if .Values.witness.usePasswordFiles }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
               value: "/opt/bitnami/postgresql/secrets/postgres-password"


### PR DESCRIPTION
### Description of the change

This PR ensures we properly set `POSTGRES_POSTGRES_PASSWORD` when using a custom user/db, regardless the password for 'postgres' user is consumed from an existing secret or not. 

### Benefits

The workflow below works:

```
kubectl create secret generic pgpool --from-literal=admin-password=adminPassword --from-literal=sr-check-password=srCheckPassword
kubectl create secret generic postgresql --from-literal=postgres-password=postgresPassword --from-literal=password=password --from-literal=repmgr-password=repmgrPassword
helm install my-release oci://registry-1.docker.io/bitnamicharts/postgresql-ha --set global.postgresql.existingSecret=postgresql --set global.pgpool.existingSecret=pgpool --set postgresql.database=test --set postgresql.username=test
```

### Possible drawbacks

None

### Applicable issues

- fixes #25671

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
