### PR TITLE
[bitnami/appsmith] Fix example errors in README.md

### DIFF
--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -85,11 +85,11 @@ You may want to have appsmith connect to an external database rather than instal
 
 ```console
 mongodb.enabled=false
-externalDatabase.host=myexternalhost
+externalDatabase.hosts=[]
 externalDatabase.user=myuser
 externalDatabase.password=mypassword
 externalDatabase.database=mydatabase
-externalDatabase.port=3306
+externalDatabase.port=27017
 ```
 
 ### External redis support
@@ -98,11 +98,9 @@ You may want to have appsmith connect to an external redis rather than installin
 
 ```console
 redis.enabled=false
-externalDatabase.host=myexternalhost
-externalDatabase.user=myuser
-externalDatabase.password=mypassword
-externalDatabase.redis=myredis
-externalDatabase.port=3306
+externalRedis.host=myexternalhost
+externalRedis.password=mypassword
+externalRedis.port=6379
 ```
 
 ### Ingress


### PR DESCRIPTION
### Description of the change

Fix example errors in README.md related to external MongoDB and Redis configuration.
- Corrected externalDatabase.host to externalDatabase.hosts (MongoDB expects an array).
- Fixed incorrect port number for MongoDB (3306 → 27017).
- Fixed Redis example to use externalRedis.* instead of incorrect externalDatabase.* fields.

### Benefits
- Clarifies correct usage of external database configuration.
- Prevents confusion or misconfiguration when users refer to the README.
- Improves developer and user experience.

### Possible drawbacks
- None.

### Applicable issues
- fixes #

### Additional information

These changes only modify documentation. No chart version bump is necessary.
