### PR TITLE
[bitnami/schema-registry] Remove duplicate @param entries from chart

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 25.1.6 (2025-05-12)
+## 25.1.7 (2025-06-07)
 
-* [bitnami/schema-registry] :zap: :arrow_up: Update dependency references ([#33615](https://github.com/bitnami/charts/pull/33615))
+* [bitnami/schema-registry] Remove duplicate @param entries from chart ([#34245](https://github.com/bitnami/charts/pull/34245))
+
+## <small>25.1.6 (2025-05-12)</small>
+
+* [bitnami/schema-registry] :zap: :arrow_up: Update dependency references (#33615) ([67a2ddc](https://github.com/bitnami/charts/commit/67a2ddcc1b699ed3cbfb98122eec26655294c43a)), closes [#33615](https://github.com/bitnami/charts/issues/33615)
 
 ## <small>25.1.5 (2025-05-12)</small>
 

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 25.1.6
+version: 25.1.7

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -361,12 +361,6 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 | `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                          | `[]`                     |
 | `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                | `{}`                     |
 | `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                            | `{}`                     |
-| `ingress.enabled`                       | Enable ingress controller resource                                                                    | `false`                  |
-| `ingress.hostname`                      | Default host for the ingress resource                                                                 | `schema-registry.local`  |
-| `ingress.annotations`                   | Ingress annotations                                                                                   | `{}`                     |
-| `ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                            | `[]`                     |
-| `ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
-| `ingress.secrets`                       | Custom TLS certificates as secrets                                                                    | `[]`                     |
 | `ingress.enabled`                       | Enable ingress record generation for Schema Registry                                                  | `false`                  |
 | `ingress.pathType`                      | Ingress path type                                                                                     | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                         | `""`                     |

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -604,12 +604,6 @@ networkPolicy:
   ##
   ingressNSMatchLabels: {}
   ingressNSPodMatchLabels: {}
-## @param ingress.enabled                Enable ingress controller resource
-## @param ingress.hostname               Default host for the ingress resource
-## @param ingress.annotations            Ingress annotations
-## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
-## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
-## @param ingress.secrets Custom TLS certificates as secrets
 ## Configure the ingress resource that allows you to access Schema Registry
 ##
 ingress:


### PR DESCRIPTION
### Description of the change

Duplicate @param comments caused certain parameters to appear twice in the generated README.md, leading to visual clutter and confusion.

### Benefits

This change removes those redundant comments to improve documentation clarity.

### Checklist

- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
