### PR TITLE
fix prometheusRules syntax

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.0.3 (2025-06-30)
+## 21.0.4 (2025-07-04)
 
-* [bitnami/nginx] :zap: :arrow_up: Update dependency references ([#34717](https://github.com/bitnami/charts/pull/34717))
+* fix prometheusRules syntax ([#34801](https://github.com/bitnami/charts/pull/34801))
+
+## <small>21.0.3 (2025-06-30)</small>
+
+* [bitnami/nginx] :zap: :arrow_up: Update dependency references (#34717) ([46e4710](https://github.com/bitnami/charts/commit/46e47104483cb8e3d774345ddb068f417d6cda8c)), closes [#34717](https://github.com/bitnami/charts/issues/34717)
 
 ## <small>21.0.2 (2025-06-30)</small>
 

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 21.0.4 (2025-07-04)
+## 21.0.4 (2025-07-05)
 
 * fix prometheusRules syntax ([#34801](https://github.com/bitnami/charts/pull/34801))
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 21.0.3
+version: 21.0.4

--- a/bitnami/nginx/templates/prometheusrules.yaml
+++ b/bitnami/nginx/templates/prometheusrules.yaml
@@ -15,10 +15,12 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   groups:
     - name: {{ include "common.names.fullname" . }}
-      rules: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.rules "context" $ ) | nindent 6 }}
+      rules:
+        {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.rules "context" $ ) | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

- fix the syntax of the prometheusRules template

### Benefits

- chart fixed

### Possible drawbacks

<!-- Describe any known limitations with your change -->

- helm template error 

```bash
Error: YAML parse error on nginx/templates/prometheusrules.yaml: error converting YAML to JSON: yaml: line 18: could not find expected ':'
helm.go:92: 2025-07-04 14:38:28.307659 +0200 CEST m=+0.169137667 [debug] error converting YAML to JSON: yaml: line 18: could not find expected ':'
YAML parse error on nginx/templates/prometheusrules.yaml
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
