### PR TITLE
[bitnami/grafana] Templated Rendering of Grafana Datasource SecretName

### DIFF
--- a/bitnami/grafana/CHANGELOG.md
+++ b/bitnami/grafana/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.0.7 (2025-06-18)
+## 12.0.8 (2025-06-18)
 
-* [bitnami/grafana] :zap: :arrow_up: Update dependency references ([#34535](https://github.com/bitnami/charts/pull/34535))
+* [bitnami/grafana] Templated Rendering of Grafana Datasource SecretName ([#34541](https://github.com/bitnami/charts/pull/34541))
+
+## <small>12.0.7 (2025-06-18)</small>
+
+* [bitnami/grafana] :zap: :arrow_up: Update dependency references (#34535) ([303818e](https://github.com/bitnami/charts/commit/303818e6e5ccb33cbbb3bac0d882f3f809846732)), closes [#34535](https://github.com/bitnami/charts/issues/34535)
 
 ## <small>12.0.6 (2025-06-13)</small>
 

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 12.0.7
+version: 12.0.8

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -367,7 +367,7 @@ spec:
         {{- if .Values.datasources.secretName }}
         - name: datasources
           secret:
-            secretName: {{ .Values.datasources.secretName }}
+            secretName: {{ include "common.tplvalues.render" ( dict "value" .Values.datasources.secretName "context" $) }}
         {{- else if .Values.datasources.secretDefinition }}
         - name: datasources
           secret:

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@ metadata:
 secrets:
   - name: {{ include "grafana.adminSecretName" . }}
   {{- if .Values.datasources.secretName }}
-  - name: {{ .Values.datasources.secretName }}
+  - name: {{ include "common.tplvalues.render" ( dict "value" .Values.datasources.secretName "context" $) }}
   {{- else if .Values.datasources.secretDefinition }}
   - name: {{ include "common.names.fullname" . }}-datasources
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Minimal changes were made to the Grafana subchart involving the rendering of `{{ .Values.datasources.secretName }}` to both the `deployment.yaml` and the `serviceaccount.yaml`. These changes more closely align with the rest of the chart's capabilities involving templated rendering of value file attributes.

### Benefits

This change is backwards compatible while providing a more customized way of setting the DataSource's secret name in the chart. The templated rendering should still keep the functionality of previous implementation, while providing more needed customization.
This change would allow me to deploy a secret name based on some variables in the chart, instead of the current approach, which only accepts a hardcoded non-templated value.

### Possible drawbacks

In all honesty, I don't think this causes any drawbacks. The changes were minimal to the Grafana chart (2 lines) and they're backwards compatible.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
