### PR TITLE
[bitnami/multus-cni] Fix "Text file busy" after node reboot

### DIFF
--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: multus-cni
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/multus-cni
-version: 2.2.19
+version: 2.2.20

--- a/bitnami/multus-cni/templates/daemonset.yaml
+++ b/bitnami/multus-cni/templates/daemonset.yaml
@@ -61,28 +61,15 @@ spec:
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
-        - name: install-multus-binary
-          image: {{ template "multus-cni.image" . }}
-          command:
-            - cp 
-            - -r
-            # Using /usr/src to allow compatibility with upstream multus container
-            - "/usr/src/multus-cni/bin/multus"
-            - "{{ .Values.CNIMountPath }}/opt/cni/bin/"
-          {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: cni-bin-dir
-              mountPath: {{ .Values.CNIMountPath }}/opt/cni/bin
-              mountPropagation: Bidirectional
-        - name: generate-kubeconfig
+        - name: install-multus
           image: {{ template "multus-cni.image" . }}
           command:
             - install_multus
           args:
             - "--type"
             - "thin"
+            - "--dest-dir"
+            - "{{ .Values.CNIMountPath }}/opt/cni/bin"
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

Multus daemonset has init container that copy multus binary to host with `cp`. After node reboot or massive pods recreation it fails with error like `cannot create regular file '.../cni/bin/multus': Text file busy`. That is because other pods execute binary to setup network.

Upstream multus doesn't have this init container because install_multus already copies the binary "atomically", which prevents this error from happening: https://github.com/k8snetworkplumbingwg/multus-cni/blob/v4.2.2/cmd/install_multus/main.go#L49

In result, copy container  is useless and harmful for multus 4.x, so i removed it. Tested with Kind, works well

### Benefits

Fixes "Text file busy" after reboot

### Possible drawbacks

None

### Applicable issues

Same problem with `cp`  in upstream manifest for **thick** version: https://github.com/k8snetworkplumbingwg/multus-cni/issues/1221

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
