### PR TITLE
[template] Service Monitor support `tlsConfig`

### DIFF
--- a/template/CHART_NAME/templates/servicemonitor.yaml
+++ b/template/CHART_NAME/templates/servicemonitor.yaml
@@ -26,6 +26,10 @@ spec:
   endpoints:
     - port: tcp-metrics
       path: "/metrics"
+      {{- if .Values.metrics.serviceMonitor.tlsConfig }}
+      scheme: https
+      tlsConfig: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.tlsConfig "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -854,6 +854,9 @@ metrics:
     ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
     ##
     honorLabels: false
+    ## @param metrics.serviceMonitor.tlsConfig TLS configuration to use when scraping the endpoint
+    ##
+    tlsConfig: {}
     ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ## e.g:


### PR DESCRIPTION
### Description of the change

This PR adds support for configuring TLS settings in the `ServiceMonitor` resource by introducing a new `tlsConfig` field in the chart's `values.yaml` and updating the `servicemonitor.yaml` template accordingly. This allows secure communication with the monitored service when using Prometheus Operator.

### Benefits

- Enables users to specify TLS configuration for the `ServiceMonitor`, improving security for metrics scraping.
- Enhances compatibility with services requiring TLS for monitoring endpoints.
- Provides more flexibility and control over Prometheus monitoring setup in the chart.

### Possible drawbacks

- No known drawbacks. The change is backward compatible and optional.

### Applicable issues

-

### Additional information

This change aligns with best practices for secure monitoring and extends the chart's observability features by supporting TLS in `ServiceMonitor`.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.  
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)  
- [x] Title of the pull request follows this pattern [bitnami/] Descriptive title  
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
