### PR TITLE
[bitnami/mongodb] generate-tls-certs init container should respect tls securityContext

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.5.16 (2025-06-03)
+## 16.5.17 (2025-06-04)
 
-* [bitnami/mongodb] :zap: :arrow_up: Update dependency references ([#34085](https://github.com/bitnami/charts/pull/34085))
+* [bitnami/mongodb] generate-tls-certs init container should respect tls securityContext ([#33803](https://github.com/bitnami/charts/pull/33803))
+
+## <small>16.5.16 (2025-06-03)</small>
+
+* [bitnami/mongodb] :zap: :arrow_up: Update dependency references (#34085) ([f8d2e2e](https://github.com/bitnami/charts/commit/f8d2e2ea8ca1f5d7f88f6e23d424d9b6616268b3)), closes [#34085](https://github.com/bitnami/charts/issues/34085)
 
 ## <small>16.5.15 (2025-06-03)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.5.16
+version: 16.5.17

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -126,6 +126,9 @@ spec:
             - /bitnami/scripts/generate-certs.sh
           args:
             - -s {{ include "mongodb.arbiter.service.nameOverride" . }}
+          {{- if .Values.tls.securityContext }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.tls.securityContext "context" $) | nindent 12 }}
+          {{- end }}
         {{- end }}
       containers:
         - name: mongodb-arbiter

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -115,6 +115,9 @@ spec:
               {{- else if ne .Values.tls.resourcesPreset "none" }}
               resources: {{- include "common.resources.preset" (dict "type" .Values.tls.resourcesPreset) | nindent 16 }}
               {{- end }}
+              {{- if .Values.tls.securityContext }}
+              securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.tls.securityContext "context" $) | nindent 16 }}
+              {{- end }}
           {{- end }}
           containers:
           - name: {{ include "mongodb.fullname" . }}-mongodump

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -149,6 +149,9 @@ spec:
           {{- else if ne .Values.tls.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.tls.resourcesPreset) | nindent 12 }}
           {{- end }}
+          {{- if .Values.tls.securityContext }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.tls.securityContext "context" $) | nindent 12 }}
+          {{- end }}
         {{- end }}
       containers:
         - name: mongodb


### PR DESCRIPTION
### Description of the change

The generate-tls-certs initContainer in the backup CronJob will now apply the securityContext set in `tls.securityContext` the same way it does when used as an initContainer for the StatefulSet.  

### Benefits

Backup CronJob can successfully deploy to systems using restricted PSS

### Possible drawbacks

None

### Applicable issues

- fixes #33802


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
