### PR TITLE
[bitnami/kuberay]  Update `operator.metrics.serviceMonitor.honorLabels` to keep in sync with upstream chart

### DIFF
--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.18 (2025-06-20)
+## 1.4.19 (2025-07-04)
 
-* [bitnami/kuberay] :zap: :arrow_up: Update dependency references ([#34574](https://github.com/bitnami/charts/pull/34574))
+* [bitnami/kuberay]  Update `operator.metrics.serviceMonitor.honorLabels` to keep in sync with upstream chart ([#34793](https://github.com/bitnami/charts/pull/34793))
+
+## <small>1.4.18 (2025-06-20)</small>
+
+* [bitnami/kuberay] :zap: :arrow_up: Update dependency references (#34574) ([ef4c802](https://github.com/bitnami/charts/commit/ef4c80257e9fb6563e0550ef6700dafd0f6918cd)), closes [#34574](https://github.com/bitnami/charts/issues/34574)
 
 ## <small>1.4.17 (2025-06-19)</small>
 

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.4.18
+version: 1.4.19

--- a/bitnami/kuberay/README.md
+++ b/bitnami/kuberay/README.md
@@ -332,7 +332,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `operator.metrics.serviceMonitor.annotations`       | Additional custom annotations for the ServiceMonitor                                                   | `{}`    |
 | `operator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                    | `{}`    |
 | `operator.metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                       | `""`    |
-| `operator.metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                               | `false` |
+| `operator.metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                               | `true`  |
 | `operator.metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                           | `""`    |
 | `operator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`    |
 | `operator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                               | `[]`    |

--- a/bitnami/kuberay/values.yaml
+++ b/bitnami/kuberay/values.yaml
@@ -738,7 +738,7 @@ operator:
       jobLabel: ""
       ## @param operator.metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
       ##
-      honorLabels: false
+      honorLabels: true
       ## @param operator.metrics.serviceMonitor.interval Interval at which metrics should be scraped.
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
       ## e.g:


### PR DESCRIPTION
### Description of the change

Update `operator.metrics.serviceMonitor.honorLabels` from `false` to `true`

### Benefits

To keep in sync with upstream's defaults

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #34792

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
