### PR TITLE
Declare kind and apiVersion for volumeClaimTemplates

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 24.1.2 (2025-06-01)
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 24.1.1 (2025-05-18)
 
 * [bitnami/airflow] update README to match deprecated values ([#33602](https://github.com/bitnami/charts/pull/33602))

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 24.1.1
+version: 24.1.2

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -301,7 +301,9 @@ spec:
     whenScaled: {{ .Values.triggerer.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: logs
         {{- if or .Values.triggerer.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" (dict "values" .Values.triggerer.persistence.annotations .Values.commonAnnotations "context" .) | fromYaml }}

--- a/bitnami/concourse/CHANGELOG.md
+++ b/bitnami/concourse/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.1.33 (2025-06-01)
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 5.1.32 (2025-05-23)
 
 * [bitnami/concourse] :zap: :arrow_up: Update dependency references ([#33868](https://github.com/bitnami/charts/pull/33868))

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: concourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/concourse
-version: 5.1.32
+version: 5.1.33

--- a/bitnami/concourse/templates/worker/statefulset.yaml
+++ b/bitnami/concourse/templates/worker/statefulset.yaml
@@ -275,7 +275,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: concourse-work-dir
         {{- if .Values.worker.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/consul/CHANGELOG.md
+++ b/bitnami/consul/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 11.4.19 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 11.4.18 (2025-05-23)
 
 * [bitnami/consul] :zap: :arrow_up: Update dependency references ([#33864](https://github.com/bitnami/charts/pull/33864))

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 11.4.18
+version: 11.4.19

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -368,7 +368,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.15 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 2.3.14 (2025-05-23)
 
 * [bitnami/deepspeed] :zap: :arrow_up: Update dependency references ([#33851](https://github.com/bitnami/charts/pull/33851))

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -38,4 +38,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.3.14
+version: 2.3.15

--- a/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
@@ -241,7 +241,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.worker.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 2.0.3 (2025-05-21)
 
 * [bitnami/dremio] fix: ingress to wrong port ([#33804](https://github.com/bitnami/charts/pull/33804))

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 2.0.3
+version: 2.0.4

--- a/bitnami/dremio/templates/coordinator/statefulset.yaml
+++ b/bitnami/dremio/templates/coordinator/statefulset.yaml
@@ -367,7 +367,9 @@ spec:
         {{- end }}
   {{- if .Values.coordinator.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.coordinator.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" (dict "values" .Values.coordinator.persistence.annotations .Values.commonAnnotations "context" .) | fromYaml }}

--- a/bitnami/dremio/templates/executor/statefulset.yaml
+++ b/bitnami/dremio/templates/executor/statefulset.yaml
@@ -368,7 +368,9 @@ spec:
         {{- end }}
   {{- if $executorValues.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or $executorValues.persistence.annotations $.Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" (dict "values" $executorValues.persistence.annotations $.Values.commonAnnotations "context" $) | fromYaml }}

--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.1 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 12.0.0 (2025-05-23)
 
 * [bitnami/etcd] :zap: :arrow_up: Update dependency references ([#33840](https://github.com/bitnami/charts/pull/33840))

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -446,7 +446,9 @@ spec:
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.8.13 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 4.8.12 (2025-05-30)
 
 * [bitnami/grafana-loki] :zap: :arrow_up: Update dependency references ([#34000](https://github.com/bitnami/charts/pull/34000))

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -58,4 +58,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.8.12
+version: 4.8.13

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -212,7 +212,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.commonLabels }}
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}

--- a/bitnami/grafana-mimir/CHANGELOG.md
+++ b/bitnami/grafana-mimir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.8 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 2.0.7 (2025-05-30)
 
 * [bitnami/grafana-mimir] :zap: :arrow_up: Update dependency references ([#33997](https://github.com/bitnami/charts/pull/33997))

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -61,4 +61,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 2.0.7
+version: 2.0.8

--- a/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
@@ -223,7 +223,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.alertmanager.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
@@ -222,7 +222,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.compactor.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.compactor.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
@@ -222,7 +222,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.ingester.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
@@ -222,7 +222,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.storeGateway.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.storeGateway.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-tempo/CHANGELOG.md
+++ b/bitnami/grafana-tempo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.7 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 4.0.6 (2025-05-13)
 
 * [bitnami/grafana-tempo] :zap: :arrow_up: Update dependency references ([#33653](https://github.com/bitnami/charts/pull/33653))

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 4.0.6
+version: 4.0.7

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -209,7 +209,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.ingester.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingester.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/statefulset.yaml
@@ -209,7 +209,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.metricsGenerator.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metricsGenerator.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.6.2 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 26.6.1 (2025-05-30)
 
 * [bitnami/harbor] :zap: :arrow_up: Update dependency references ([#33999](https://github.com/bitnami/charts/pull/33999))

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -56,4 +56,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 26.6.1
+version: 26.6.2

--- a/bitnami/harbor/templates/trivy/trivy-sts.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-sts.yaml
@@ -243,7 +243,9 @@ spec:
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 10 }}
         {{- if .Values.persistence.persistentVolumeClaim.trivy.annotations }}

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.11 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 0.5.10 (2025-05-22)
 
 * [bitnami/keydb] :zap: :arrow_up: Update dependency references ([#33823](https://github.com/bitnami/charts/pull/33823))

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -36,4 +36,4 @@ name: keydb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keydb
 - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.5.10
+version: 0.5.11

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -409,7 +409,9 @@ spec:
     whenScaled: {{ .Values.master.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.master.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" (dict "values" .Values.master.persistence.annotations .Values.commonAnnotations "context" .) | fromYaml }}

--- a/bitnami/keydb/templates/replica/statefulset.yaml
+++ b/bitnami/keydb/templates/replica/statefulset.yaml
@@ -431,7 +431,9 @@ spec:
     whenScaled: {{ .Values.replica.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.replica.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" (dict "values" .Values.replica.persistence.annotations .Values.commonAnnotations "context" .) | fromYaml }}

--- a/bitnami/logstash/CHANGELOG.md
+++ b/bitnami/logstash/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.2 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 7.0.2 (2025-05-06)
 
 * [bitnami/logstash] Release 7.0.2 ([#33465](https://github.com/bitnami/charts/pull/33465))

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: logstash
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 7.0.2
+version: 7.0.3

--- a/bitnami/logstash/templates/sts.yaml
+++ b/bitnami/logstash/templates/sts.yaml
@@ -225,7 +225,9 @@ spec:
         {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/mariadb-galera/CHANGELOG.md
+++ b/bitnami/mariadb-galera/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 14.2.7 (2025=06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 14.2.6 (2025-05-23)
 
 * [bitnami/mariadb-galera] :zap: :arrow_up: Update dependency references ([#33855](https://github.com/bitnami/charts/pull/33855))

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 14.2.6
+version: 14.2.7

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -510,7 +510,9 @@ spec:
           emptyDir: {}
 {{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}

--- a/bitnami/mariadb/CHANGELOG.md
+++ b/bitnami/mariadb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20.5.7 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 20.5.6 (2025-05-23)
 
 * [bitnami/mariadb] :zap: :arrow_up: Update dependency references ([#33856](https://github.com/bitnami/charts/pull/33856))

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 20.5.6
+version: 20.5.7

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -469,7 +469,9 @@ spec:
           emptyDir: {}
   {{- else if and .Values.primary.persistence.enabled (not .Values.primary.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    -   apiVersion: v1
+        kind: PersistentVolumeClaim
+        metadata:
         name: data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.primary.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -437,7 +437,9 @@ spec:
           emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.secondary.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}

--- a/bitnami/memcached/CHANGELOG.md
+++ b/bitnami/memcached/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.8.5 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 7.8.4 (2025-05-28)
 
 * [bitnami/memcached] :zap: :arrow_up: Update dependency references ([#33947](https://github.com/bitnami/charts/pull/33947))

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.8.4
+version: 7.8.5

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -290,7 +290,9 @@ spec:
         {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}

--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16.5.14 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 16.5.13 (2025-05-30)
 
 * [bitnami/mongodb] :zap: :arrow_up: Update dependency references ([#34007](https://github.com/bitnami/charts/pull/34007))

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.5.13
+version: 16.5.14

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -570,7 +570,9 @@ spec:
           {{- end }}
   {{- else }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: datadir
         {{- if .Values.hidden.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -579,7 +579,9 @@ spec:
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: datadir
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -522,7 +522,9 @@ spec:
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .Values.persistence.name | default "datadir" }}
         {{- if .Values.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13.0.1 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 13.0.0 (2025-05-12)
 
 * [bitnami/mysql] :zap: :arrow_up: Update dependency references ([#33608](https://github.com/bitnami/charts/pull/33608))

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -457,7 +457,9 @@ spec:
     whenScaled: {{ .Values.primary.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: primary

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -437,7 +437,9 @@ spec:
     whenScaled: {{ .Values.secondary.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: secondary

--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.0.19 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 9.0.18 (2025-05-22)
 
 * [bitnami/nats] :zap: :arrow_up: Update dependency references ([#33839](https://github.com/bitnami/charts/pull/33839))

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 9.0.18
+version: 9.0.19

--- a/bitnami/nats/templates/application.yaml
+++ b/bitnami/nats/templates/application.yaml
@@ -248,7 +248,9 @@ spec:
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
         {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.11 (2025-06-01)
+
+* Declare `kind` and `apiVersion` for `volumeClaimTemplate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools ([#34025](https://github.com/bitnami/charts/pull/34054))
+
 ## 3.0.10 (2025-05-22)
 
 * [bitnami/valkey-cluster] :zap: :arrow_up: Update dependency references ([#33826](https://github.com/bitnami/charts/pull/33826))

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -36,4 +36,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 3.0.10
+version: 3.0.11

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -476,7 +476,9 @@ spec:
   {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: valkey-data
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 10 }}
         {{- if .Values.persistence.labels }}


### PR DESCRIPTION
### Description of the change

* Declare `kind` and `apiVersion` for `volumeClaimTemplpate`s as these are hydrated by k8s API and can cause sync issues with GitOps tools

### Benefits

- Prevents out-of-box sync issues from GitOps tools

### Possible drawbacks

- Slightly increases noise in YAML files

#### There is not consensus that this will fix this issue
Similar tools have implemented similar changes: 
- https://github.com/VictoriaMetrics/helm-charts/issues/1092
- However full discussion in Argo is here: https://github.com/argoproj/argo-cd/issues/11143

### Applicable issues

https://github.com/argoproj/argo-cd/issues/11143

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [N/A] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
