### PR TITLE
[bitnami/nessie]fix(serviceMonitor): Amend selector

### DIFF
--- a/bitnami/nessie/CHANGELOG.md
+++ b/bitnami/nessie/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.19 (2025-06-18)
+## 2.0.20 (2025-06-23)
 
-* [bitnami/nessie] :zap: :arrow_up: Update dependency references ([#34376](https://github.com/bitnami/charts/pull/34376))
+* [bitnami/nessie]fix(serviceMonitor): Amend selector ([#34584](https://github.com/bitnami/charts/pull/34584))
+
+## <small>2.0.19 (2025-06-18)</small>
+
+* [bitnami/nessie] :zap: :arrow_up: Update dependency references (#34376) ([cd35dd0](https://github.com/bitnami/charts/commit/cd35dd0a560e9e6b20ac40ac1a17cf964cb48515)), closes [#34376](https://github.com/bitnami/charts/issues/34376)
 
 ## <small>2.0.18 (2025-06-11)</small>
 

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -40,4 +40,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nessie
 - https://github.com/bitnami/containers/tree/main/bitnami/nessie
 - https://github.com/nessie/nessie
-version: 2.0.19
+version: 2.0.20

--- a/bitnami/nessie/templates/service-management.yaml
+++ b/bitnami/nessie/templates/service-management.yaml
@@ -11,6 +11,9 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: nessie
     app.kubernetes.io/part-of: nessie
+  {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+    prometheus.io/scrape: "true"
+  {{- end}}
   {{- if or .Values.service.management.annotations .Values.commonAnnotations .Values.metrics.enabled }}
   {{- $metricsDefaultAnnotations := dict
     "prometheus.io/scrape" "true"

--- a/bitnami/nessie/templates/servicemonitor.yaml
+++ b/bitnami/nessie/templates/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: nessie
       app.kubernetes.io/component: nessie
-      prometheus.io/scrape: true
+      prometheus.io/scrape: "true"
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Amend labels in `serviceMonitor` object and nessie-management service.

### Benefits

Promethues integration works as expected.

### Possible drawbacks
None

### Applicable issues

- fixes #34110

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
