### PR TITLE
[bitnami/keycloak] Use https port for realm endpoint of service monitor when scheme set to https

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.7.1 (2025-05-22)
+## 24.7.2 (2025-05-23)
 
-* [bitnami/keycloak] fix: preserve timestamps in init script ([#33812](https://github.com/bitnami/charts/pull/33812))
+* [bitnami/keycloak] Use https port for realm endpoint of service monitor when scheme set to https ([#33801](https://github.com/bitnami/charts/pull/33801))
+
+## <small>24.7.1 (2025-05-22)</small>
+
+* [bitnami/keycloak] fix: preserve timestamps in init script (#33812) ([f3ec521](https://github.com/bitnami/charts/commit/f3ec521adf17b1e836760f963c99f8e129bbd276)), closes [#33812](https://github.com/bitnami/charts/issues/33812)
 
 ## 24.7.0 (2025-05-19)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.7.1
+version: 24.7.2

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1054,7 +1054,7 @@ metrics:
     endpoints:
       - path: '{{ include "keycloak.httpPath" . }}metrics'
       - path: '{{ include "keycloak.httpPath" . }}realms/{{ .Values.adminRealm }}/metrics'
-        port: http
+        port: '{{ ternary "https" "http" (eq .Values.metrics.serviceMonitor.scheme "https") }}'
     ## @param metrics.serviceMonitor.path Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead
     ##
     path: ""


### PR DESCRIPTION
### Description of the change

Bugfix: When `.Values.metrics.serviceMonitor.scheme` is set to `https`, the port of the realm metrics endpoint is also set to the `https` port.

### Benefits

Bugfix. Currently the port is set to `http` which will result in a failing target in Prometheus, since it will try to access the endpoint with the `https` scheme.

### Possible drawbacks

%

### Applicable issues

%

### Additional information

%

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
