### PR TITLE
[bitnami/airflow] Configure correct section for api/web secret_key

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.4 (2025-06-19)
+## 24.1.5 (2025-06-23)
 
-* [bitnami/airflow] :zap: :arrow_up: Update dependency references ([#34306](https://github.com/bitnami/charts/pull/34306))
+* [bitnami/airflow] Configure correct section for api/web secret_key ([#34581](https://github.com/bitnami/charts/pull/34581))
+
+## <small>24.1.4 (2025-06-19)</small>
+
+* [bitnami/airflow] :zap: :arrow_up: Update dependency references (#34306) ([24c47d3](https://github.com/bitnami/charts/commit/24c47d393449d1e7d1a62f60ba2ef5db27068239)), closes [#34306](https://github.com/bitnami/charts/issues/34306)
 
 ## <small>24.1.3 (2025-06-16)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 24.1.4
+version: 24.1.5

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -357,8 +357,13 @@ Add environment variables to configure airflow common values
 {{- if .Values.usePasswordFiles }}
 - name: AIRFLOW__CORE__FERNET_KEY_CMD
   value: "cat /opt/bitnami/airflow/secrets/airflow-fernet-key"
+{{- if (include "airflow.isImageMajorVersion3" .) }}
+- name: AIRFLOW__API__SECRET_KEY_CMD
+  value: "cat /opt/bitnami/airflow/secrets/airflow-secret-key"
+{{- else }}
 - name: AIRFLOW__WEBSERVER__SECRET_KEY_CMD
   value: "cat /opt/bitnami/airflow/secrets/airflow-secret-key"
+{{- end }}
 {{- if (include "airflow.isImageMajorVersion3" .) }}
 - name: AIRFLOW__API_AUTH__JWT_SECRET_CMD
   value: "cat /opt/bitnami/airflow/secrets/airflow-jwt-secret-key"
@@ -369,11 +374,19 @@ Add environment variables to configure airflow common values
     secretKeyRef:
       name: {{ include "airflow.secretName" . }}
       key: airflow-fernet-key
+{{- if (include "airflow.isImageMajorVersion3" .) }}
+- name: AIRFLOW__API__SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "airflow.secretName" . }}
+      key: airflow-secret-key
+{{- else }}
 - name: AIRFLOW__WEBSERVER__SECRET_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "airflow.secretName" . }}
       key: airflow-secret-key
+{{- end }}
 {{- if (include "airflow.isImageMajorVersion3" .) }}
 - name: AIRFLOW__API_AUTH__JWT_SECRET_CMD
   valueFrom:


### PR DESCRIPTION
### Description of the change

Configures the right section for the `secret_key` configuration setting depending on Airflow's major version. Addresses the next initialization warning:

```
DeprecationWarning: The secret_key option in [webserver] has been moved to the secret_key option in [api] - the old setting has been used, but please update your config.
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
