### PR TITLE
bitnami/rabbitmq-cluster-operator: pull matching CRD from upstream

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/crds/rabbitmq-cluster/rabbitmq.com_rabbitmqclusters.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/rabbitmq-cluster/rabbitmq.com_rabbitmqclusters.yaml
@@ -1,5 +1,5 @@
 # Source: https://raw.githubusercontent.com/rabbitmq/cluster-operator/v{version}/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
-# Version: 2.14.0
+# Version: 2.15.0
 # RabbitMQ Cluster Operator
 #
 # Copyright 2020 VMware, Inc. All Rights Reserved.
@@ -938,6 +938,11 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                   type: object
+                autoEnableAllFeatureFlags:
+                  description: |-
+                    Set to true to automatically enable all feature flags after each upgrade
+                    For more information, see https://www.rabbitmq.com/docs/feature-flags
+                  type: boolean
                 delayStartSeconds:
                   default: 30
                   description: |-


### PR DESCRIPTION
Closes #34785

This just pulls the latest version of the CRD from upstream.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
