### PR TITLE
[bitnami/fluentd] Make  volume mount read-only

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 7.1.9
+version: 7.2.0

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -281,6 +281,7 @@ spec:
             {{- end }}
             - name: varlog
               mountPath: /var/log
+              readOnly: true
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true

--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -23,6 +23,7 @@ spec:
     - pathPrefix: '/var/lib/docker/containers'
       readOnly: true
     - pathPrefix: '/var/log'
+      readOnly: true
   volumes:
     - 'configMap'
     - 'emptyDir'


### PR DESCRIPTION
Set the `/var/log` volume mount as `readOnly: true`, aligning it with the `/var/lib/docker/containers` mount. This change improves security posture by ensuring the container does not have write access to host logs.

This was manually tested, confirming that setting the volume as read-only does not impact Fluentd’s ability to collect logs.