### PR TITLE
[bitnami/gitlab-runner] feat: add support for custom image_pull_secrets

### DIFF
--- a/bitnami/gitlab-runner/CHANGELOG.md
+++ b/bitnami/gitlab-runner/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.1.1 (2025-07-14)
+## 1.1.2 (2025-07-15)
 
-* [bitnami/gitlab-runner] :zap: :arrow_up: Update dependency references ([#35044](https://github.com/bitnami/charts/pull/35044))
+* [bitnami/gitlab-runner] feat: add support for custom image_pull_secrets ([#35057](https://github.com/bitnami/charts/pull/35057))
+
+## <small>1.1.1 (2025-07-14)</small>
+
+* [bitnami/gitlab-runner] :zap: :arrow_up: Update dependency references (#35044) ([aefd1d3](https://github.com/bitnami/charts/commit/aefd1d325ab30175d292ef24b86b04715a6fab28)), closes [#35044](https://github.com/bitnami/charts/issues/35044)
 
 ## 1.1.0 (2025-07-14)
 

--- a/bitnami/gitlab-runner/Chart.yaml
+++ b/bitnami/gitlab-runner/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: gitlab-runner
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitlab-runner
-version: 1.1.1
+version: 1.1.2

--- a/bitnami/gitlab-runner/Chart.yaml
+++ b/bitnami/gitlab-runner/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: gitlab-runner
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitlab-runner
-version: 1.1.0
+version: 1.1.1

--- a/bitnami/gitlab-runner/templates/_helpers.tpl
+++ b/bitnami/gitlab-runner/templates/_helpers.tpl
@@ -45,6 +45,33 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names as a raw comma-separated string
+*/}}
+{{- define "gitlab-runner.imagePullSecretsRaw" -}}
+{{- $context := . }}
+{{- $pullSecrets := list }}
+{{- range ((.Values.global).imagePullSecrets) -}}
+  {{- if kindIs "map" . -}}
+    {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context) | quote) -}}
+  {{- else -}}
+    {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context) | quote) -}}
+  {{- end -}}
+{{- end -}}
+{{- range (list .Values.image .Values.helperImage) -}}
+  {{- range .pullSecrets -}}
+    {{- if kindIs "map" . -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context) | quote) -}}
+    {{- else -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context) | quote) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if (not (empty $pullSecrets)) -}}
+  {{- $pullSecrets | join ", " -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Name of the Runner Secret
 */}}
 {{- define "gitlab-runner.secretName" -}}

--- a/bitnami/gitlab-runner/values.yaml
+++ b/bitnami/gitlab-runner/values.yaml
@@ -601,6 +601,7 @@ runners:
         namespace = "{{ include "common.names.namespace" . }}"
         image = "{{ include "gitlab-runner.image" . }}"
         helper_image = "{{ include "gitlab-runner.helper.image" . }}"
+        image_pull_secrets = [{{ include "gitlab-runner.imagePullSecretsRaw" . }}]
 
   ## @param runners.configPath Absolute path for an existing runner configuration file (to be used with volumes/extraVolumes)
   ##


### PR DESCRIPTION
### Description of the change

This PR adds support for custom image pull secrets on runners.

### Benefits

Users can use private container images for runners.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
