### PR TITLE
[bitnami/argo-cd] Remove duplicate `matchLabels` from applicationset `ServiceMonitor`

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 9.0.30
+version: 9.0.31

--- a/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
@@ -40,7 +40,6 @@ spec:
     matchNames:
       - {{ include "common.names.namespace" . }}
   selector:
-    matchLabels:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: metrics
       app.kubernetes.io/part-of: applicationSet


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove duplicate `matchLabels` from applicationset `ServiceMonitor`

### Benefits

No longer causes kustomize to error out when setting `applicationSet.metrics.serviceMonitor.enabled` to `true`

```
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 25: mapping key "matchLabels" already defined at line 24
```

### Possible drawbacks

none that I'm aware of

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
