### PR TITLE
Fix ingress annotations in argo-workflows

### DIFF
--- a/bitnami/argo-workflows/CHANGELOG.md
+++ b/bitnami/argo-workflows/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## <small>13.0.1 (2025-07-24)</small>
+
+* Fix ingress annotations retrieval ([#35273](https://github.com/bitnami/charts/issues/35273))
+
 ## 13.0.0 (2025-07-23)
 
 * [bitnami/argo-workflows] Upgrade MySQL subchart to 14 ([#35254](https://github.com/bitnami/charts/pull/35254))

--- a/bitnami/argo-workflows/CHANGELOG.md
+++ b/bitnami/argo-workflows/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
-## <small>13.0.1 (2025-07-24)</small>
+## 13.0.1 (2025-07-24)
 
-* Fix ingress annotations retrieval ([#35273](https://github.com/bitnami/charts/issues/35273))
+* Fix ingress annotations in argo-workflows ([#35275](https://github.com/bitnami/charts/pull/35275))
 
 ## 13.0.0 (2025-07-23)
 
-* [bitnami/argo-workflows] Upgrade MySQL subchart to 14 ([#35254](https://github.com/bitnami/charts/pull/35254))
+* [bitnami/*] Adapt main README and change ascii (#35173) ([73d15e0](https://github.com/bitnami/charts/commit/73d15e03e04647efa902a1d14a09ea8657429cd0)), closes [#35173](https://github.com/bitnami/charts/issues/35173)
+* [bitnami/*] Adapt welcome message to BSI (#35170) ([e1c8146](https://github.com/bitnami/charts/commit/e1c8146831516fb35de736a6f3fd10e5e7a44286)), closes [#35170](https://github.com/bitnami/charts/issues/35170)
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/argo-workflows] Upgrade MySQL subchart to 14 (#35254) ([06cb090](https://github.com/bitnami/charts/commit/06cb0900f83b402447250875b832ce05b1dc73fd)), closes [#35254](https://github.com/bitnami/charts/issues/35254)
 
 ## <small>12.0.7 (2025-07-08)</small>
 

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/argo-workflows/templates/server/ingress.yaml
+++ b/bitnami/argo-workflows/templates/server/ingress.yaml
@@ -21,8 +21,8 @@ metadata:
     ingress.kubernetes.io/protocol: https # Traefik
     nginx.ingress.kubernetes.io/backend-protocol: https # Nginx
     {{- end }}
-    {{- if or .Values.controller.service.annotations .Values.commonAnnotations }}
-    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.service.annotations .Values.commonAnnotations ) "context" . ) }}
+    {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:


### PR DESCRIPTION
### Description of the change

This PR updates the ingress template of the `bitnami/argo-workflows` chart to correctly apply the `.Values.ingress.annotations` field when `server.ingress.enabled` is `true`.  
It leverages the existing Bitnami `tpl` helper (`include "common.tplvalues.render"`) to render user-defined annotations, which were previously ignored.

### Benefits

- Fixes a bug that prevented custom ingress annotations from being applied, despite being documented in `values.yaml`.
- Enables use cases like cert-manager integration or ingress controller-specific configuration.
- Aligns behavior with Bitnami chart conventions and expectations of users relying on global `ingress.annotations`.

### Possible drawbacks

- If users had workarounds depending on the absence of annotations, this change may conflict with them. However, such use cases are unsupported and undocumented.
- Applies only when `.Values.server.ingress.enabled` is `true` — consistent with expected behavior.

### Applicable issues

- fixes [bitnami/charts#35273](https://github.com/bitnami/charts/issues/35273)

### Additional information

- Tested on a forked chart against both NGINX and cert-manager-enabled ingress controllers.
- Preserves compatibility with Bitnami's `common` library helper functions.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern `[bitnami/argo-workflows] Fix ingress.annotations being ignored`
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
