### PR TITLE
[bitnami/redis] bugfix: issue on ACL when no existing users secret is passed

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 21.1.6
+version: 21.1.7

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -59,8 +59,12 @@ data:
     {{- $userSecret := .Values.auth.acl.userSecret -}}
     {{- range .Values.auth.acl.users }}
     {{- $userPassword := .password | default "" }}
-    {{- $secretPassword := (include "common.secrets.get" (dict "secret" $userSecret "key" .username "context" $))}}
-    user {{ .username }} {{ default "on" .enabled }} {{ if $secretPassword }}#{{ sha256sum $secretPassword }}{{ else if $userPassword }}#{{ sha256sum $userPassword }}{{ else }}nopass{{ end }} {{ default "~*" .keys }} {{ default "&*" .channels }} {{ default "+@all" .commands }}
+    {{- if $userSecret }}
+    {{- $secretPassword := include "common.secrets.get" (dict "secret" $userSecret "key" .username "context" $) }}
+    user {{ .username }} {{ default "on" .enabled }} {{ if $secretPassword }}#{{ sha256sum $secretPassword }}{{ else }}nopass{{ end }} {{ default "~*" .keys }} {{ default "&*" .channels }} {{ default "+@all" .commands }}
+    {{- else }}
+    user {{ .username }} {{ default "on" .enabled }} {{ if $userPassword }}#{{ sha256sum $userPassword }}{{ else }}nopass{{ end }} {{ default "~*" .keys }} {{ default "&*" .channels }} {{ default "+@all" .commands }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- end }}


### PR DESCRIPTION
### Description of the change

This PR fixes an issue when ACL is enabled and no existing secret is passed via the `auth.acl.userSecret` parameter given the chart was failing with the error below:

```
Error: template: redis/templates/replicas/application.yaml:49:38: executing "redis/templates/replicas/application.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: redis/templates/configmap.yaml:62:28: executing "redis/templates/configmap.yaml" at <include "common.secrets.get" (dict "secret" $userSecret "key" .username "context" $)>: error calling include: template: redis/templates/_helpers.tpl:218:20: executing "common.secrets.get" at <index $secret.data .key>: error calling index: index of untyped nil
```

when using values such as this one:

```yaml
auth:
  enabled: true
  acl:
    enabled: true
    users:
      - username: "my-user"
        password: "mypassword"
        enabled: "on"
        commands: "+@all"
        keys: "~*"
        channels: "&*"
```

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
