### PR TITLE
[kube-prometheus] add thanos sidecar service monitor

### DIFF
--- a/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kube-prometheus.prometheus.fullname" . }}-thanos
+  name: {{ template "kube-prometheus.thanos.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/subcomponent: thanos
@@ -42,6 +42,15 @@ spec:
   externalTrafficPolicy: {{ .Values.prometheus.thanos.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
+    {{- if .Values.prometheus.thanos.serviceMonitor.enabled }}
+    - name: http
+      port: {{ .Values.prometheus.thanos.service.ports.http }}
+      targetPort: http
+      protocol: TCP
+      {{- if and .Values.prometheus.thanos.service.nodePorts.http (or (eq .Values.prometheus.thanos.service.type "NodePort") (eq .Values.prometheus.thanos.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.prometheus.thanos.service.nodePorts.http }}
+      {{- end }}
+    {{- end }}
     - name: grpc
       port: {{ .Values.prometheus.thanos.service.ports.grpc }}
       targetPort: grpc

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanos.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kube-prometheus.thanos.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Values.prometheus.thanos.serviceMonitor.jobLabel }}
+  selector:
+    matchLabels: {{- include "kube-prometheus.prometheus.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/subcomponent: thanos
+  namespaceSelector:
+    matchNames:
+      - {{ include "common.names.namespace" . | quote }}
+  endpoints:
+    - port: http
+      {{- if .Values.prometheus.thanos.serviceMonitor.interval }}
+      interval: {{ .Values.prometheus.thanos.serviceMonitor.interval }}
+      {{- end }}
+      path: {{ .Values.prometheus.thanos.serviceMonitor.path }}
+      {{- if .Values.prometheus.thanos.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.thanos.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.thanos.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.prometheus.thanos.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -1594,6 +1594,7 @@ prometheus:
       ##
       ports:
         grpc: 10901
+        http: 10902
       ## @param prometheus.thanos.service.clusterIP Specific cluster IP when service type is cluster IP. Use `None` to create headless service by default.
       ## Use a "headless" service by default so it returns every pod's IP instead of loadbalancing requests.
       ##
@@ -1746,6 +1747,33 @@ prometheus:
       ## Useful when looking for additional customization, such as using different backend
       ##
       extraRules: []
+    ## Create a ServiceMonitor to monitor Prometheus thanos sidecar
+    ##
+    serviceMonitor:
+      ## @param prometheus.thanos.serviceMonitor.enabled Creates a ServiceMonitor to monitor Prometheus thanos sidecar
+      ##
+      enabled: false
+      ## @param prometheus.thanos.serviceMonitor.interval Scrape interval (use by default, falling back to Prometheus' default)
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
+      ##
+      interval: ""
+      ## @param prometheus.thanos.serviceMonitor.path HTTP path to scrape for metrics
+      ##
+      path: /metrics
+      ## @param prometheus.thanos.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+      ##
+      jobLabel: ""
+      ## @param prometheus.thanos.serviceMonitor.metricRelabelings Metric relabeling
+      ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+      ##
+      metricRelabelings: []
+      ## @param prometheus.thanos.serviceMonitor.relabelings Relabel configs
+      ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      ##
+      relabelings: []
+      ## @param prometheus.thanos.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+      ##
+      sampleLimit: ""
   ## config-reloader sidecar container configuration
   ##
   configReloader:
@@ -3643,8 +3671,8 @@ thanosRuler:
   ## @param thanosRuler.containerPorts.grpc GRPC container port
   ##
   containerPorts:
-    http: 10902
     grpc: 10901
+    http: 10902
   ## @param thanosRuler.alertQueryUrl The external Query URL the Thanos Ruler will set in the ‘Source’ field of all alerts
   ## Maps to the ‘–alert.query-url’ CLI arg
   ##


### PR DESCRIPTION
Add thanos sidecar service monitor
Also use `kube-prometheus.thanos.fullname` in place of concatenation of strings
