### PR TITLE
[bitnami/milvus] feat: major version due to Minio major bump

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.0.0
+  version: 12.0.1
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 32.2.8
+  version: 32.2.12
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.0.10
+  version: 17.0.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.1
-digest: sha256:8bf35fc6041427d8330f42e6cb526ce7ab19f8c879d52e10fd64fa2e88697728
-generated: "2025-05-26T10:21:15.087767+02:00"
+digest: sha256:2704e238d9b6f9628aeed634adbfd5ba2c80b9b799a96039b2d29b456873b31c
+generated: "2025-06-04T08:48:31.940112+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
+  version: 17.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -51,4 +51,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 14.0.1
+version: 15.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1865,6 +1865,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 15.0.0
+
+This major updates the `minio` subchart to its newest major, 17.0.0. For more information on this subchart's major, please refer to [minio upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/minio#to-1700).
+
 ### To 14.0.0
 
 This major updates the `etcd` subchart to it newest major, 12.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1200).


### PR DESCRIPTION
### Description of the change

This PR bumps the chart major version due to a major bump on one of its dependencies: MinIO.

### Benefits

Deps are up to date.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
