### PR TITLE
[bitnami/airflow] [Feature request] Support multiple configmaps in Airflow chart

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 24.2.4
+version: 24.3.0

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -123,11 +123,23 @@ spec:
             {{- if .Values.dagProcessor.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.dagProcessor.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.dagProcessor.extraEnvVarsCM .Values.dagProcessor.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.dagProcessor.extraEnvVarsCM .Values.dagProcessor.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsCMs .Values.dagProcessor.extraEnvVarsCMs }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsCMs }}
+            {{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.dagProcessor.extraEnvVarsCMs }}
+            {{- range .Values.dagProcessor.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -123,7 +123,7 @@ spec:
             {{- if .Values.dagProcessor.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.dagProcessor.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.dagProcessor.extraEnvVarsCM .Values.dagProcessor.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsCMs .Values.dagProcessor.extraEnvVarsCMs }}
+          {{- if or .Values.dagProcessor.extraEnvVarsCM .Values.dagProcessor.extraEnvVarsCMs .Values.dagProcessor.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsCMs .Values.extraEnvVarsSecret }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -127,11 +127,23 @@ spec:
             {{- if .Values.scheduler.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
+          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.scheduler.extraEnvVarsCMs }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsCMs }}
+            {{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.scheduler.extraEnvVarsCMs }}
+            {{- range .Values.scheduler.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -127,7 +127,7 @@ spec:
             {{- if .Values.scheduler.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.scheduler.extraEnvVarsCMs }}
+          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsCMs .Values.scheduler.extraEnvVarsSecret .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsCMs .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
             {{- if .Values.triggerer.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.triggerer.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.triggerer.extraEnvVarsCM .Values.triggerer.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.triggerer.extraEnvVarsCMs .Values.extraEnvVarsCMs }}
+          {{- if or .Values.triggerer.extraEnvVarsCM .Values.triggerer.extraEnvVarsCMs .Values.triggerer.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsCMs .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -127,11 +127,23 @@ spec:
             {{- if .Values.triggerer.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.triggerer.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.triggerer.extraEnvVarsCM .Values.triggerer.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
+          {{- if or .Values.triggerer.extraEnvVarsCM .Values.triggerer.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.triggerer.extraEnvVarsCMs .Values.extraEnvVarsCMs }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsCMs }}
+            {{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.triggerer.extraEnvVarsCMs }}
+            {{- range .Values.triggerer.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -136,11 +136,23 @@ spec:
             {{- if .Values.web.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret .Values.web.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
+          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret .Values.web.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.web.extraEnvVarsCMs }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsCMs }}
+            {{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.web.extraEnvVarsCMs }}
+            {{- range .Values.web.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -136,7 +136,7 @@ spec:
             {{- if .Values.web.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret .Values.web.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.web.extraEnvVarsCMs }}
+          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsCMs .Values.web.extraEnvVarsSecret .Values.web.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsCMs .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -129,11 +129,23 @@ spec:
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
+          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.worker.extraEnvVarsCMs }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsCMs }}
+            {{- range .Values.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.worker.extraEnvVarsCMs }}
+            {{- range .Values.worker.extraEnvVarsCMs }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -129,7 +129,7 @@ spec:
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets .Values.extraEnvVarsCMs .Values.worker.extraEnvVarsCMs }}
+          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsCMs .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsCMs .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -501,6 +501,9 @@ extraEnvVars: []
 ## @param extraEnvVarsCM ConfigMap with extra environment variables for all the Airflow pods
 ##
 extraEnvVarsCM: ""
+## @param extraEnvVarsCMs ConfigMaps with extra environment variables for all the Airflow pods
+##
+extraEnvVarsCMs: []
 ## @param extraEnvVarsSecret Secret with extra environment variables for all the Airflow pods
 ##
 extraEnvVarsSecret: ""
@@ -593,6 +596,9 @@ web:
   ## @param web.extraEnvVarsCM ConfigMap containing extra environment variables for Airflow webserver pods
   ##
   extraEnvVarsCM: ""
+  ## @param web.extraEnvVarsCMs ConfigMaps with extra environment variables for Airflow webserver pods
+  ##
+  extraEnvVarsCMs: []
   ## @param web.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow webserver pods
   ##
   extraEnvVarsSecret: ""
@@ -944,6 +950,9 @@ scheduler:
   ## @param scheduler.extraEnvVarsCM ConfigMap with extra environment variables
   ##
   extraEnvVarsCM: ""
+  ## @param scheduler.extraEnvVarsCMs ConfigMaps with extra environment variables
+  ##
+  extraEnvVarsCMs: []
   ## @param scheduler.extraEnvVarsSecret Secret with extra environment variables
   ##
   extraEnvVarsSecret: ""
@@ -1292,6 +1301,9 @@ dagProcessor:
   ## @param dagProcessor.extraEnvVarsCM ConfigMap with extra environment variables
   ##
   extraEnvVarsCM: ""
+  ## @param dagProcessor.extraEnvVarsCMs ConfigMaps with extra environment variables
+  ##
+  extraEnvVarsCMs: []
   ## @param dagProcessor.extraEnvVarsSecret Secret with extra environment variables
   ##
   extraEnvVarsSecret: ""
@@ -1640,6 +1652,9 @@ triggerer:
   ## @param triggerer.extraEnvVarsCM ConfigMap with extra environment variables
   ##
   extraEnvVarsCM: ""
+  ## @param triggerer.extraEnvVarsCMs ConfigMaps with extra environment variables
+  ##
+  extraEnvVarsCMs: []
   ## @param triggerer.extraEnvVarsSecret Secret with extra environment variables
   ##
   extraEnvVarsSecret: ""
@@ -2088,6 +2103,9 @@ worker:
   ## @param worker.extraEnvVarsCM ConfigMap containing extra environment variables for Airflow worker pods
   ##
   extraEnvVarsCM: ""
+  ## @param worker.extraEnvVarsCMs ConfigMaps with extra environment variables for Airflow worker pods
+  ##
+  extraEnvVarsCMs: []
   ## @param worker.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods
   ##
   extraEnvVarsSecret: ""


### PR DESCRIPTION
### Description of the change

Adds support for supplying multiple configmap resource types to various components of the Airflow chart following style of the extra secrets and for the resources supporting the extra secrets too (triggerer, web, worker, scheduler, processor).

### Benefits

Beneficial for if multiple distinct configmaps are deployed to the namespace already for other workloads - previous workarounds were merging into one configmap dedicated to Airflow via Helm variables which can be a bit messy.

Related: https://github.com/bitnami/charts/issues/8521

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #8521


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
