### PR TITLE
[bitnami/kafka]fix(provisioning): Fix typo in initContainers

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
-## 32.3.6 (2025-07-18)
+## 32.3.7 (2025-07-23)
 
-* [bitnami/kafka] Update default controller.heapOpts to fit default RAM limit ([#34796](https://github.com/bitnami/charts/pull/34796))
+* [bitnami/kafka]fix(provisioning): Fix typo in initContainers ([#35255](https://github.com/bitnami/charts/pull/35255))
+
+## <small>32.3.6 (2025-07-18)</small>
+
+* [bitnami/*] Adapt main README and change ascii (#35173) ([73d15e0](https://github.com/bitnami/charts/commit/73d15e03e04647efa902a1d14a09ea8657429cd0)), closes [#35173](https://github.com/bitnami/charts/issues/35173)
+* [bitnami/*] Adapt welcome message to BSI (#35170) ([e1c8146](https://github.com/bitnami/charts/commit/e1c8146831516fb35de736a6f3fd10e5e7a44286)), closes [#35170](https://github.com/bitnami/charts/issues/35170)
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/kafka] Update default controller.heapOpts to fit default RAM limit (#34796) ([eb6830e](https://github.com/bitnami/charts/commit/eb6830efb87aa905ff874ba93e75b82f5303a6fb)), closes [#34796](https://github.com/bitnami/charts/issues/34796)
 
 ## <small>32.3.5 (2025-07-16)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 32.3.6
+version: 32.3.7

--- a/bitnami/kafka/templates/provisioning/job.yaml
+++ b/bitnami/kafka/templates/provisioning/job.yaml
@@ -154,9 +154,6 @@ spec:
           volumeMounts:
             - name: shared
               mountPath: /shared
-        {{- if .Values.provisioning.initContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.provisioning.initContainers "context" $ ) | nindent 8 }}
-        {{- end }}
         {{- if .Values.provisioning.waitForKafka }}
         - name: wait-for-available-kafka
           image: {{ include "kafka.image" . }}
@@ -194,6 +191,9 @@ spec:
         {{- end }}
         {{- if .Values.provisioning.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.provisioning.initContainers "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $ ) | nindent 8 }}
         {{- end }}
       containers:
         - name: kafka-provisioning


### PR DESCRIPTION
### Description of the change

Fix typo in provisioning job to avoid rendering `provisioning.initContainers` twice.

### Benefits

Provisioned initContainers are rendered properly.

### Possible drawbacks

None

### Additional information



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
