### PR TITLE
[bitnami/nessie] Recover quarkus specific environment variables

### DIFF
--- a/bitnami/nessie/CHANGELOG.md
+++ b/bitnami/nessie/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.25 (2025-07-15)
+## 2.0.26 (2025-07-16)
 
-* [bitnami/nessie] :zap: :arrow_up: Update dependency references ([#35102](https://github.com/bitnami/charts/pull/35102))
+* [bitnami/nessie] Recover quarkus specific environment variables ([#35158](https://github.com/bitnami/charts/pull/35158))
+
+## <small>2.0.25 (2025-07-15)</small>
+
+* [bitnami/nessie] :zap: :arrow_up: Update dependency references (#35102) ([fa6b4d5](https://github.com/bitnami/charts/commit/fa6b4d5f346c00fbf97acbcf4c3e2a9a41431482)), closes [#35102](https://github.com/bitnami/charts/issues/35102)
 
 ## <small>2.0.24 (2025-07-12)</small>
 

--- a/bitnami/nessie/Chart.lock
+++ b/bitnami/nessie/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
+  version: 16.7.19
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.0
-digest: sha256:1b5577724d7ca3aec34781d6c3e9f3cb866d81a7fc077746aa83a84b2bdd95c0
-generated: "2025-05-06T10:47:30.155429756+02:00"
+  version: 2.31.3
+digest: sha256:7ce69653c8b8873150d564fd396cd891f642b0a03d61ae0105aecc08324a889a
+generated: "2025-07-16T10:13:21.381832+02:00"

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -40,4 +40,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nessie
 - https://github.com/bitnami/containers/tree/main/bitnami/nessie
 - https://github.com/nessie/nessie
-version: 2.0.25
+version: 2.0.26

--- a/bitnami/nessie/README.md
+++ b/bitnami/nessie/README.md
@@ -90,7 +90,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 The chart supports setting Nessie [application properties](https://github.com/projectnessie/nessie/blob/main/servers/quarkus-server/src/main/resources/application.properties) via two parameters:
 
 - `configOverrides`: Overrides non-sensitive application properties, such as `quarkus.micrometer.enabled`. Nested and plain YAML are supported.
-- `secretConfigOverrides`: Overrides sensitive application properties, such as `quarkus.datasource.password`. Nested and plain YAML are supported.
+- `secretConfigOverrides`: Overrides sensitive application properties, such as `quarkus.datasource.postgresql.password`. Nested and plain YAML are supported.
 
 In the following example, we use `configOverrides` to disable the HTTP access log and the HTTP decompression:
 

--- a/bitnami/nessie/templates/_helpers.tpl
+++ b/bitnami/nessie/templates/_helpers.tpl
@@ -282,7 +282,7 @@ Return the volume-permissions init container
       value: {{ include "nessie.database.port" . | quote }}
     {{- if .Values.usePasswordFiles }}
     - name: DATABASE_PASSWORD_FILE
-      value: "/bitnami/nessie/secrets/database/QUARKUS_DATASOURCE_PASSWORD"
+      value: "/bitnami/nessie/secrets/database/QUARKUS_DATASOURCE_POSTGRESQL_PASSWORD"
     {{- else -}}
     - name: DATABASE_PASSWORD
       valueFrom:

--- a/bitnami/nessie/templates/configmap.yaml
+++ b/bitnami/nessie/templates/configmap.yaml
@@ -14,9 +14,10 @@ quarkus.management.port: {{ .Values.containerPorts.management }}
 nessie.version.store.type: "ROCKSDB"
 nessie.version.store.persist.rocks.database-path: {{ .Values.persistence.mountPath }}
 {{- else if eq .Values.versionStoreType "JDBC_POSTGRESQL" }}
-nessie.version.store.type: "JDBC"
-quarkus.datasource.jdbc.url: {{ include "nessie.database.url" . }}
-quarkus.datasource.username: {{ include "nessie.database.user" . }}
+nessie.version_store.type: "JDBC"
+nessie.version_store.persist.jdbc.datasource: "postgresql"
+quarkus.datasource.postgresql.jdbc.url: {{ include "nessie.database.url" . }}
+quarkus.datasource.postgresql.username: {{ include "nessie.database.user" . }}
 {{- else }}
 nessie.version.store.type: {{ .Values.versionStoreType }}
 {{- end }}

--- a/bitnami/nessie/templates/deployment.yaml
+++ b/bitnami/nessie/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             {{- if and (eq .Values.versionStoreType "JDBC_POSTGRESQL") (not .Values.usePasswordFiles) }}
-            - name: QUARKUS_DATASOURCE_PASSWORD
+            - name: QUARKUS_DATASOURCE_POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "nessie.database.secretName" . }}
@@ -235,7 +235,7 @@ spec:
             secretName: {{ include "nessie.database.secretName" . }}
             items:
               - key: {{ include "nessie.database.passwordKey" . }}
-                path: QUARKUS_DATASOURCE_PASSWORD
+                path: QUARKUS_DATASOURCE_POSTGRESQL_PASSWORD
         {{- end }}
         {{- if (or .Values.secretConfigOverrides .Values.existingSecret) }}
         - name: secret-configuration


### PR DESCRIPTION
### Description of the change

This PR reverts some changes applied in #34376, once the dependencies have been updated. Using specific database env vars is the preferred way.

### Benefits

Use the recommended configuration

### Possible drawbacks

N/A (it only would fail with version 0.104.2)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
