### PR TITLE
[bitnami/dremio] fix: ingress to wrong port

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.1 (2025-05-16)
+## 2.0.3 (2025-05-20)
 
-* [bitnami/dremio] :zap: :arrow_up: Update dependency references ([#33761](https://github.com/bitnami/charts/pull/33761))
+* [bitnami/dremio] fix: ingress to wrong port ([#33804](https://github.com/bitnami/charts/pull/33804))
+
+## <small>2.0.1 (2025-05-16)</small>
+
+* [bitnami/dremio] :zap: :arrow_up: Update dependency references (#33761) ([2a6b0ba](https://github.com/bitnami/charts/commit/2a6b0ba70ae3702d635ae8dae59914e432210c96)), closes [#33761](https://github.com/bitnami/charts/issues/33761)
 
 ## 2.0.0 (2025-05-16)
 

--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.3 (2025-05-20)
+## 2.0.3 (2025-05-21)
 
 * [bitnami/dremio] fix: ingress to wrong port ([#33804](https://github.com/bitnami/charts/pull/33804))
 

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 2.0.1
+version: 2.0.3

--- a/bitnami/dremio/templates/ingress.yaml
+++ b/bitnami/dremio/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
           {{- end }}
           - path: {{ .Values.ingress.path }}
             pathType: {{ .Values.ingress.pathType }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http-web" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name | quote }}


### PR DESCRIPTION
### Description of the change

Make the ingress expose the correct port to the UI

### Benefits

Make the ingress work by default

### Possible drawbacks

Maybe it should be a variable ?

### Additional information

Port name is defined here : https://github.com/bitnami/charts/blob/788718d0999fa2ebb8953eb604e3df5226f7c84c/bitnami/dremio/templates/service.yaml#L40C13-L40C21

Chart.yml version was bumped two minor versions, to be compatible with #33752 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
