### PR TITLE
[bitnami/thanos] Disable MinIO Console

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.0.1 (2025-06-06)
+## 17.0.2 (2025-06-09)
 
-* [bitnami/thanos] :zap: :arrow_up: Update dependency references ([#34222](https://github.com/bitnami/charts/pull/34222))
+* [bitnami/thanos] Disable MinIO Console ([#34269](https://github.com/bitnami/charts/pull/34269))
+
+## <small>17.0.1 (2025-06-06)</small>
+
+* [bitnami/thanos] :zap: :arrow_up: Update dependency references (#34222) ([48654e6](https://github.com/bitnami/charts/commit/48654e6c16ca5e0f972cf94c1010fa94800a2f96)), closes [#34222](https://github.com/bitnami/charts/issues/34222)
 
 ## 17.0.0 (2025-06-04)
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.0.1
+version: 17.0.2

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1643,6 +1643,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `minio.defaultBuckets`    | Comma, semi-colon or space separated list of MinIO&reg; buckets to create                                                                                                                                  | `thanos` |
 | `minio.resourcesPreset`   | Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro`  |
 | `minio.resources`         | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                          | `{}`     |
+| `minio.console.enabled`   | Enable MinIO&reg; Console                                                                                                                                                                                  | `false`  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -5107,3 +5107,7 @@ minio:
   ##     memory: 1024Mi
   ##
   resources: {}
+  ## @param minio.console.enabled Enable MinIO&reg; Console
+  ##
+  console:
+    enabled: false


### PR DESCRIPTION
### Description of the change

This PR disable MinIO Console by default given it's not required when using MinIO as a storage backend for the application.

### Benefits

Only deploy required components by default, reducing resource consumption and improving security by not exposing the MinIO Console.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
