### PR TITLE
 [bitnami/keydb] Fix StatefulSet capitalization in replica HPA

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.5.13 (2025-06-13)
+## 0.5.14 (2025-06-30)
 
-* [bitnami/keydb] :zap: :arrow_up: Update dependency references ([#34485](https://github.com/bitnami/charts/pull/34485))
+*  [bitnami/keydb] Fix StatefulSet capitalization in replica HPA ([#34729](https://github.com/bitnami/charts/pull/34729))
+
+## <small>0.5.13 (2025-06-13)</small>
+
+* [bitnami/keydb] :zap: :arrow_up: Update dependency references (#34485) ([6e0d14c](https://github.com/bitnami/charts/commit/6e0d14c221d3475dc491144f8394108b3b806bd0)), closes [#34485](https://github.com/bitnami/charts/issues/34485)
 
 ## <small>0.5.12 (2025-06-08)</small>
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -36,4 +36,4 @@ name: keydb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keydb
 - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.5.13
+version: 0.5.14

--- a/bitnami/keydb/templates/replica/hpa.yaml
+++ b/bitnami/keydb/templates/replica/hpa.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-    kind: Statefulset
+    kind: StatefulSet
     name: {{ template "keydb.replica.fullname" . }}
   minReplicas: {{ .Values.replica.autoscaling.hpa.minReplicas }}
   maxReplicas: {{ .Values.replica.autoscaling.hpa.maxReplicas }}


### PR DESCRIPTION
### Description of the change

Fix capitalization in KeyDB replica HPA template where `kind: Statefulset` incorrectly uses lowercase 's' instead of the correct `kind: StatefulSet` with uppercase 'S'. This causes the HPA controller to fail with the error:

"the HPA controller was unable to get the target's current scale: no matches for kind "Statefulset" in group "apps""

The change is a simple one-character correction to ensure proper capitalization.

### Benefits

- Fixes HPA functionality for KeyDB replicas
- Prevents error messages in cluster logs
- Enables proper autoscaling for KeyDB replica pods
- Improves user experience by ensuring out-of-the-box functionality works as expected

### Possible drawbacks

None. This is a straightforward fix that corrects a typo in the resource kind name.

### Applicable issues

<!-- If there's an issue tracking this problem, reference it here -->
- fixes #XXXX <!-- Replace with actual issue number if one exists -->

### Additional information

The Kubernetes API is case-sensitive for resource kinds. While `statefulset` or `Statefulset` might work in some contexts (like kubectl), the API server strictly requires `StatefulSet` with correct capitalization when referenced in other resources like HPAs.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/keydb] Fix StatefulSet capitalization in replica HPA
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)