### PR TITLE
[bitnami/kube-state-metrics] ci: VIB verify

### DIFF
--- a/.vib/kube-state-metrics/goss/goss.yaml
+++ b/.vib/kube-state-metrics/goss/goss.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 http:
-  https://127.0.0.1:{{ .Vars.containerPorts.http }}/metrics:
+  http://127.0.0.1:{{ .Vars.containerPorts.http }}/metrics:
     status: 200
     body:
     - /kube_deployment_status_replicas_ready.*kube-state-metrics.*{{ .Vars.replicaCount }}/

--- a/.vib/kube-state-metrics/goss/goss.yaml
+++ b/.vib/kube-state-metrics/goss/goss.yaml
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 http:
+  https://127.0.0.1:{{ .Vars.containerPorts.http }}/metrics:
+    status: 200
+    body:
+    - /kube_deployment_status_replicas_ready.*kube-state-metrics.*{{ .Vars.replicaCount }}/
+    - "!kube_secret_"
   http://kube-state-metrics:{{ .Vars.service.ports.http }}/metrics:
     status: 200
     body:

--- a/.vib/kube-state-metrics/runtime-parameters.yaml
+++ b/.vib/kube-state-metrics/runtime-parameters.yaml
@@ -12,6 +12,8 @@ podSecurityContext:
 containerSecurityContext:
   enabled: true
   runAsUser: 1002
+containerPorts:
+  http: 8080
 service:
   type: LoadBalancer
   ports:

--- a/.vib/kube-state-metrics/vib-verify.json
+++ b/.vib/kube-state-metrics/vib-verify.json
@@ -40,13 +40,6 @@
       },
       "actions": [
         {
-          "action_id": "health-check",
-          "params": {
-            "endpoint": "lb-kube-state-metrics-http",
-            "app_protocol": "HTTP"
-          }
-        },
-        {
           "action_id": "goss",
           "params": {
             "resources": {

--- a/bitnami/kube-state-metrics/CHANGELOG.md
+++ b/bitnami/kube-state-metrics/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.0.12 (2025-07-09)
+## 5.0.13 (2025-07-15)
 
-* [bitnami/kube-state-metrics] :zap: :arrow_up: Update dependency references ([#34914](https://github.com/bitnami/charts/pull/34914))
+* [bitnami/kube-state-metrics] ci: VIB verify ([#35059](https://github.com/bitnami/charts/pull/35059))
+
+## <small>5.0.12 (2025-07-09)</small>
+
+* [bitnami/kube-state-metrics] :zap: :arrow_up: Update dependency references (#34914) ([855aade](https://github.com/bitnami/charts/commit/855aade37218f200274e7d71e4ecaf53062b31bf)), closes [#34914](https://github.com/bitnami/charts/issues/34914)
 
 ## <small>5.0.11 (2025-06-25)</small>
 

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: kube-state-metrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
-version: 5.0.12
+version: 5.0.13


### PR DESCRIPTION
### Description of the change

Similar to https://github.com/bitnami/charts/pull/34819, this PR removes the usage of `health-check` on VIB verify given it adds no value. We're already given that:

- `health-check` is very limited we can't configure the sub-path to use as target. Also, it accepts a wide range of status code responses are valid (`>= 200 && <= 499`).
- We're testing the same service endpoint on Goss with more precision.

### Benefits

Simplify tests.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
