### PR TITLE
Deprecate Spring Cloud

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 37.0.4 (2025-05-20)
+## 37.0.5 (2025-05-29)
 
-* [bitnami/spring-cloud-dataflow] :zap: :arrow_up: Update dependency references ([#33793](https://github.com/bitnami/charts/pull/33793))
+* Deprecate Spring Cloud ([#33958](https://github.com/bitnami/charts/pull/33958))
+
+## <small>37.0.4 (2025-05-20)</small>
+
+* [bitnami/spring-cloud-dataflow] :zap: :arrow_up: Update dependency references (#33793) ([67deb62](https://github.com/bitnami/charts/commit/67deb626e62f6da42035c75ce329a09dd915e1b0)), closes [#33793](https://github.com/bitnami/charts/issues/33793)
 
 ## <small>37.0.3 (2025-05-15)</small>
 

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,7 +38,9 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: Spring Cloud Data Flow is a microservices-based toolkit for building
+# The Spring Cloud Data Flow chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Spring Cloud Data Flow is a microservices-based toolkit for building
   streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
@@ -47,10 +49,8 @@ keywords:
 - dataflow
 - skipper
 - spring
-maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+maintainers: []
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 37.0.4
+version: 37.0.5

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -6,6 +6,10 @@ Spring Cloud Data Flow is a microservices-based toolkit for building streaming a
 
 [Overview of Spring Cloud Data Flow](https://github.com/spring-cloud/spring-cloud-dataflow)
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued, therefore, this Helm chart will be deprecated as well.
+
 ## TL;DR
 
 ```console

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued, therefore, this Helm chart will be deprecated as well.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
Those applications are not being maintained upstream, see https://spring.io/blog/2025/04/21/spring-cloud-data-flow-commercial:

> Today we're announcing that going forward *we will not be maintaining Spring Cloud Data Flow, Spring Cloud Deployer, or Spring Statemachine as open-source projects*. Spring Cloud Data Flow 2.11.x, Spring Cloud Deployer 2.9.x, and Spring Statemachine 4.0.x will be the last open-source lines and any future releases will only be made available to Tanzu Spring customers. This change has no impact on the rest of the open-source Spring portfolio or the support obligations of the currently available OSS versions for existing users.

Related to https://github.com/bitnami/charts/issues/33797