### PR TITLE
[bitnami/redis] fix(redis): add support for script prestop prestart with external access

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 21.2.13
+version: 21.2.14

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -192,7 +192,9 @@ data:
         info "Current master: REDIS_SENTINEL_INFO=(${REDIS_SENTINEL_INFO[0]},${REDIS_SENTINEL_INFO[1]})"
         REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
         REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
-
+        {{- if and .Values.sentinel.externalAccess.enabled .Values.sentinel.externalAccess.service.loadBalancerIP }}
+        if [[ "$REDIS_MASTER_HOST" == "$(get_service_ip "$SVC_NAME")" ]]; then
+        {{- else }}
         if [[ "$REDIS_MASTER_HOST" == "$(get_full_hostname "$HOSTNAME")" ]]; then
         {{- end }}
             # Case 3: Active sentinel and master it is this node --> MASTER

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -71,8 +71,6 @@ data:
 
     REDISPORT=$(get_port "$HOSTNAME" "REDIS")
 
-    HEADLESS_SERVICE="{{ template "common.names.fullname" . }}-headless.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-
     if [ -n "$REDIS_EXTERNAL_MASTER_HOST" ]; then
         REDIS_SERVICE="$REDIS_EXTERNAL_MASTER_HOST"
     else
@@ -174,6 +172,9 @@ data:
     fi
 
     if [[ $redisRetVal -ne 0 ]]; then
+        {{- if and .Values.sentinel.externalAccess.enabled .Values.sentinel.externalAccess.service.loadBalancerIP }}
+        if [[ "$master_in_persisted_conf" == "$(get_service_ip "$SVC_NAME")" ]]; then
+        {{- else }}
         if [[ "$master_in_persisted_conf" == "$(get_full_hostname "$HOSTNAME")" ]]; then
         {{- end }}
             # Case 1: No active sentinel and in previous sentinel.conf we were the master --> MASTER
@@ -540,7 +541,37 @@ data:
     . /opt/bitnami/scripts/libvalidations.sh
     . /opt/bitnami/scripts/libos.sh
 
-    HEADLESS_SERVICE="{{ template "common.names.fullname" . }}-headless.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+    {{- if and .Values.sentinel.externalAccess.enabled .Values.sentinel.externalAccess.service.loadBalancerIP }}
+
+    SERVICE_NAMES="{{ $fullname := include "common.names.fullname" . -}}
+    {{- range $i, $e := .Values.sentinel.externalAccess.service.loadBalancerIP -}}
+        {{- if $i }} {{ end }}{{ printf "%s-svc-%d" $fullname $i }}
+    {{- end }}"
+    SERVICE_IPS="{{- range $i, $ip := .Values.sentinel.externalAccess.service.loadBalancerIP -}}
+    {{- if $i }} {{ end }}{{ $ip }}
+    {{- end }}"
+
+
+    # Helper function to get IP by service name
+    get_service_ip() {
+        search_name="$1"
+        set -- $SERVICE_NAMES
+        for i in $(seq 1 $#); do
+            eval name=\${$i}
+            if [ "$name" = "$search_name" ]; then
+            set -- $SERVICE_IPS
+            eval echo \${$i}
+            return 0
+            fi
+        done
+        return 1
+    }
+    
+    SVC_NAME=$(hostname | sed 's/node/svc/g')
+    {{- else }}
+    HEADLESS_SERVICE="{{ template "common.names.fullname" . }}-headless.{{- include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+    {{- end }}
+
 
     get_full_hostname() {
         hostname="$1"
@@ -576,10 +607,38 @@ data:
             redis-cli -p "$REDIS_SENTINEL_PORT" sentinel "$@"
         fi
     }
+
     sentinel_failover_finished() {
-      REDIS_SENTINEL_INFO=($(run_sentinel_command get-master-addr-by-name "{{ .Values.sentinel.masterSet }}"))
-      REDIS_MASTER_HOST="${REDIS_SENTINEL_INFO[0]}"
-      [[ "$REDIS_MASTER_HOST" != "$(get_full_hostname $HOSTNAME)" ]]
+        REDIS_SENTINEL_INFO=($(run_sentinel_command get-master-addr-by-name "{{ .Values.sentinel.masterSet }}"))
+        echo "REDIS_SENTINEL_INFO: $REDIS_SENTINEL_INFO"
+        REDIS_MASTER_HOST="${REDIS_SENTINEL_INFO[0]}"
+        echo "REDIS_MASTER_HOST: $REDIS_MASTER_HOST"
+        {{- if .Values.sentinel.externalAccess.enabled }}
+        # Get the current service name and its IP
+        CURRENT_SERVICE_NAME="$SVC_NAME"
+        echo "CURRENT_SERVICE_NAME: $CURRENT_SERVICE_NAME"
+        CURRENT_SERVICE_IP=$(get_service_ip "$CURRENT_SERVICE_NAME")
+        echo "CURRENT_SERVICE_IP: $CURRENT_SERVICE_IP"
+        # Check if both variables are not empty
+        if [[ -z "$REDIS_MASTER_HOST" ]]; then
+            echo "WARNING: REDIS_MASTER_HOST is empty, assuming failover not finished"
+            return 1
+        fi
+        
+        if [[ -z "$CURRENT_SERVICE_IP" ]]; then
+            echo "WARNING: CURRENT_SERVICE_IP is empty, assuming failover not finished"
+            return 1
+        fi
+        [[ "$REDIS_MASTER_HOST" != "$CURRENT_SERVICE_IP" ]]
+        {{- else }}
+        echo "REDIS_MASTER_HOST: $(get_full_hostname $HOSTNAME)"
+        # Check if both variables are not empty
+        if [[ -z "$REDIS_MASTER_HOST" ]]; then
+            echo "WARNING: REDIS_MASTER_HOST is empty, assuming failover not finished"
+            return 1
+        fi
+        [[ "$REDIS_MASTER_HOST" != "$(get_full_hostname $HOSTNAME)" ]]
+        {{- end }}
     }
 
     {{ if .Values.auth.sentinel -}}
@@ -651,7 +710,6 @@ data:
     }
     
     SVC_NAME=$(hostname | sed 's/node/svc/g')
-    EXTERNAL_SERVICE="$SVC_NAME.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     {{- else }}
     HEADLESS_SERVICE="{{ template "common.names.fullname" . }}-headless.{{- include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
     {{- end }}
@@ -704,9 +762,24 @@ data:
         echo "CURRENT_SERVICE_NAME: $CURRENT_SERVICE_NAME"
         CURRENT_SERVICE_IP=$(get_service_ip "$CURRENT_SERVICE_NAME")
         echo "CURRENT_SERVICE_IP: $CURRENT_SERVICE_IP"
+        # Check if both variables are not empty
+        if [[ -z "$REDIS_MASTER_HOST" ]]; then
+            echo "WARNING: REDIS_MASTER_HOST is empty, assuming failover not finished"
+            return 1
+        fi
+        
+        if [[ -z "$CURRENT_SERVICE_IP" ]]; then
+            echo "WARNING: CURRENT_SERVICE_IP is empty, assuming failover not finished"
+            return 1
+        fi
         [[ "$REDIS_MASTER_HOST" != "$CURRENT_SERVICE_IP" ]]
         {{- else }}
         echo "REDIS_MASTER_HOST: $(get_full_hostname $HOSTNAME)"
+        # Check if both variables are not empty
+        if [[ -z "$REDIS_MASTER_HOST" ]]; then
+            echo "WARNING: REDIS_MASTER_HOST is empty, assuming failover not finished"
+            return 1
+        fi
         [[ "$REDIS_MASTER_HOST" != "$(get_full_hostname $HOSTNAME)" ]]
         {{- end }}
     }

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -115,6 +115,39 @@ data:
         retry_while "eval $sentinel_info_command" 2 5
     }
 
+    {{- if and .Values.sentinel.externalAccess.enabled .Values.sentinel.externalAccess.service.loadBalancerIP }}
+
+    SERVICE_NAMES="{{- $fullname := include "common.names.fullname" . -}}
+    {{- range $i, $e := .Values.sentinel.externalAccess.service.loadBalancerIP -}}
+        {{- if $i }} {{ end }}{{ printf "%s-svc-%d" $fullname $i }}
+    {{- end }}"
+    SERVICE_IPS="{{- range $i, $ip := .Values.sentinel.externalAccess.service.loadBalancerIP -}}
+    {{- if $i }} {{ end }}{{ $ip }}
+    {{- end }}"
+
+
+    # Helper function to get IP by service name
+    get_service_ip() {
+        search_name="$1"
+        set -- $SERVICE_NAMES
+        for i in $(seq 1 $#); do
+            eval name=\${$i}
+            if [ "$name" = "$search_name" ]; then
+            set -- $SERVICE_IPS
+            eval echo \${$i}
+            return 0
+            fi
+        done
+        return 1
+    }
+    
+    SVC_NAME=$(hostname | sed 's/node/svc/g')
+    CURRENT_SERVICE_IP=$(get_service_ip "$SVC_NAME")
+    echo "CURRENT_SERVICE_IP: $CURRENT_SERVICE_IP"
+    {{- else }}
+    HEADLESS_SERVICE="{{ template "common.names.fullname" . }}-headless.{{- include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+    {{- end }}
+
     {{- if and .Values.replica.containerSecurityContext.runAsUser (eq (.Values.replica.containerSecurityContext.runAsUser | int) 0) }}
     useradd redis
     chown -R redis {{ .Values.replica.persistence.path }}
@@ -124,7 +157,7 @@ data:
     [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
 
     # check if there is a master
-    master_in_persisted_conf="$(get_full_hostname "$HOSTNAME")"
+    master_in_persisted_conf="$(get_service_ip "$SVC_NAME")"
     master_port_in_persisted_conf="$REDIS_MASTER_PORT_NUMBER"
     master_in_sentinel="$(get_sentinel_master_info)"
     redisRetVal=$?
@@ -142,6 +175,7 @@ data:
 
     if [[ $redisRetVal -ne 0 ]]; then
         if [[ "$master_in_persisted_conf" == "$(get_full_hostname "$HOSTNAME")" ]]; then
+        {{- end }}
             # Case 1: No active sentinel and in previous sentinel.conf we were the master --> MASTER
             info "Configuring the node as master"
             export REDIS_REPLICATION_MODE="master"
@@ -160,6 +194,7 @@ data:
         REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
 
         if [[ "$REDIS_MASTER_HOST" == "$(get_full_hostname "$HOSTNAME")" ]]; then
+        {{- end }}
             # Case 3: Active sentinel and master it is this node --> MASTER
             info "Configuring the node as master"
             export REDIS_REPLICATION_MODE="master"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This pull request enhances the Redis Helm chart by introducing support for external access to Sentinel services using specific LoadBalancer IPs. The changes include adding helper functions for service IP resolution, modifying how the master node is determined, and ensuring compatibility with the new external access configuration.

### Improvements for external Sentinel access:

* Added logic to handle external access for Sentinel services by defining `SERVICE_NAMES` and `SERVICE_IPS` based on `loadBalancerIP` values. This includes a helper function `get_service_ip` to resolve IPs by service name.
* Updated the master node resolution logic to use `get_service_ip` instead of `get_full_hostname` when external access is enabled.

### Compatibility adjustments:

* Added conditional blocks to ensure proper configuration of the master node when external access is enabled, modifying the logic for cases where a node is identified as the master.

### Benefits

Handle redis restart when they are using `sentinel.externalAccess.enabled`. Script where updated to handle properly
- `start-node.sh` -> handle start as master when externalAccess is used 
- `prestop-sentinel.sh` -> handle proper failover before shutting down the sentinel
- `prestop-redis.sh` -> handle proper failover before shutting down the redis

### Possible drawbacks

Not identify

### Applicable issues

- fixes : https://github.com/bitnami/charts/issues/34756

### Additional information

If you have any test that I can run let me know

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
