### PR TITLE
[bitnami/deepspeed] Wrong input expected by the helper function

### DIFF
--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.3.21 (2025-06-30)
+## 2.3.22 (2025-07-03)
 
-* [bitnami/deepspeed] :zap: :arrow_up: Update dependency references ([#34708](https://github.com/bitnami/charts/pull/34708))
+* [bitnami/deepspeed] Wrong input expected by the helper function ([#34783](https://github.com/bitnami/charts/pull/34783))
+
+## <small>2.3.21 (2025-06-30)</small>
+
+* [bitnami/deepspeed] :zap: :arrow_up: Update dependency references (#34708) ([0879716](https://github.com/bitnami/charts/commit/0879716d3460207a05b73630465b0d0b80a257bb)), closes [#34708](https://github.com/bitnami/charts/issues/34708)
 
 ## <small>2.3.20 (2025-06-26)</small>
 

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -38,4 +38,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.3.21
+version: 2.3.22

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -97,7 +97,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.client.initContainers }}
-        {{- include "common.tplvalues.render" (dict "values" .Values.client.initContainers "context" $) | nindent 8}}
+        {{- include "common.tplvalues.render" (dict "value" .Values.client.initContainers "context" $) | nindent 8}}
         {{- end }}
       containers:
         - name: deepspeed


### PR DESCRIPTION
Replaced "values" with "value" in the call to common.tplvalues.render, as this helper expects a single value (e.g. a list, string, or map) under the key "value", along with a "context", like so:
```
dict "value" .Values.somePath "context" $
```

The previous usage incorrectly passed "values", which is not supported by `common.tplvalues.render`.