### PR TITLE
[bitnami/mlflow] Create flask-server-secret-key when upgrading

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.0.2 (2025-06-25)
+## 5.0.3 (2025-06-25)
 
-* [bitnami/mlflow] :zap: :arrow_up: Update dependency references ([#34619](https://github.com/bitnami/charts/pull/34619))
+* [bitnami/mlflow] Create flask-server-secret-key when upgrading ([#34629](https://github.com/bitnami/charts/pull/34629))
+
+## <small>5.0.2 (2025-06-25)</small>
+
+* [bitnami/mlflow] :zap: :arrow_up: Update dependency references (#34619) ([4003b7b](https://github.com/bitnami/charts/commit/4003b7b7f3780a03d0945b51dd91a1754c2096c0)), closes [#34619](https://github.com/bitnami/charts/issues/34619)
 
 ## <small>5.0.1 (2025-06-16)</small>
 

--- a/bitnami/mlflow/Chart.lock
+++ b/bitnami/mlflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.0.4
+  version: 17.0.8
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.11
+  version: 16.7.13
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:c252094b712972505989fb32c50bd90bf5cfa17b03ea021aa24b753094f3959f
-generated: "2025-06-16T11:32:02.033411+02:00"
+digest: sha256:a49a0e646101b87c316424a5ad413f3f43251800598bf746e72e458781bbbca8
+generated: "2025-06-25T16:02:41.651744+02:00"

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -47,4 +47,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 5.0.2
+version: 5.0.3

--- a/bitnami/mlflow/templates/tracking/auth-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/auth-secret.yaml
@@ -19,5 +19,5 @@ data:
   # We need to add the username as it is required by the ServiceMonitor object
   admin-user: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "admin-user" "providedValues" (list "tracking.auth.username") "context" $) }}
   admin-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "admin-password" "providedValues" (list "tracking.auth.password") "context" $) }}
-  flask-server-secret-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "flask-server-secret-key" "providedValues" (list "tracking.auth.flaskServerSecretKey") "context" $) }}
+  flask-server-secret-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "flask-server-secret-key" "providedValues" (list "tracking.auth.flaskServerSecretKey") "failOnNew" false "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Create flask-server-secret-key when upgrading if it does not exists

### Benefits

Allows upgrading from version prior to 2.5.1 

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #34156

### Additional information

Change [added to auth-secret.yaml template in version 2.5.1](https://github.com/bitnami/charts/commit/955396401facdf2dfc3fb203c0435411cc38004a#diff-5a0a775cec0600396479fd9399f9cf38d755c7141dca468ab8d5f3eea4f69215R22)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
