### PR TITLE
[bitnami/kafka] Fix provisioning postScript

### DIFF
--- a/bitnami/kafka/templates/provisioning/job.yaml
+++ b/bitnami/kafka/templates/provisioning/job.yaml
@@ -274,7 +274,7 @@ spec:
                   wait
               done
 
-              {{- if .Values.provisioning.preScript }}
+              {{- if .Values.provisioning.postScript }}
               echo "Running post-provisioning script"
               {{ .Values.provisioning.postScript | nindent 14 }}
               {{- end }}


### PR DESCRIPTION
I'm using kafka helm chart with `Values.provisioning.postScript` variable, but it doesn't work.

I discovered on the source code that there was an error on the variable used on the `if` block.

Signed-off-by: Luca Cireddu <sardylan@gmail.com>
