### PR TITLE
[bitnami/mastodon] fix broken PDB Label matching

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -51,4 +51,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 13.0.2
+version: 13.0.3

--- a/bitnami/mastodon/templates/sidekiq/deployment.yaml
+++ b/bitnami/mastodon/templates/sidekiq/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/part-of: mastodon
         app.kubernetes.io/component: sidekiq
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}

--- a/bitnami/mastodon/templates/streaming/deployment.yaml
+++ b/bitnami/mastodon/templates/streaming/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.streaming.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/part-of: mastodon
         app.kubernetes.io/component: streaming
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}

--- a/bitnami/mastodon/templates/web/deployment.yaml
+++ b/bitnami/mastodon/templates/web/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.web.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/part-of: mastodon
         app.kubernetes.io/component: web
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}


### PR DESCRIPTION
### Description of the change

Fix the currently broken PodDisruptionBudgets of Web, Streaming and Sidekiq by applying missing Labels to respective Pods Templates (and therefore Pods)

### Benefits

Existing PodDisruptionBudgets actually take effect, leading to less downtime especially for Web

### Possible drawbacks

None

### Applicable issues

- fixes #34544

### Additional information

It appears that these Labels have been missing from the start, meaning the PDBs were broken form the point they were added to the repo.
The missing `app.kubernetes.io/part-of` Labels in question are part of the [standard Labels mentioned in Helm best practices](https://helm.sh/docs/chart_best_practices/labels/#standard-labels) and already present on the parent Deployments of the Pods, as well as most other objects in this Chart.

Sample output of `kubectl get pdb -n <your-namespace> mastodon-web -oyaml` before the change in an otherwise healthy and ready deployment of this Helm chart:

```
...
status:
  conditions:
  - lastTransitionTime: "2025-06-20T08:23:25Z"
    message: ""
    observedGeneration: 1
    reason: InsufficientPods
    status: "False"
    type: DisruptionAllowed
  currentHealthy: 0
  desiredHealthy: 1
  disruptionsAllowed: 0
  expectedPods: 0
  observedGeneration: 1

```

Note the "InsufficientPods" part, indicating the PdB does not find the 3 running pods generated by the Web Deployment, due to them lacking the Labels.

Output of same command after this change:

```
status:
  conditions:
  - lastTransitionTime: "2025-06-20T08:13:01Z"
    message: ""
    observedGeneration: 1
    reason: SufficientPods
    status: "True"
    type: DisruptionAllowed
  currentHealthy: 3
  desiredHealthy: 1
  disruptionsAllowed: 2
  expectedPods: 3
  observedGeneration: 1

```

the "Sufficient Pods" reason indicates that the selector actually worked this time.
Please disregard the timestamps, as I went back and forth during testing a few times.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)