### PR TITLE
[bitnami/harbor] bugfix: use proper helper name

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -56,4 +56,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 26.7.3
+version: 26.7.4

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -232,13 +232,13 @@ true
     {{- $externalRedis.password -}}
   {{- else if and (not .context.Values.redis.enabled) $externalRedis.existingSecret -}}
     {{- $secret := tpl $externalRedis.existingSecret .context -}}
-    {{- include "common.secrets.get" (dict "secret" $secret "key" "redis-password" "context" .context) }}
+    {{- include "common.secrets.lookup" (dict "secret" $secret "key" "redis-password" "context" .context) }}
   {{- end -}}
   {{- if and .context.Values.redis.enabled .context.Values.redis.auth.enabled .context.Values.redis.auth.password -}}
     {{- .context.Values.redis.auth.password -}}
   {{- else if and .context.Values.redis.enabled .context.Values.redis.auth.enabled .context.Values.redis.auth.existingSecret -}}
     {{- $secret := tpl .context.Values.redis.auth.existingSecret .context -}}
-    {{- include "common.secrets.get" (dict "secret" $secret "key" "redis-password" "context" .context) }}
+    {{- include "common.secrets.lookup" (dict "secret" $secret "key" "redis-password" "context" .context) }}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

This PR fixes some references to a helper that doesn't exist in common library.

### Benefits

An existing Redis instance can be successfully used.

### Possible drawbacks

None

### Applicable issues

- fixes #33869

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
