### PR TITLE
[bitnami/keycloak] Add support for customization of the Keycloak database schema

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.7.7
+version: 24.8.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -106,6 +106,7 @@ externalDatabase.user=myuser
 externalDatabase.password=mypassword
 externalDatabase.database=mydatabase
 externalDatabase.port=5432
+externalDatabase.schema=public
 ```
 
 > NOTE: Only PostgreSQL database server is supported as external database
@@ -687,6 +688,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `externalDatabase.user`                      | Non-root username for Keycloak                                                                                    | `bn_keycloak`      |
 | `externalDatabase.password`                  | Password for the non-root username for Keycloak                                                                   | `""`               |
 | `externalDatabase.database`                  | Keycloak database name                                                                                            | `bitnami_keycloak` |
+| `externalDatabase.schema`                    | Keycloak database schema                                                                                          | `public`           |
 | `externalDatabase.existingSecret`            | Name of an existing secret resource containing the database credentials                                           | `""`               |
 | `externalDatabase.existingSecretHostKey`     | Name of an existing secret key containing the database host name                                                  | `""`               |
 | `externalDatabase.existingSecretPortKey`     | Name of an existing secret key containing the database port                                                       | `""`               |

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -131,6 +131,13 @@ Return the Database database name
 {{- end -}}
 
 {{/*
+Return the Database port
+*/}}
+{{- define "keycloak.databaseSchema" -}}
+{{- ternary "public" (tpl (.Values.externalDatabase.schema | toString) $) .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
 Return the Database user
 */}}
 {{- define "keycloak.databaseUser" -}}

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -60,6 +60,7 @@ data:
   {{- if not .Values.externalDatabase.existingSecretDatabaseKey }}
   KEYCLOAK_DATABASE_NAME: {{ include "keycloak.databaseName" . | quote }}
   {{- end }}
+  KEYCLOAK_DATABASE_SCHEMA: {{ include "keycloak.databaseSchema" . }}
   {{- if not .Values.externalDatabase.existingSecretUserKey }}
   KEYCLOAK_DATABASE_USER: {{ include "keycloak.databaseUser" . | quote }}
   {{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1353,6 +1353,7 @@ postgresql:
 ## @param externalDatabase.user Non-root username for Keycloak
 ## @param externalDatabase.password Password for the non-root username for Keycloak
 ## @param externalDatabase.database Keycloak database name
+## @param externalDatabase.schema Keycloak database schema
 ## @param externalDatabase.existingSecret Name of an existing secret resource containing the database credentials
 ## @param externalDatabase.existingSecretHostKey Name of an existing secret key containing the database host name
 ## @param externalDatabase.existingSecretPortKey Name of an existing secret key containing the database port
@@ -1366,6 +1367,7 @@ externalDatabase:
   port: 5432
   user: bn_keycloak
   database: bitnami_keycloak
+  schema: public
   password: ""
   existingSecret: ""
   existingSecretHostKey: ""


### PR DESCRIPTION
### Description of the change

This PR adds support for specifying the database schema when using an external PostgreSQL database with the Keycloak Helm chart.

The following changes were made:

-     Introduced a new externalDatabase.schema field in values.yaml
-     Defined a new helper template keycloak.databaseSchema in _helpers.tpl
-     Included the KEYCLOAK_DATABASE_SCHEMA environment variable in the deployment template
-     Updated documentation for values.yaml accordingly

### Benefits

- Allows users to specify a custom schema name when connecting Keycloak to a shared PostgreSQL database.
- Makes it hard to integrate with PostgreSQL databases that enforce the use of specific schemas for multi-tenant or legacy reasons.
- Improves flexibility when managing Keycloak in environments where multiple services share the same database.

### Possible drawbacks

None

### Applicable issues

- fixes #35186

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
