### PR TITLE
[bitnami/nginx] Allow wildcards in ingress.hostname parameter

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 20.0.5
+version: 20.0.6

--- a/bitnami/nginx/templates/ingress-tls-secret.yaml
+++ b/bitnami/nginx/templates/ingress-tls-secret.yaml
@@ -22,7 +22,7 @@ data:
 ---
 {{- end }}
 {{- else if and .Values.ingress.tls .Values.ingress.selfSigned }}
-{{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
+{{- $secretName := printf "%s-tls" (.Values.ingress.hostname | replace "*." "") }}
 {{- $ca := genCA "nginx-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -58,7 +58,7 @@ spec:
         {{- if and (or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" )) (not (contains "www." (tpl .Values.ingress.hostname .)))  }}
         - {{ printf "www.%s" (tpl .Values.ingress.hostname $) | quote }}
         {{- end }}
-      secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) }}
+      secretName: {{ printf "%s-tls" (.Values.ingress.hostname | replace "*." "") }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

Allow wildcards in the ingress.hostname parameter 

```
diff --git a/bitnami/nginx/values.yaml b/bitnami/nginx/values.yaml
index 0a1400339b..4074ed99e1 100644
--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -765,10 +765,10 @@ networkPolicy:
 ingress:
   ## @param ingress.enabled Set to true to enable ingress record generation
   ##
-  enabled: false
+  enabled: true
   ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
   ##
-  selfSigned: false
+  selfSigned: true
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
@@ -777,7 +777,7 @@ ingress:
   apiVersion: ""
   ## @param ingress.hostname Default host for the ingress resource
   ##
-  hostname: nginx.local
+  hostname: "*.example.com"
   ## @param ingress.path The Path to Nginx. You may need to set this to '/*' in order to use this with ALB ingress controllers.
   ##
   path: /
@@ -802,7 +802,7 @@ ingress:
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
   ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
-  tls: false
+  tls: true
   ## @param ingress.tlsWwwPrefix Adds www subdomain to default cert
   ## Creates tls host with ingress.hostname: {{ print "www.%s" .Values.ingress.hostname }}
   ## Is enabled if "nginx.ingress.kubernetes.io/from-to-www-redirect" is "true"

```

```
➜  nginx git:(bitnami/charts/issues/33692) k get secret example.com-tls -o yaml                                                                                              
Warning: Use tokens from the TokenRequest API or manually created secret-based tokens instead of auto-generated secret-based tokens.
apiVersion: v1
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJ...
```

### Benefits

Allows users using wildcards when generating certificates

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/33692

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
