### PR TITLE
[bitnami/clickhouse-operator] docs: update CHI & CHK examples

### DIFF
--- a/bitnami/clickhouse-operator/README.md
+++ b/bitnami/clickhouse-operator/README.md
@@ -155,6 +155,8 @@ extraDeploy:
     name: test
   spec:
     defaults:
+      storageManagement:
+        provisioner: Operator
       templates:
         podTemplate: default-clickhouse
         dataVolumeClaimTemplate: default-volume-claim
@@ -200,6 +202,8 @@ extraDeploy:
     name: test
   spec:
     defaults:
+      storageManagement:
+        provisioner: Operator
       templates:
         podTemplate: default-keeper
         dataVolumeClaimTemplate: default-volume-claim


### PR DESCRIPTION
### Description of the change

This PR updates the CHI & CHK examples in the README so they include the "storageManagement" properties (useful for managing PVCs via operator and make it easier to scale up/down PVC size).

### Benefits

N/A

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
