### PR TITLE
[bitnami/charts/issues/35218] Share context with apisix.etcd.authEnabled function

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.0.7 (2025-07-15)
+## 5.0.8 (2025-07-23)
 
-* [bitnami/apisix] :zap: :arrow_up: Update dependency references ([#35079](https://github.com/bitnami/charts/pull/35079))
+* [bitnami/charts/issues/35218] Share context with apisix.etcd.authEnabled function ([#35257](https://github.com/bitnami/charts/pull/35257))
+
+## <small>5.0.7 (2025-07-15)</small>
+
+* [bitnami/apisix] :zap: :arrow_up: Update dependency references (#35079) ([03f66b2](https://github.com/bitnami/charts/commit/03f66b2c6caaaf14477cb720e8dff0c43407f686)), closes [#35079](https://github.com/bitnami/charts/issues/35079)
 
 ## <small>5.0.6 (2025-07-08)</small>
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -48,4 +48,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 5.0.7
+version: 5.0.8

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -418,7 +418,7 @@ Init container definition for waiting for the database to be ready
     - name: empty-dir
       mountPath: /tmp
       subPath: tmp-dir
-    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
+    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .context)) }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}
@@ -671,7 +671,7 @@ Render configuration for the dashboard and ingress-controller components
       subPath: app-conf-dir
     - name: config
       mountPath: /bitnami/apisix/conf/00_default
-    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
+    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .context)) }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}


### PR DESCRIPTION
### Description of the change

Installation was failing when following the documentation

https://github.com/bitnami/charts/issues/35218

### Benefits

Installation works 

```
➜  apisix git:(bitnami/charts/issues/35218) k get pods 
NAME                                 READY   STATUS    RESTARTS   AGE
apisix-data-plane-77986f5f99-mhrb6   1/1     Running   0          2m50s
redis-node-0                         2/2     Running   0          79m
```

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/35218

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
