### PR TITLE
fix(retry-failed-releases): Find releases with new format

### DIFF
--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -27,7 +27,7 @@ jobs:
           curl -X GET -GLkso "${TEMP_FILE}" "${WORKFLOW_RUNS_URL}" \
             -d "status=failure" -d "actor=bitnami-bot" -d "created=>$(date -d '-3 day' '+%Y-%m-%d')" -d "per_page=100"
           readarray -t retriable_runs_ids < <(jq --argjson runs ${MAX_RUNS_ATTEMPS} \
-            '.workflow_runs[] | select((.run_attempt < $runs) and (.display_title | contains("Release"))).id' "${TEMP_FILE}")
+            '.workflow_runs[] | select((.run_attempt < $runs) and (.display_title | contains("Update dependency references"))).id' "${TEMP_FILE}")
 
           echo "Found ${#retriable_runs_ids[@]} failed runs that need to be retried"
           if [[ ${#retriable_runs_ids[@]} -gt ${MAX_RETRY_SLOTS} ]]; then

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           # Obtain "CI Pipeline" failed runs executed by the bitnami-bot and filter those from release PRs with $MAX_RUNS_ATTEMPS or more attempts
           curl -X GET -GLkso "${TEMP_FILE}" "${WORKFLOW_RUNS_URL}" \
-            -d "status=failure" -d "author=bitnami-bot" -d "created=>$(date -d '-3 day' '+%Y-%m-%d')" -d "per_page=100"
+            -d "status=failure" -d "actor=bitnami-bot" -d "created=>$(date -d '-3 day' '+%Y-%m-%d')" -d "per_page=100"
           readarray -t retriable_runs_ids < <(jq --argjson runs ${MAX_RUNS_ATTEMPS} \
             '.workflow_runs[] | select((.run_attempt < $runs) and (.display_title | contains("Release"))).id' "${TEMP_FILE}")
 


### PR DESCRIPTION
### Description of the change

* According to the [documentation](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow) `author` is not a valid query parameter.
* Title for automated releases has been changed. Some examples:
  * #33948
  * #33924

### Benefits

Automated releases can be retried again automatically.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
