### PR TITLE
[bitnami/grafana-loki] Upgrade Alloy chart

### DIFF
--- a/bitnami/grafana-loki/Chart.lock
+++ b/bitnami/grafana-loki/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: grafana-alloy
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 0.2.1
+  version: 1.0.0
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.8.5
+  version: 7.9.3
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.8.5
+  version: 7.9.3
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.8.5
+  version: 7.9.3
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.8.5
+  version: 7.9.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.1
-digest: sha256:723979019bf323373130482740874a78a9794126818948d9079d1415ff1d8b1e
-generated: "2025-06-12T12:59:56.140636+02:00"
+  version: 2.31.3
+digest: sha256:0c0d8ba130ced7123bcb9c7ef19addec77ac39f1be75d3fdf4388ec0bda24546
+generated: "2025-07-18T13:17:06.513141+02:00"

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   condition: grafanaalloy.enabled
   name: grafana-alloy
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 0.x.x
+  version: 1.x.x
 - alias: memcachedchunks
   condition: memcachedchunks.enabled
   name: memcached
@@ -61,4 +61,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 5.0.7
+version: 6.0.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -1536,6 +1536,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 6.0.0
+
+This major release bumps the Grafana Alloy chart version to [1.x.x](https://github.com/bitnami/charts/pull/35172). Find more information about the changes in this chart version in [the upstream changelog](https://github.com/grafana/alloy/blob/main/CHANGELOG.md#v1100). No major issues are expected during the upgrade.
+
 ### To 5.0.0
 
 This major replaces Promtail image with Alloy subchart. It is possible to convert configuration files from Promtail to Alloy using the following command:


### PR DESCRIPTION
### Description of the change

This major release bumps the Grafana Alloy chart version to [1.x.x](https://github.com/bitnami/charts/pull/35172). Fin
d more information about the changes in this chart version in [the upstream changelog](https://github.com/grafana/alloy
/blob/main/CHANGELOG.md#v1100). No major issues are expected during the upgrade.


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
