### PR TITLE
[bitnami/thanos] Fix commonLabels on sharded storegateway

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## <small>17.2.3 (2025-07-22)</small>
 
-* [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238))
+* [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238)) 
 
 ## 17.2.2 (2025-07-21)
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-## <small>17.2.3 (2025-07-22)</small>
+## 17.2.3 (2025-07-22)
 
-* [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238)) 
+* [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238))
 
-## 17.2.2 (2025-07-21)
+## <small>17.2.2 (2025-07-21)</small>
 
-* [bitnami/thanos] :zap: :arrow_up: Update dependency references ([#35226](https://github.com/bitnami/charts/pull/35226))
+* [bitnami/*] Adapt main README and change ascii (#35173) ([73d15e0](https://github.com/bitnami/charts/commit/73d15e03e04647efa902a1d14a09ea8657429cd0)), closes [#35173](https://github.com/bitnami/charts/issues/35173)
+* [bitnami/*] Adapt welcome message to BSI (#35170) ([e1c8146](https://github.com/bitnami/charts/commit/e1c8146831516fb35de736a6f3fd10e5e7a44286)), closes [#35170](https://github.com/bitnami/charts/issues/35170)
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/thanos] :zap: :arrow_up: Update dependency references (#35226) ([efbbe03](https://github.com/bitnami/charts/commit/efbbe03289f99a78de4ac4c8eeb66d64d4b79bcd)), closes [#35226](https://github.com/bitnami/charts/issues/35226)
 
 ## <small>17.2.1 (2025-07-15)</small>
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 17.2.3 (2025-07-22)
+## 17.2.3 (2025-07-23)
 
 * [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238))
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## <small>17.2.3 (2025-07-22)</small>
+
+* [bitnami/thanos] Fix commonLabels on sharded storegateway ([#35238](https://github.com/bitnami/charts/pull/35238))
+
 ## 17.2.2 (2025-07-21)
 
 * [bitnami/thanos] :zap: :arrow_up: Update dependency references ([#35226](https://github.com/bitnami/charts/pull/35226))

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.2.2
+version: 17.2.3

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -28,7 +28,7 @@ kind: StatefulSet
 metadata:
   name: {{ printf "%s-%s" (include "thanos.storegateway.fullname" $) (toString $index) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" $ }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: storegateway
     shard: {{ $index | quote }}
     {{- if $.Values.storegateway.statefulsetLabels }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - Fix a bug
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes [#35002](https://github.com/bitnami/charts/issues/35002). Currently helm chart fails to render using storewaygay sharded and commonLabels


### Applicable issues

- fixes #35002


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
