### PR TITLE
[bitnami/airflow] fix AIRFLOW__API_AUTH__JWT_SECRET

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 24.2.5 (2025-08-01)
 
-* [bitnami/airflow] Fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
+* fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
 
-## 24.2.4 (2025-07-24)
+## <small>24.2.4 (2025-07-25)</small>
 
-* [bitnami/airflow] Fix/add extra env vars secrets to triggerer ([#35047](https://github.com/bitnami/charts/pull/35047))
+* [bitnami/airflow] Fix/add extra env vars secrets to triggerer (#35047) ([f91d7dc](https://github.com/bitnami/charts/commit/f91d7dc52e9892c9de8cc5eb9a3d3abf14336d9b)), closes [#35047](https://github.com/bitnami/charts/issues/35047)
 
 ## <small>24.2.3 (2025-07-21)</small>
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 24.2.5 (2025-08-01)
+## 24.2.5 (2025-08-02)
 
-* fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
+* [bitnami/airflow] fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
 
 ## <small>24.2.4 (2025-07-25)</small>
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.2.5 (2025-08-01)
+
+* [bitnami/airflow] Fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
+
 ## 24.2.4 (2025-07-24)
 
 * [bitnami/airflow] Fix/add extra env vars secrets to triggerer ([#35047](https://github.com/bitnami/charts/pull/35047))

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.2.5 (2025-08-02)
+## 24.2.5 (2025-08-03)
 
 * [bitnami/airflow] fix AIRFLOW__API_AUTH__JWT_SECRET ([#35355](https://github.com/bitnami/charts/pull/35355))
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 24.2.4
+version: 24.2.5

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -388,7 +388,7 @@ Add environment variables to configure airflow common values
       key: airflow-secret-key
 {{- end }}
 {{- if (include "airflow.isImageMajorVersion3" .) }}
-- name: AIRFLOW__API_AUTH__JWT_SECRET_CMD
+- name: AIRFLOW__API_AUTH__JWT_SECRET
   valueFrom:
     secretKeyRef:
       name: {{ include "airflow.secretName" . }}


### PR DESCRIPTION
### Description of the change

fix `AIRFLOW__API_AUTH__JWT_SECRET_CMD `env
`AIRFLOW__API_AUTH__JWT_SECRET_CMD` used twice - one time correct and another is wrong

### Benefits
now `AIRFLOW__API_AUTH__JWT_SECRET_CMD` and `AIRFLOW__API_AUTH__JWT_SECRET` will be correct