### PR TITLE
[bitnami/victoriametrics] bugfix: common.capabilities.vpa.apiVersion context

### DIFF
--- a/bitnami/victoriametrics/CHANGELOG.md
+++ b/bitnami/victoriametrics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.17 (2025-06-12)
+## 0.1.17 (2025-06-13)
 
 * [bitnami/victoriametrics] bugfix: common.capabilities.vpa.apiVersion context ([#34381](https://github.com/bitnami/charts/pull/34381))
 

--- a/bitnami/victoriametrics/CHANGELOG.md
+++ b/bitnami/victoriametrics/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.16 (2025-06-09)
+## 0.1.17 (2025-06-12)
 
-* [bitnami/victoriametrics] :zap: :arrow_up: Update dependency references ([#34277](https://github.com/bitnami/charts/pull/34277))
+* [bitnami/victoriametrics] bugfix: common.capabilities.vpa.apiVersion context ([#34381](https://github.com/bitnami/charts/pull/34381))
+
+## <small>0.1.16 (2025-06-09)</small>
+
+* [bitnami/victoriametrics] :zap: :arrow_up: Update dependency references (#34277) ([770d769](https://github.com/bitnami/charts/commit/770d769c828d73865cd108cdf002638d46a400c2)), closes [#34277](https://github.com/bitnami/charts/issues/34277)
 
 ## <small>0.1.15 (2025-06-06)</small>
 

--- a/bitnami/victoriametrics/Chart.lock
+++ b/bitnami/victoriametrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.0
-digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
-generated: "2025-05-06T11:13:02.52964167+02:00"
+  version: 2.31.3
+digest: sha256:f9c314553215490ea1b94c70082cb152d6ff5916ce185b4e00f5287f81545b4c
+generated: "2025-06-12T19:33:23.84887+02:00"

--- a/bitnami/victoriametrics/Chart.yaml
+++ b/bitnami/victoriametrics/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: victoriametrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/victoriametrics
-version: 0.1.16
+version: 0.1.17

--- a/bitnami/victoriametrics/templates/vmagent/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vmagent/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.vmagent.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vmagent.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vmagent.fullname" . }}

--- a/bitnami/victoriametrics/templates/vmalert/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vmalert/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.vmalert.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vmalert.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vmalert.fullname" . }}

--- a/bitnami/victoriametrics/templates/vmauth/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vmauth/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.vmauth.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vmauth.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vmauth.fullname" . }}

--- a/bitnami/victoriametrics/templates/vminsert/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vminsert/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vminsert.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vminsert.fullname" . }}

--- a/bitnami/victoriametrics/templates/vmselect/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vmselect/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vmselect.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vmselect.fullname" . }}

--- a/bitnami/victoriametrics/templates/vmstorage/vpa.yaml
+++ b/bitnami/victoriametrics/templates/vmstorage/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.vmstorage.autoscaling.vpa.enabled }}
-apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
+apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "victoriametrics.vmstorage.fullname" . }}


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/charts/pull/34372 ensuring the usage of `common.capabilities.vpa.apiVersion` is properly adapted according to latest standard. 

### Benefits

Simplify usage.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)