### PR TITLE
[bitnami/dremio] bugfix: common.capabilities.vpa.apiVersion context

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.3 (2025-06-10)
+## 3.0.4 (2025-06-12)
 
-* [bitnami/dremio] :zap: :arrow_up: Update dependency references ([#34303](https://github.com/bitnami/charts/pull/34303))
+* [bitnami/dremio] bugfix: common.capabilities.vpa.apiVersion context ([#34380](https://github.com/bitnami/charts/pull/34380))
+
+## <small>3.0.3 (2025-06-10)</small>
+
+* [bitnami/dremio] :zap: :arrow_up: Update dependency references (#34303) ([f5e9ccb](https://github.com/bitnami/charts/commit/f5e9ccb38d712460211fed98e05de6651c881904)), closes [#34303](https://github.com/bitnami/charts/issues/34303)
 
 ## <small>3.0.2 (2025-06-09)</small>
 

--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.4 (2025-06-12)
+## 3.0.4 (2025-06-13)
 
 * [bitnami/dremio] bugfix: common.capabilities.vpa.apiVersion context ([#34380](https://github.com/bitnami/charts/pull/34380))
 

--- a/bitnami/dremio/Chart.lock
+++ b/bitnami/dremio/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.0.1
+  version: 17.0.4
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 13.8.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.1
-digest: sha256:a530d425ade75a07713a804cea123637fde79bf80462dba252a0df8ca08ba845
-generated: "2025-06-04T08:42:45.510037+02:00"
+  version: 2.31.3
+digest: sha256:2d339a3ab8d2d0a47338a6b4809d202a55d63368289eea533f684fae3a0de7b2
+generated: "2025-06-12T19:33:10.666529+02:00"

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/dremio/templates/coordinator/vpa.yaml
+++ b/bitnami/dremio/templates/coordinator/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.coordinator.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "dremio.coordinator.fullname" . }}

--- a/bitnami/dremio/templates/executor/vpa.yaml
+++ b/bitnami/dremio/templates/executor/vpa.yaml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" $ )) $executorValues.autoscaling.vpa.enabled }}
 ---
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" $ }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "dremio.executor.fullname" (dict "context" $ "engine" $engine.name) }}

--- a/bitnami/dremio/templates/master-coordinator/vpa.yaml
+++ b/bitnami/dremio/templates/master-coordinator/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.masterCoordinator.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "dremio.master-coordinator.fullname" . }}


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/charts/pull/34372 ensuring the usage of `common.capabilities.vpa.apiVersion` is properly adapted according to latest standard. 

### Benefits

Simplify usage.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
