### PR TITLE
[bitnami/jupyterhub] feat!: :boom: :wrench: Update default Authenticator

### DIFF
--- a/.vib/jupyterhub/runtime-parameters.yaml
+++ b/.vib/jupyterhub/runtime-parameters.yaml
@@ -1,7 +1,7 @@
 hub:
   baseUrl: /
   adminUser: test_user
-  password: ComplicatedPassword123!4
+  password: BitnamiComplicatedPassword123!45678
   containerPorts:
     http: 8082
   containerSecurityContext:

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 9.0.16
+version: 10.0.0

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -869,6 +869,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 10.0.0
+
+This major changes the default Authenticator from the deprecated DummyAuthenticator to [SharedPasswordAuthenticator](https://jupyterhub.readthedocs.io/en/latest/reference/api/auth.html#jupyterhub.authenticators.shared.SharedPasswordAuthenticator). This Authenticator forces passwords to have at least 32 characters. Once set a proper password, no major issues should be found during upgrades.
+
 ### To 9.0.0
 
 This major updates the JupyterHub and Jupyter Base Notebook images to 5.x versions.

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -133,16 +133,15 @@ hub:
       config:
         JupyterHub:
           admin_access: true
-          authenticator_class: dummy
-          DummyAuthenticator:
-          {{- if .Values.hub.password }}
-            password: {{ .Values.hub.password | quote }}
-          {{- else }}
-            password: {{ randAlphaNum 10 | quote }}
-          {{- end }}
-          Authenticator:
+          authenticator_class: shared-password
+          SharedPasswordAuthenticator:
             admin_users:
               - {{ .Values.hub.adminUser }}
+          {{- if .Values.hub.password }}
+            admin_password: {{ .Values.hub.password | quote }}
+          {{- else }}
+            admin_password: {{ randAlphaNum 32 | quote }}
+          {{- end }}
       cookieSecret:
       concurrentSpawnLimit: 64
       consecutiveFailureLimit: 5


### PR DESCRIPTION
BREAKING CHANGE

### Description of the change

This PR updates the default Authenticator from DummyAuthenticator (deprecated) to SharedPasswordAuthenticator. As the password restrictions change, users will need to set a password with a least 32 characters.

### Benefits

Use a non-deprecated authenticator

### Possible drawbacks

Users need to update the password length

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
