### PR TITLE
[bitnami/mongodb] Replace `0o` octal notation with `0###`

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.5.35 (2025-07-31)
+## 16.5.36 (2025-08-05)
 
-* [bitnami/mongodb] :zap: :arrow_up: Update dependency references ([#35366](https://github.com/bitnami/charts/pull/35366))
+* [bitnami/mongodb] Replace `0o` octal notation with `0###` ([#35406](https://github.com/bitnami/charts/pull/35406))
+
+## <small>16.5.35 (2025-07-31)</small>
+
+* [bitnami/mongodb] :zap: :arrow_up: Update dependency references (#35366) ([44d6930](https://github.com/bitnami/charts/commit/44d6930ef787929099fb7c94435ff40ea5f55d3d)), closes [#35366](https://github.com/bitnami/charts/issues/35366)
 
 ## <small>16.5.34 (2025-07-31)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.5.35
+version: 16.5.36

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -306,7 +306,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o555
+            defaultMode: 0555
         {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap }}
         - name: config
           configMap:
@@ -322,10 +322,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0o600
+              mode: 0600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0o600
+              mode: 0600
         {{- else }}
         - name: mongodb-certs-0
           secret:

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -198,7 +198,7 @@ spec:
             - name: common-scripts
               configMap:
                 name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-                defaultMode: 0o550
+                defaultMode: 0550
             {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
             - name: mongodb-secrets
               secret:
@@ -214,10 +214,10 @@ spec:
                 items:
                 - key: mongodb-ca-cert
                   path: mongodb-ca-cert
-                  mode: 0o600
+                  mode: 0600
                 - key: mongodb-ca-key
                   path: mongodb-ca-key
-                  mode: 0o600
+                  mode: 0600
             {{- else }}
             - name: mongodb-certs-0
               secret:

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -513,7 +513,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o555
+            defaultMode: 0555
         {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
         - name: mongodb-secrets
           secret:
@@ -536,7 +536,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o755
+            defaultMode: 0755
         {{- if .Values.hidden.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.hidden.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
@@ -550,10 +550,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0o600
+              mode: 0600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0o600
+              mode: 0600
         {{- else }}
         {{- range $index, $secret := .Values.tls.hidden.existingSecrets }}
         - name: mongodb-certs-{{ $index }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -514,7 +514,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o550
+            defaultMode: 0550
         {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
         - name: mongodb-secrets
           secret:
@@ -537,7 +537,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o755
+            defaultMode: 0755
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
@@ -551,10 +551,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0o600
+              mode: 0600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0o600
+              mode: 0600
         {{- else }}
         {{- range $index, $secret := .Values.tls.replicaset.existingSecrets }}
         - name: mongodb-certs-{{ $index }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -459,7 +459,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0o550
+            defaultMode: 0550
         {{- if and .Values.usePasswordFiles .Values.auth.enabled }}
         - name: mongodb-secrets
           secret:
@@ -488,10 +488,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0o600
+              mode: 0600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0o600
+              mode: 0600
         {{- else }}
         - name: mongodb-certs-0
           secret:


### PR DESCRIPTION
This PR replaces the `0o` octal notation with `0###` to unify this chart with the rest of the catalog.