### PR TITLE
[bitnami/drupal] Update passwordFile secret mountPath

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: drupal
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/drupal
-version: 22.0.3
+version: 22.0.4

--- a/bitnami/drupal/templates/deployment.yaml
+++ b/bitnami/drupal/templates/deployment.yaml
@@ -205,7 +205,7 @@ spec:
               value: {{ include "drupal.databaseUser" . | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: DRUPAL_DATABASE_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/drupal/secrets/%s" (include "drupal.databasePasswordKey" .) }}
+              value: {{ printf "/secrets/%s" (include "drupal.databasePasswordKey" .) }}
             {{- else }}
             - name: DRUPAL_DATABASE_PASSWORD
               valueFrom:
@@ -221,7 +221,7 @@ spec:
               value: {{ .Values.drupalUsername | quote }}
             {{- if .Values.usePasswordFiles }}
             - name: DRUPAL_PASSWORD_FILE
-              value: "/opt/bitnami/drupal/secrets/drupal-password"
+              value: "/secrets/drupal-password"
             {{- else }}
             - name: DRUPAL_PASSWORD
               valueFrom:
@@ -246,7 +246,7 @@ spec:
             {{- if .Values.smtpPassword }}
             {{- if .Values.usePasswordFiles }}
             - name: SMTP_PASSWORD_FILE
-              value: "/opt/bitnami/drupal/secrets/smtp-password"
+              value: "/secrets/smtp-password"
             {{- else }}
             - name: SMTP_PASSWORD
               valueFrom:
@@ -354,7 +354,7 @@ spec:
               mountPath: /bitnami/drupal
             {{- if .Values.usePasswordFiles }}
             - name: drupal-secrets
-              mountPath: /opt/bitnami/drupal/secrets
+              mountPath: /secrets
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Move drupal password files mountpath from `/opt/bitnami/drupal/secrets/` to `/secrets`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
