### PR TITLE
[bitnami/harbor] bugfix: amend ConfigMap & Secret references

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 26.7.1 (2025-06-06)
+## 26.7.3 (2025-06-06)
 
-* [bitnami/harbor] :zap: :arrow_up: Update dependency references ([#34175](https://github.com/bitnami/charts/pull/34175))
+* [bitnami/harbor] bugfix: amend ConfigMap & Secret references ([#34227](https://github.com/bitnami/charts/pull/34227))
+
+## <small>26.7.2 (2025-06-06)</small>
+
+* [bitnami/harbor] :zap: :arrow_up: Update dependency references (#34177) ([ad08bd5](https://github.com/bitnami/charts/commit/ad08bd5bdc86d99d7e467fb70674c09306faad94)), closes [#34177](https://github.com/bitnami/charts/issues/34177)
+
+## <small>26.7.1 (2025-06-06)</small>
+
+* [bitnami/harbor] :zap: :arrow_up: Update dependency references (#34175) ([8d335ad](https://github.com/bitnami/charts/commit/8d335adf2e80cc8526d6430a0eeca5e27e2a1458)), closes [#34175](https://github.com/bitnami/charts/issues/34175)
 
 ## 26.7.0 (2025-06-05)
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -56,4 +56,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 26.7.0
+version: 26.7.1

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -137,9 +137,9 @@ spec:
             {{- end }}
           envFrom:
             - configMapRef:
-                name: {{ printf "%s-envvars" (include "harbor.core" .) }}
+                name: {{ printf "%s-envvars" (include "harbor.exporter" .) }}
             - secretRef:
-                name: {{ template "harbor.core.envvars.secretName" . }}
+                name: {{ printf "%s-envvars" (include "harbor.exporter" .) }}
             {{- if .Values.exporter.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.exporter.extraEnvVarsSecret "context" $) }}


### PR DESCRIPTION
### Description of the change

This PR amends the ConfigMap & Secret references used on Harbor exporter to load env. variables.

### Benefits

Address bug introduced at https://github.com/bitnami/charts/commit/fd3d9a6bfeb495dc46e17ac29923646c51c67ca6#diff-647397203d5eb5fb06c525555d02e53926a7cd8d0e9adadc05228e9f290be6a9R132-R140

### Possible drawbacks

None

### Applicable issues

- fixes #34099

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
