### PR TITLE
[bitnami/memcached] Allow trafficDistribution field to be specified

### DIFF
--- a/bitnami/memcached/CHANGELOG.md
+++ b/bitnami/memcached/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.8.6 (2025-06-13)
+## 7.9.0 (2025-07-03)
 
-* [bitnami/memcached] :zap: :arrow_up: Update dependency references ([#34464](https://github.com/bitnami/charts/pull/34464))
+* [bitnami/memcached] Allow trafficDistribution field to be specified ([#34773](https://github.com/bitnami/charts/pull/34773))
+
+## <small>7.8.6 (2025-06-13)</small>
+
+* [bitnami/memcached] :zap: :arrow_up: Update dependency references (#34464) ([2cde47a](https://github.com/bitnami/charts/commit/2cde47a374bf489f218ec2f22ebfe3158ed96d4e)), closes [#34464](https://github.com/bitnami/charts/issues/34464)
 
 ## <small>7.8.5 (2025-06-06)</small>
 

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.8.6
+version: 7.9.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -276,6 +276,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | `service.nodePorts.memcached`           | Node port for Memcached                                                                                       | `""`        |
 | `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                              | `""`        |
 | `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                   | `{}`        |
+| `service.trafficDistribution`           | Traffic distribution preference                                                                               | `""`        |
 | `service.clusterIP`                     | Memcached service Cluster IP                                                                                  | `""`        |
 | `service.loadBalancerIP`                | Memcached service Load Balancer IP                                                                            | `""`        |
 | `service.loadBalancerSourceRanges`      | Memcached service Load Balancer sources                                                                       | `[]`        |

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.service.sessionAffinityConfig }}
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -460,6 +460,10 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## @param service.trafficDistribution Traffic distribution preference
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+  ##
+  trafficDistribution: ""
   ## @param service.clusterIP Memcached service Cluster IP
   ## e.g.:
   ## clusterIP: None


### PR DESCRIPTION
### Description of the change

Similarly to https://github.com/bitnami/charts/pull/32442 and https://github.com/bitnami/charts/pull/32443, this MR introduces possibility to set `Service.spec.trafficDistribution` field in the `memcached` chart: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution

### Possible drawbacks

Virtually none - we're not setting it at all by default, so potential caveats and Kubernetes version requirements are completely up to the chart's end users.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
