### PR TITLE
fix(ci-pipeline): Add comment with errors only when MAX_RUNS_ATTEMPTS is reached

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -657,7 +657,7 @@ jobs:
       # If the CI did not succeed ('VIB Verify' failed or skipped),
       # post a comment on the PR and assign a maintainer agent to review it
       - name: Manual review required
-        if: ${{ always() && (needs.vib-verify.result != 'success' || steps.merge.outcome != 'success' ) }}
+        if: ${{ always() && github.run_attempt >= vars.MAX_RUNS_ATTEMPS && (needs.vib-verify.result != 'success' || steps.merge.outcome != 'success' ) }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           BODY: |

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -657,7 +657,7 @@ jobs:
       # If the CI did not succeed ('VIB Verify' failed or skipped),
       # post a comment on the PR and assign a maintainer agent to review it
       - name: Manual review required
-        if: ${{ always() && github.run_attempt >= vars.MAX_RUNS_ATTEMPS && (needs.vib-verify.result != 'success' || steps.merge.outcome != 'success' ) }}
+        if: ${{ always() && github.run_attempt >= vars.MAX_RUNS_ATTEMPTS && (needs.vib-verify.result != 'success' || steps.merge.outcome != 'success' ) }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           BODY: |

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Retry "CI Pipeline" failed runs in releases PRs
         env:
           MAX_RETRY_SLOTS: 15
-          MAX_RUNS_ATTEMPS: 3
+          MAX_RUNS_ATTEMPS: ${{vars.MAX_RUNS_ATTEMPS}}
           TEMP_FILE: "${{runner.temp}}/failed_runs.json"
           WORKFLOW_RUNS_URL: "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/35553382/runs"
           TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -18,15 +18,15 @@ jobs:
       - name: Retry "CI Pipeline" failed runs in releases PRs
         env:
           MAX_RETRY_SLOTS: 15
-          MAX_RUNS_ATTEMPS: ${{vars.MAX_RUNS_ATTEMPS}}
+          MAX_RUNS_ATTEMPTS: ${{vars.MAX_RUNS_ATTEMPTS}}
           TEMP_FILE: "${{runner.temp}}/failed_runs.json"
           WORKFLOW_RUNS_URL: "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/35553382/runs"
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Obtain "CI Pipeline" failed runs executed by the bitnami-bot and filter those from release PRs with $MAX_RUNS_ATTEMPS or more attempts
+          # Obtain "CI Pipeline" failed runs executed by the bitnami-bot and filter those from release PRs with $MAX_RUNS_ATTEMPTS or more attempts
           curl -X GET -GLkso "${TEMP_FILE}" "${WORKFLOW_RUNS_URL}" \
             -d "status=failure" -d "actor=bitnami-bot" -d "created=>$(date -d '-3 day' '+%Y-%m-%d')" -d "per_page=100"
-          readarray -t retriable_runs_ids < <(jq --argjson runs ${MAX_RUNS_ATTEMPS} \
+          readarray -t retriable_runs_ids < <(jq --argjson runs ${MAX_RUNS_ATTEMPTS} \
             '.workflow_runs[] | select((.run_attempt < $runs) and (.display_title | contains("Update dependency references"))).id' "${TEMP_FILE}")
 
           echo "Found ${#retriable_runs_ids[@]} failed runs that need to be retried"


### PR DESCRIPTION
### Description of the change

Insert the comment in automated PRs with pipeline errors when maximun number of attempts is reached

### Benefits

Avoid the removal of the `auto-merge` label in the first retry. That label is removed once the comment is added.

### Possible drawbacks

None

### Applicable issues

[Several PRs are freezed](https://github.com/bitnami/charts/pulls?q=is%3Apr+is%3Aopen+label%3Areview-required) after the first retry


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
