### PR TITLE
[bitnami/influxdb] bugfix: address limitations with read-only restrictive environments

### DIFF
--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.2 (2025-05-22)
+## 7.0.3 (2025-05-23)
 
-* [bitnami/influxdb] :zap: :arrow_up: Update dependency references ([#33842](https://github.com/bitnami/charts/pull/33842))
+* [bitnami/influxdb] bugfix: address limitations with read-only restrictive environments ([#33852](https://github.com/bitnami/charts/pull/33852))
+
+## <small>7.0.2 (2025-05-22)</small>
+
+* [bitnami/influxdb] :zap: :arrow_up: Update dependency references (#33842) ([d06f954](https://github.com/bitnami/charts/commit/d06f95414a039530f74b16ddf7d140596e48e91d)), closes [#33842](https://github.com/bitnami/charts/issues/33842)
 
 ## <small>7.0.1 (2025-05-22)</small>
 

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 7.0.2
+version: 7.0.3

--- a/bitnami/influxdb/templates/create-admin-token-job.yaml
+++ b/bitnami/influxdb/templates/create-admin-token-job.yaml
@@ -159,7 +159,11 @@ spec:
             {{- end }}
           volumeMounts:
             - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
               mountPath: /shared
+              subPath: shared-dir
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- if and (or (eq .Values.objectStore "s3") (eq .Values.objectStore "google") (eq .Values.objectStore "azure")) .Values.usePasswordFiles }}
@@ -203,7 +207,11 @@ spec:
               EOF
           volumeMounts:
             - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
               mountPath: /shared
+              subPath: shared-dir
       volumes:
         - name: empty-dir
           emptyDir: {}

--- a/bitnami/influxdb/templates/delete-admin-token-job.yaml
+++ b/bitnami/influxdb/templates/delete-admin-token-job.yaml
@@ -81,4 +81,11 @@ spec:
             - --namespace
             - {{ include "common.names.namespace" . }}
             - --ignore-not-found
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
 {{- end }}


### PR DESCRIPTION
### Description of the change

In some very restrictive environments, we need to allow write permissions in `/tmp` when using read-only fs on the K8s jobs that make use of `kubectl`

### Benefits

Stability

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
