### PR TITLE
[bitnami/fluent-bit] Remove healthcheck VIB test

### DIFF
--- a/.vib/fluent-bit/vib-verify.json
+++ b/.vib/fluent-bit/vib-verify.json
@@ -40,13 +40,6 @@
       },
       "actions": [
         {
-          "action_id": "health-check",
-          "params": {
-            "endpoint": "lb-fluent-bit-http",
-            "app_protocol": "HTTP"
-          }
-        },
-        {
           "action_id": "goss",
           "params": {
             "resources": {

--- a/bitnami/fluent-bit/CHANGELOG.md
+++ b/bitnami/fluent-bit/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.1.6 (2025-06-29)
+## 3.1.7 (2025-07-07)
 
-* [bitnami/fluent-bit] :zap: :arrow_up: Update dependency references ([#34704](https://github.com/bitnami/charts/pull/34704))
+* [bitnami/fluent-bit] Remove healthcheck VIB test ([#34829](https://github.com/bitnami/charts/pull/34829))
+
+## <small>3.1.6 (2025-06-29)</small>
+
+* [bitnami/fluent-bit] :zap: :arrow_up: Update dependency references (#34704) ([4a29a32](https://github.com/bitnami/charts/commit/4a29a322d558718ff9e3a582e38faef1c5c49026)), closes [#34704](https://github.com/bitnami/charts/issues/34704)
 
 ## <small>3.1.5 (2025-06-03)</small>
 

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 3.1.6
+version: 3.1.7


### PR DESCRIPTION
### Description of the change

Removes the duplicated 'healthcheck' test.

Both the service and the containerPort connectivity are tested in the goss tests, so it is unnecessary to also run the "healthcheck" action, saving some extra resources.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
