### PR TITLE
[bitnami/wordpress] Update passwordFile secret mountPath

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 25.0.3 (2025-07-15)
+## 25.0.4 (2025-07-21)
 
-* [bitnami/wordpress] :zap: :arrow_up: Update dependency references ([#35143](https://github.com/bitnami/charts/pull/35143))
+* [bitnami/wordpress] Update passwordFile secret mountPath ([#35222](https://github.com/bitnami/charts/pull/35222))
+
+## <small>25.0.3 (2025-07-15)</small>
+
+* [bitnami/wordpress] :zap: :arrow_up: Update dependency references (#35143) ([348bee6](https://github.com/bitnami/charts/commit/348bee6aaffd3e15e5a2e3eb519152f76d0d1958)), closes [#35143](https://github.com/bitnami/charts/issues/35143)
 
 ## <small>25.0.2 (2025-07-15)</small>
 

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 25.0.3
+version: 25.0.4

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
               value: {{ include "wordpress.databaseUser" . | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: WORDPRESS_DATABASE_PASSWORD_FILE
-              value: "/opt/bitnami/wordpress/secrets/mariadb-password"
+              value: "/secrets/mariadb-password"
             {{- else }}
             - name: WORDPRESS_DATABASE_PASSWORD
               valueFrom:
@@ -212,7 +212,7 @@ spec:
               value: {{ .Values.wordpressUsername | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: WORDPRESS_PASSWORD_FILE
-              value: "/opt/bitnami/wordpress/secrets/wordpress-password"
+              value: "/secrets/wordpress-password"
             {{- else }}
             - name: WORDPRESS_PASSWORD
               valueFrom:
@@ -272,7 +272,7 @@ spec:
             {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
             {{- if .Values.usePasswordFiles }}
             - name: SMTP_PASSWORD_FILE
-              value: "/opt/bitnami/wordpress/secrets/smtp-password"
+              value: "/secrets/smtp-password"
             {{- else }}
             - name: SMTP_PASSWORD
               valueFrom:
@@ -372,7 +372,7 @@ spec:
               subPath: wordpress
             {{- if  .Values.usePasswordFiles }}
             - name: wordpress-secrets
-              mountPath: /opt/bitnami/wordpress/secrets
+              mountPath: /secrets
             {{- end }}
             {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
             - name: wordpress-config


### PR DESCRIPTION
### Description of the change

Move wordpress password files mountpath from `/opt/bitnami/wordpress/secrets/` to `/secrets`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
