### PR TITLE
fix(kuberay): wrong indentation in nodeAffinity element

### DIFF
--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 1.4.11 (2025-05-26)
+## 1.4.12 (2025-05-28)
 
-* [bitnami/kuberay] Release 1.4.11 ([#33481](https://github.com/bitnami/charts/pull/33481))
+* fix(kuberay): wrong indentation in nodeAffinity element ([#33929](https://github.com/bitnami/charts/pull/33929))
+
+## <small>1.4.11 (2025-05-26)</small>
+
+* [bitnami/kubeapps] Deprecation followup (#33579) ([77e312c](https://github.com/bitnami/charts/commit/77e312c1772d4d7c4dc5d3ac0e80f4e452e3a062)), closes [#33579](https://github.com/bitnami/charts/issues/33579)
+* [bitnami/kuberay] Release 1.4.11 (#33481) ([5b3a24b](https://github.com/bitnami/charts/commit/5b3a24bb0bb33c11f7839bb793bf8ea82129bc75)), closes [#33481](https://github.com/bitnami/charts/issues/33481)
 
 ## <small>1.4.10 (2025-05-06)</small>
 

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.4.11
+version: 1.4.12

--- a/bitnami/kuberay/templates/cluster/raycluster.yaml
+++ b/bitnami/kuberay/templates/cluster/raycluster.yaml
@@ -171,7 +171,7 @@ spec:
             {{- $podAntiAffinityPreset := coalesce .podAntiAffinityPreset $.Values.cluster.worker.common.podAntiAffinityPreset }}
             podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $podAntiAffinityPreset "component" (printf "cluster-worker-%s" .groupName) "customLabels" $podLabels "context" $) | nindent 14 }}
             {{- $nodeAffinityPreset := coalesce .nodeAffinityPreset $.Values.cluster.worker.common.nodeAffinityPreset }}
-            nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $nodeAffinityPreset.type "key" $nodeAffinityPreset.key "values" $nodeAffinityPreset.values) | nindent 12 }}
+            nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $nodeAffinityPreset.type "key" $nodeAffinityPreset.key "values" $nodeAffinityPreset.values) | nindent 14 }}
           {{- end }}
           {{- $nodeSelector := coalesce .nodeSelector $.Values.cluster.worker.common.nodeSelector }}
           {{- if $nodeSelector }}


### PR DESCRIPTION
### Description of the change

Fix the indentation of `nodeAffinity` element in `workerGroupSpecs`.

### Benefits

This chart does not work unless setting `cluster.enabled: false`

### Possible drawbacks

None

### Applicable issues

- fixes #33887

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
