### PR TITLE
[bitnami/valkey] Fix key on condition to create PodDisruptionBudget

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.15 (2025-06-18)
+## 3.0.16 (2025-06-25)
 
-* [bitnami/valkey] :zap: :arrow_up: Update dependency references ([#34549](https://github.com/bitnami/charts/pull/34549))
+* [bitnami/valkey] Fix key on condition to create PodDisruptionBudget ([#34641](https://github.com/bitnami/charts/pull/34641))
+
+## <small>3.0.15 (2025-06-18)</small>
+
+* [bitnami/valkey] :zap: :arrow_up: Update dependency references (#34549) ([efaba92](https://github.com/bitnami/charts/commit/efaba9295865e5ee85201399acb23d6875b509a1)), closes [#34549](https://github.com/bitnami/charts/issues/34549)
 
 ## <small>3.0.14 (2025-06-16)</small>
 

--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.16 (2025-06-25)
+## 3.0.16 (2025-06-26)
 
 * [bitnami/valkey] Fix key on condition to create PodDisruptionBudget ([#34641](https://github.com/bitnami/charts/pull/34641))
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: valkey
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 3.0.15
+version: 3.0.16

--- a/bitnami/valkey/templates/primary/pdb.yaml
+++ b/bitnami/valkey/templates/primary/pdb.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- $pdb := coalesce .Values.pdb .Values.primary.pdb }}
-{{- if and $pdb.create (gt (int64 .Values.primary.count) 0) (or (not (eq .Values.architecture "replication")) (not .Values.sentinel.enabled)) }}
+{{- if and $pdb.create (gt (int64 .Values.primary.replicaCount) 0) (or (not (eq .Values.architecture "replication")) (not .Values.sentinel.enabled)) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Fixes a bug in the Helm template condition that prevents the PodDisruptionBudget (PDB) from being rendered when using the `standalone` architecture.

The condition incorrectly references `.Values.primary.count`, which is not defined in the `values.yaml`. It has been updated to use `.Values.primary.replicaCount`, which is the correct and documented field for specifying the number of primary replicas.

### Benefits

Ensures that the PDB is rendered as expected when `primary.pdb.create` is `true` and `primary.replicaCount > 0`.

### Possible drawbacks

If any users were unknowingly relying on `primary.count` (despite it not being documented), their configuration might stop working. However, this is unlikely and would indicate misalignment with the intended values schema.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
