### PR TITLE
[bitnami/charts/issues/35055] Increase lenght of auto-generated password for MLFlow

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.1.3 (2025-07-15)
+## 5.1.4 (2025-07-16)
 
-* [bitnami/mlflow] :zap: :arrow_up: Update dependency references ([#35114](https://github.com/bitnami/charts/pull/35114))
+* [bitnami/charts/issues/35055] Increase lenght of auto-generated password for MLFlow ([#35156](https://github.com/bitnami/charts/pull/35156))
+
+## <small>5.1.3 (2025-07-15)</small>
+
+* [bitnami/mlflow] :zap: :arrow_up: Update dependency references (#35114) ([c800f4a](https://github.com/bitnami/charts/commit/c800f4ac124887a5921ca6012113fe6482a2b2ac)), closes [#35114](https://github.com/bitnami/charts/issues/35114)
 
 ## <small>5.1.2 (2025-07-08)</small>
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -47,4 +47,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 5.1.3
+version: 5.1.4

--- a/bitnami/mlflow/templates/tracking/auth-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/auth-secret.yaml
@@ -18,6 +18,6 @@ metadata:
 data:
   # We need to add the username as it is required by the ServiceMonitor object
   admin-user: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "admin-user" "providedValues" (list "tracking.auth.username") "context" $) }}
-  admin-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "admin-password" "providedValues" (list "tracking.auth.password") "context" $) }}
+  admin-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "admin-password" "providedValues" (list "tracking.auth.password") "length" 12 "context" $) }}
   flask-server-secret-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mlflow.v0.tracking.fullname" .) "key" "flask-server-secret-key" "providedValues" (list "tracking.auth.flaskServerSecretKey") "failOnNew" false "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

MLFlow was failing to deploy due to password's length

```
mlflow.exceptions.MlflowException: Password must be a string longer than 12 characters.
```

After the change, I deployed the solution either using the auto-generated password and a custom password and everything worked as expected 

```diff
diff --git a/bitnami/mlflow/values.yaml b/bitnami/mlflow/values.yaml
index 0508e705c0..f715f06e99 100644
--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -273,7 +273,7 @@ tracking:
   auth:
     enabled: true
     username: user
-    password: ""
+    password: "123456789876"
     flaskServerSecretKey: ""
     existingSecret: ""
     existingSecretUserKey: ""
```

```console
$ k logs mlflow-tracking-XXXXXX
...
[2025-07-16 07:20:05 +0000] [21] [INFO] Starting gunicorn 23.0.0
[2025-07-16 07:20:05 +0000] [21] [INFO] Listening at: http://0.0.0.0:5000 (21)
[2025-07-16 07:20:05 +0000] [21] [INFO] Using worker: sync
[2025-07-16 07:20:05 +0000] [22] [INFO] Booting worker with pid: 22
[2025-07-16 07:20:05 +0000] [23] [INFO] Booting worker with pid: 23
[2025-07-16 07:20:05 +0000] [24] [INFO] Booting worker with pid: 24
[2025-07-16 07:20:05 +0000] [25] [INFO] Booting worker with pid: 25
2025/07/16 07:20:48 WARNING mlflow.server.auth: This feature is still experimental and may change in a future release without warning
2025/07/16 07:20:50 INFO mlflow.server.auth: Created admin user 'user'. It is recommended that you set a new password as soon as possible on /api/2.0/mlflow/users/update-password.
```

### Benefits

Deployment succeeds

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/35055

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
