### PR TITLE
[bitnami/dremio] Disable MinIO Console

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.1 (2025-06-06)
+## 3.0.2 (2025-06-09)
 
-* [bitnami/dremio] Fix _init_containers.tpl incorrect variable ([#33752](https://github.com/bitnami/charts/pull/33752))
+* [bitnami/dremio] Disable MinIO Console ([#34265](https://github.com/bitnami/charts/pull/34265))
+
+## <small>3.0.1 (2025-06-06)</small>
+
+* [bitnami/dremio] Fix _init_containers.tpl incorrect variable (#33752) ([6a4cb8c](https://github.com/bitnami/charts/commit/6a4cb8cca4177c8da6a672e2dcc0a8c628c88843)), closes [#33752](https://github.com/bitnami/charts/issues/33752)
 
 ## 3.0.0 (2025-06-04)
 

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/dremio/README.md
+++ b/bitnami/dremio/README.md
@@ -1182,6 +1182,7 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | `minio.service.type`               | MinIO&reg; service type                                                                                                           | `ClusterIP`                                         |
 | `minio.service.loadBalancerIP`     | MinIO&reg; service LoadBalancer IP                                                                                                | `""`                                                |
 | `minio.service.ports.api`          | MinIO&reg; service port                                                                                                           | `9000`                                              |
+| `minio.console.enabled`            | Enable MinIO&reg; Console                                                                                                         | `false`                                             |
 
 ### Prometheus metrics parameters
 

--- a/bitnami/dremio/values.yaml
+++ b/bitnami/dremio/values.yaml
@@ -2314,6 +2314,10 @@ minio:
     loadBalancerIP: ""
     ports:
       api: 9000
+  ## @param minio.console.enabled Enable MinIO&reg; Console
+  ##
+  console:
+    enabled: false
 
 ## @section Prometheus metrics parameters
 ##


### PR DESCRIPTION
### Description of the change

This PR disable MinIO Console by default given it's not required when using MinIO as a storage backend for the application.

### Benefits

Only deploy required components by default, reducing resource consumption and improving security by not exposing the MinIO Console.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)