### PR TITLE
[bitnami/kafka] fix: Correct extraListeners rendering to avoid malformed YAML

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 32.3.1 (2025-06-30)
+## 32.3.2 (2025-07-02)
 
-* [bitnami/kafka] Add ClusterIP and loadBalancerNames check for using external access hosts list ([#34359](https://github.com/bitnami/charts/pull/34359))
+* [bitnami/kafka] fix: Correct extraListeners rendering to avoid malformed YAML ([#34772](https://github.com/bitnami/charts/pull/34772))
+
+## <small>32.3.1 (2025-06-30)</small>
+
+* [bitnami/kafka] Add ClusterIP and loadBalancerNames check for using external access hosts list (#343 ([326a7cf](https://github.com/bitnami/charts/commit/326a7cf8d6584c37131ea645d3b9b577e8f5a627)), closes [#34359](https://github.com/bitnami/charts/issues/34359)
 
 ## 32.3.0 (2025-06-27)
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.3.1
+version: 32.3.2

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -511,7 +511,7 @@ Returns the containerPorts for listeners.extraListeners
 {{- range $listener := .Values.listeners.extraListeners -}}
 - name: {{ lower $listener.name}}
   containerPort: {{ $listener.containerPort }}
-{{- end -}}
+{{ end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR fixes a rendering bug in the Kafka Helm chart's _helpers.tpl where the use of {{- end -}} inside the kafka.extraListeners.containerPorts helper caused Helm to trim all newlines between loop iterations, resulting in invalid YAML under container.ports.

### Benefits

Users of the Kafka Helm chart will be able to configure and use extra listeners.

### Possible drawbacks

None

### Applicable issues

- fixes [34731](https://github.com/bitnami/charts/issues/34731)

### Additional information

**Example of the Bug**
Given this input:
```yaml
listeners:
  extraListeners:
    - name: sasl_plaintext
      containerPort: 9095
    - name: ssl
      containerPort: 9096
```
The following invalid YAML is rendered:
```yaml
ports:
  - name: sasl_plaintext
    containerPort: 9095- name: ssl
    containerPort: 9096
```

This causes helm to fail with:
Error: YAML parse error on kafka/templates/controller-eligible/statefulset.yaml: error converting YAML to JSON: yaml: line XXX: mapping values are not allowed in this context

**Fix**
Replaced:
`{{- end -}}`
with:
`{{ end }}`
in the kafka.extraListeners.containerPorts helper to allow Helm to preserve newline spacing between list items. This preserves all functional behavior while avoiding YAML breakage.

**Reproduction Instructions**
helm template kafka ./bitnami/kafka -f bug.yaml
Where bug.yaml is:
```yaml
controller:
  controllerOnly: false

listeners:
  controller:
    containerPort: 9093
  client:
    containerPort: 9092
  interbroker:
    containerPort: 9094
  extraListeners:
    - name: sasl_plaintext
      containerPort: 9095
    - name: ssl
      containerPort: 9096
```
Before patch: Helm template fails
 After patch: YAML renders cleanly

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
