### PR TITLE
[bitnami/dremio] bugfix: conditions to disable S3 storage

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.8 (2025-07-15)
+## 3.0.9 (2025-07-17)
 
-* [bitnami/dremio] :zap: :arrow_up: Update dependency references ([#35089](https://github.com/bitnami/charts/pull/35089))
+* [bitnami/dremio] bugfix: conditions to disable S3 storage ([#35169](https://github.com/bitnami/charts/pull/35169))
+
+## <small>3.0.8 (2025-07-15)</small>
+
+* [bitnami/dremio] :zap: :arrow_up: Update dependency references (#35089) ([1d94895](https://github.com/bitnami/charts/commit/1d948958cbf9f74d336ce8f48c79daf5e0482273)), closes [#35089](https://github.com/bitnami/charts/issues/35089)
 
 ## <small>3.0.7 (2025-07-14)</small>
 

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -43,4 +43,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 3.0.8
+version: 3.0.9

--- a/bitnami/dremio/templates/coordinator/statefulset.yaml
+++ b/bitnami/dremio/templates/coordinator/statefulset.yaml
@@ -90,7 +90,9 @@ spec:
         {{- include "dremio.init-containers.copy-default-conf" . | nindent 8 }}
         {{- end }}
         {{- if .Values.defaultInitContainers.wait.enabled }}
+        {{- if or (eq .Values.dremio.distStorageType "minio") (eq .Values.dremio.distStorageType "aws") }}
         {{- include "dremio.init-containers.wait-for-s3" . | nindent 8 }}
+        {{- end }}
         {{- include "dremio.init-containers.wait-for-zookeeper" . | nindent 8 }}
         {{- include "dremio.init-containers.wait-for-master-coordinator" . | nindent 8 }}
         {{- end }}

--- a/bitnami/dremio/templates/executor/statefulset.yaml
+++ b/bitnami/dremio/templates/executor/statefulset.yaml
@@ -102,7 +102,9 @@ spec:
         {{- include "dremio.init-containers.copy-default-conf" $ | nindent 8 }}
         {{- end }}
         {{- if $.Values.defaultInitContainers.wait.enabled }}
+        {{- if or (eq $.Values.dremio.distStorageType "minio") (eq $.Values.dremio.distStorageType "aws") }}
         {{- include "dremio.init-containers.wait-for-s3" $ | nindent 8 }}
+        {{- end }}
         {{- include "dremio.init-containers.wait-for-zookeeper" $ | nindent 8 }}
         {{- include "dremio.init-containers.wait-for-master-coordinator" $ | nindent 8 }}
         {{- end }}

--- a/bitnami/dremio/templates/externals3-secret.yaml
+++ b/bitnami/dremio/templates/externals3-secret.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (not .Values.minio.enabled) (not .Values.externalS3.existingSecret) .Values.enableS3 }}
+{{- if and (not .Values.minio.enabled) (not .Values.externalS3.existingSecret) (or (eq .Values.dremio.distStorageType "minio") (eq .Values.dremio.distStorageType "aws")) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/dremio/templates/master-coordinator/statefulset.yaml
+++ b/bitnami/dremio/templates/master-coordinator/statefulset.yaml
@@ -90,7 +90,9 @@ spec:
         {{- include "dremio.init-containers.copy-default-conf" . | nindent 8 }}
         {{- end }}
         {{- if .Values.defaultInitContainers.wait.enabled }}
+        {{- if or (eq .Values.dremio.distStorageType "minio") (eq .Values.dremio.distStorageType "aws") }}
         {{- include "dremio.init-containers.wait-for-s3" . | nindent 8 }}
+        {{- end }}
         {{- include "dremio.init-containers.wait-for-zookeeper" . | nindent 8 }}
         {{- end }}
         {{- if .Values.defaultInitContainers.generateConf.enabled }}


### PR DESCRIPTION
### Description of the change

This PR fixes the conditions used to identify whether resources to interact with S3 (or S3-compatible) storage system are required

### Benefits

Installation works when installing Dremio using `--set dremio.distStorageType=other`

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
