### PR TITLE
[bitnami/milvus] Disable MinIO Console

### DIFF
--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -51,4 +51,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 15.0.2
+version: 15.0.3

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1821,6 +1821,7 @@ wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
 | `minio.service.type`               | MinIO&reg; service type                                                                                                           | `ClusterIP`                                         |
 | `minio.service.loadBalancerIP`     | MinIO&reg; service LoadBalancer IP                                                                                                | `""`                                                |
 | `minio.service.ports.api`          | MinIO&reg; service port                                                                                                           | `80`                                                |
+| `minio.console.enabled`            | Enable MinIO&reg; Console                                                                                                         | `false`                                             |
 
 ### kafka sub-chart paramaters
 

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -5425,6 +5425,10 @@ minio:
     loadBalancerIP: ""
     ports:
       api: 80
+  ## @param minio.console.enabled Enable MinIO&reg; Console
+  ##
+  console:
+    enabled: false
 ## @section kafka sub-chart paramaters
 ## https://github.com/bitnami/charts/blob/main/bitnami/kafka/values.yaml
 ##


### PR DESCRIPTION
### Description of the change

This PR disable MinIO Console by default given it's not required when using MinIO as a storage backend for the application.

### Benefits

Only deploy required components by default, reducing resource consumption and improving security by not exposing the MinIO Console.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
