### PR TITLE
[bitnami/etcd] Fix protocol selection in defrag job

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.0.6 (2025-06-17)
+## 12.0.7 (2025-07-02)
 
-* [bitnami/etcd] :zap: :arrow_up: Update dependency references ([#34427](https://github.com/bitnami/charts/pull/34427))
+* [bitnami/etcd] Fix protocol selection in defrag job ([#34767](https://github.com/bitnami/charts/pull/34767))
+
+## <small>12.0.6 (2025-06-17)</small>
+
+* [bitnami/etcd] :zap: :arrow_up: Update dependency references (#34427) ([9cf5b43](https://github.com/bitnami/charts/commit/9cf5b43efaf70d8e0490b3e0af08a11276cc528b)), closes [#34427](https://github.com/bitnami/charts/issues/34427)
 
 ## <small>12.0.5 (2025-06-16)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 12.0.6
+version: 12.0.7

--- a/bitnami/etcd/templates/cronjob-defrag.yaml
+++ b/bitnami/etcd/templates/cronjob-defrag.yaml
@@ -122,7 +122,7 @@ spec:
                   {{- $replicaCount := (int .Values.replicaCount) }}
                   {{- $releaseNamespace := include "common.names.namespace" . }}
                   {{- range $iEndpoint, $e := until $replicaCount }}
-                  {{- $endpoint := printf "%s://%s-%d.%s.%s.svc.%s:%d" (include "etcd.peerProtocol" $) $etcdFullname $iEndpoint $etcdHeadlessServiceName $namespace $clusterDomain $port }}
+                  {{- $endpoint := printf "%s://%s-%d.%s.%s.svc.%s:%d" (include "etcd.clientProtocol" $) $etcdFullname $iEndpoint $etcdHeadlessServiceName $namespace $clusterDomain $port }}
                   {{- $endpointStr = printf "%s%s" $endpointStr $endpoint }}
                   {{- if ne $iEndpoint (sub $replicaCount 1) }}
                   {{- $endpointStr = printf "%s," $endpointStr }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Fix the protocol selected in the defragmentation cronjob template.

### Benefits

<!-- What benefits will be realized by the code change? -->
The cronjob no longer fails when etcd is configured to use https for peer communication but http for client communication.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Currently the template is selecting the client port but the peer protocol.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
