### PR TITLE
[bitnami/superset] Support `nameOverride` and `fullnameOverride` for internal Redis®

### DIFF
--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
 - https://github.com/bitnami/containers/tree/main/bitnami/superset
 - https://github.com/apache/superset
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/superset/templates/_helpers.tpl
+++ b/bitnami/superset/templates/_helpers.tpl
@@ -124,7 +124,11 @@ Get the configmap name
 Add environment variables to configure database values
 */}}
 {{- define "superset.database.host" -}}
-{{- ternary (include "superset.postgresql.fullname" .) .Values.externalDatabase.host .Values.postgresql.enabled -}}
+{{- if eq .Values.postgresql.architecture "replication" }}
+    {{- printf "%s-primary" (ternary (include "superset.postgresql.fullname" .) (tpl .Values.externalDatabase.host $) .Values.postgresql.enabled) -}}
+{{- else -}}
+    {{- ternary (include "superset.postgresql.fullname" .) (tpl .Values.externalDatabase.host $) .Values.postgresql.enabled -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/superset/templates/_helpers.tpl
+++ b/bitnami/superset/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create a default fully qualified redis name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "superset.redis.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "redis-master" "chartValues" .Values.redis "context" $) -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "redis" "chartValues" .Values.redis "context" $) -}}
 {{- end -}}
 
 {{/*
@@ -171,7 +171,11 @@ Add environment variables to configure database values
 Add environment variables to configure redis values
 */}}
 {{- define "superset.redis.host" -}}
-{{- ternary (include "superset.redis.fullname" .) .Values.externalRedis.host .Values.redis.enabled -}}
+{{- if .Values.redis.enabled -}}
+    {{- printf "%s-master" (include "superset.redis.fullname" .) -}}
+{{- else -}}
+    {{- printf "%s" (tpl .Values.externalRedis.host $) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Rework the definition of Redis&reg; host: it should add `-master` from the full name of Redis&reg;
- Rework the definition of PostgreSQL host: it should support both `standalone` and `replication`
 architecture
- Add `tpl` for `externalRedis.host` and `externalDatabase.host`

### Benefits

- When overriding Redis&reg; name using `redis.nameOverride` or `redis.fullnameOverride`, Airflow will start without any errors
- When setting `postgresql.architecture` to `replication`, the host will be correctly set

### Possible drawbacks

_N/A_

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #32596 
- fixes #34363

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
I did follow the way Redis&reg; helpers are set in **Appsmith** chart:[ bitnami/appsmith/templates/_helpers.tpl#L124-L141](https://github.com/bitnami/charts/blob/main/bitnami/appsmith/templates/_helpers.tpl#L124-L141)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
