### PR TITLE
[bitnami/grafana-alloy] Avoid ConfigMap creation if existing one

### DIFF
--- a/bitnami/grafana-alloy/CHANGELOG.md
+++ b/bitnami/grafana-alloy/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.1 (2025-06-09)
+## 0.1.2 (2025-06-10)
 
-* [bitnami/grafana-alloy] :zap: :arrow_up: Update dependency references ([#34238](https://github.com/bitnami/charts/pull/34238))
+* [bitnami/grafana-alloy] Avoid ConfigMap creation if existing one ([#34305](https://github.com/bitnami/charts/pull/34305))
+
+## <small>0.1.1 (2025-06-09)</small>
+
+* [bitnami/grafana-alloy] :zap: :arrow_up: Update dependency references (#34238) ([c2ff7d6](https://github.com/bitnami/charts/commit/c2ff7d60111926370948eab85b2e4f2f4959495f)), closes [#34238](https://github.com/bitnami/charts/issues/34238)
 
 ## 0.1.0 (2025-06-06)
 

--- a/bitnami/grafana-alloy/Chart.yaml
+++ b/bitnami/grafana-alloy/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: grafana-alloy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-alloy
-version: 0.1.1
+version: 0.1.2

--- a/bitnami/grafana-alloy/README.md
+++ b/bitnami/grafana-alloy/README.md
@@ -332,42 +332,42 @@ Install the [Bitnami Kube Prometheus helm chart](https://github.com/bitnami/char
 
 ### Traffic Exposure Parameters
 
-| Name                                    | Description                                                                                                                      | Value          |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `service.type`                          | Grafana Alloy service type                                                                                                       | `LoadBalancer` |
-| `service.ports.http`                    | Grafana Alloy service HTTP port                                                                                                  | `80`           |
-| `service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`           |
-| `service.clusterIP`                     | Grafana Alloy service Cluster IP                                                                                                 | `""`           |
-| `service.loadBalancerIP`                | Grafana Alloy service Load Balancer IP                                                                                           | `""`           |
-| `service.loadBalancerSourceRanges`      | Grafana Alloy service Load Balancer sources                                                                                      | `[]`           |
-| `service.externalTrafficPolicy`         | Grafana Alloy service external traffic policy                                                                                    | `Cluster`      |
-| `service.annotations`                   | Additional custom annotations for Grafana Alloy service                                                                          | `{}`           |
-| `service.extraPorts`                    | Extra ports to expose in Grafana Alloy service (normally used with the `sidecars` value)                                         | `[]`           |
-| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                                 | `None`         |
-| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`           |
-| `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`         |
-| `networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`         |
-| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`         |
-| `networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.                        | `true`         |
-| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`           |
-| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`           |
-| `networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.                              | `{}`           |
-| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                        | `{}`           |
-| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                    | `{}`           |
-| `ingress.enabled`                       | Enable ingress record generation for Grafana Alloy                                                                               | `false`        |
-| `ingress.pathType`                      | Ingress path type                                                                                                                | `Prefix`       |
-| `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`           |
-| `ingress.hostname`                      | Default host for the ingress record                                                                                              | `alloy.local`  |
-| `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`           |
-| `ingress.path`                          | Default path for the ingress record                                                                                              | `/`            |
-| `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`           |
-| `ingress.tls`                           | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`        |
-| `ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`        |
-| `ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`           |
-| `ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`           |
-| `ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`           |
-| `ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`           |
-| `ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`           |
+| Name                                    | Description                                                                                                                      | Value         |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `service.type`                          | Grafana Alloy service type                                                                                                       | `ClusterIP`   |
+| `service.ports.http`                    | Grafana Alloy service HTTP port                                                                                                  | `80`          |
+| `service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`          |
+| `service.clusterIP`                     | Grafana Alloy service Cluster IP                                                                                                 | `""`          |
+| `service.loadBalancerIP`                | Grafana Alloy service Load Balancer IP                                                                                           | `""`          |
+| `service.loadBalancerSourceRanges`      | Grafana Alloy service Load Balancer sources                                                                                      | `[]`          |
+| `service.externalTrafficPolicy`         | Grafana Alloy service external traffic policy                                                                                    | `Cluster`     |
+| `service.annotations`                   | Additional custom annotations for Grafana Alloy service                                                                          | `{}`          |
+| `service.extraPorts`                    | Extra ports to expose in Grafana Alloy service (normally used with the `sidecars` value)                                         | `[]`          |
+| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                                 | `None`        |
+| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`          |
+| `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`        |
+| `networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`        |
+| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`        |
+| `networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.                        | `true`        |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`          |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`          |
+| `networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.                              | `{}`          |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                        | `{}`          |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                    | `{}`          |
+| `ingress.enabled`                       | Enable ingress record generation for Grafana Alloy                                                                               | `false`       |
+| `ingress.pathType`                      | Ingress path type                                                                                                                | `Prefix`      |
+| `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`          |
+| `ingress.hostname`                      | Default host for the ingress record                                                                                              | `alloy.local` |
+| `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`          |
+| `ingress.path`                          | Default path for the ingress record                                                                                              | `/`           |
+| `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`          |
+| `ingress.tls`                           | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`       |
+| `ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`       |
+| `ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`          |
+| `ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`          |
+| `ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`          |
+| `ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`          |
+| `ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`          |
 
 ### Other Parameters
 

--- a/bitnami/grafana-alloy/templates/configmap.yaml
+++ b/bitnami/grafana-alloy/templates/configmap.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if not .Values.alloy.existingConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,3 +46,4 @@ data:
     {{- if .Values.alloy.extraConfig }}
     {{- include "common.tplvalues.render" (dict "value" .Values.alloy.extraConfig "context" .) | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/bitnami/grafana-alloy/values.yaml
+++ b/bitnami/grafana-alloy/values.yaml
@@ -639,7 +639,7 @@ configReloader:
 service:
   ## @param service.type Grafana Alloy service type
   ##
-  type: LoadBalancer
+  type: ClusterIP
   ## @param service.ports.http Grafana Alloy service HTTP port
   ##
   ports:


### PR DESCRIPTION
### Description of the change

Avoid creating a ConfigMap for Alloy configuration if one already exists. It also changes the default service type to ClusterIP as it is usual in our charts.

### Benefits

Avoid extra resources to be created

### Possible drawbacks

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
