### PR TITLE
[bitnami/mastodon] Disable MinIO Console

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 13.0.1 (2025-06-05)
+## 13.0.2 (2025-06-09)
 
-* [bitnami/mastodon] :zap: :arrow_up: Update dependency references ([#34126](https://github.com/bitnami/charts/pull/34126))
+* [bitnami/mastodon] Disable MinIO Console ([#34266](https://github.com/bitnami/charts/pull/34266))
+
+## <small>13.0.1 (2025-06-05)</small>
+
+* [bitnami/mastodon] :zap: :arrow_up: Update dependency references (#34126) ([f5df349](https://github.com/bitnami/charts/commit/f5df349c81da25bad94adeba8561f1b96372ccd7)), closes [#34126](https://github.com/bitnami/charts/issues/34126)
 
 ## 13.0.0 (2025-06-04)
 

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -51,4 +51,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 13.0.1
+version: 13.0.2

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -823,6 +823,7 @@ The [Bitnami mastodon](https://github.com/bitnami/containers/tree/main/bitnami/m
 | `minio.service.type`               | MinIO&reg; service type                                                                                                          | `ClusterIP`                                            |
 | `minio.service.loadBalancerIP`     | MinIO&reg; service LoadBalancer IP                                                                                               | `""`                                                   |
 | `minio.service.ports.api`          | MinIO&reg; service port                                                                                                          | `80`                                                   |
+| `minio.console.enabled`            | Enable MinIO&reg; Console                                                                                                        | `false`                                                |
 
 ### Elasticsearch chart configuration
 

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -1981,6 +1981,10 @@ minio:
     loadBalancerIP: ""
     ports:
       api: 80
+  ## @param minio.console.enabled Enable MinIO&reg; Console
+  ##
+  console:
+    enabled: false
 ## @section Elasticsearch chart configuration
 ## https://github.com/bitnami/charts/blob/main/bitnami/elasticsearch/values.yaml
 ##


### PR DESCRIPTION
### Description of the change

This PR disable MinIO Console by default given it's not required when using MinIO as a storage backend for the application.

### Benefits

Only deploy required components by default, reducing resource consumption and improving security by not exposing the MinIO Console.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
