### PR TITLE
[bitnami/kube-prometheus] Remove references to deprecated helpers

### DIFF
--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: node-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 4.5.11
+  version: 4.5.17
 - name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 5.0.6
+  version: 5.0.14
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.0
+  version: 2.31.3
 - name: kube-prometheus-crds
   repository: file://./charts/kube-prometheus-crds
   version: 0.1.0
-digest: sha256:de42c1e1526b829d9d076246ddf42552463a72055feb50e89cc99646f94763d7
-generated: "2025-05-06T10:29:37.160030815+02:00"
+digest: sha256:31c3fd5b6d824b7eb09586d3ff2ce05b847cdc4de88e654a38eb0212f57b9774
+generated: "2025-08-05T11:05:43.585369+02:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -19,36 +19,35 @@ annotations:
 apiVersion: v2
 appVersion: 0.84.0
 dependencies:
-- condition: exporters.enabled,exporters.node-exporter.enabled
-  name: node-exporter
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 4.x.x
-- condition: exporters.enabled,exporters.kube-state-metrics.enabled
-  name: kube-state-metrics
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 5.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
-- name: kube-prometheus-crds
-  repository: file://./charts/kube-prometheus-crds
-  version: 0.x.x
-description: Prometheus Operator provides easy monitoring definitions for Kubernetes
-  services and deployment and management of Prometheus instances.
+  - condition: exporters.enabled,exporters.node-exporter.enabled
+    name: node-exporter
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 4.x.x
+  - condition: exporters.enabled,exporters.kube-state-metrics.enabled
+    name: kube-state-metrics
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 5.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+  - name: kube-prometheus-crds
+    repository: file://./charts/kube-prometheus-crds
+    version: 0.x.x
+description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:
-- prometheus
-- alertmanager
-- operator
-- monitoring
+  - prometheus
+  - alertmanager
+  - operator
+  - monitoring
 kubeVersion: '>= 1.16.0-0'
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kube-prometheus
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 11.2.16
+  - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
+version: 11.2.17

--- a/bitnami/kube-prometheus/templates/thanos-ruler/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/thanos-ruler/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations: {{ include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.thanosRuler.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  {{- if .Values.thanosRuler.ingress.ingressClassName }}
   ingressClassName: {{ .Values.thanosRuler.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
@@ -27,9 +27,7 @@ spec:
       http:
         paths:
           - path: {{ .Values.thanosRuler.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.thanosRuler.ingress.pathType }}
-            {{- end }}
             backend: {{ include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.thanosRuler.fullname" .) "servicePort" "http" "context" .) | nindent 14 }}
     {{- end }}
     {{- range .Values.thanosRuler.ingress.extraHosts }}
@@ -37,9 +35,7 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{ include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.thanosRuler.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.thanosRuler.ingress.extraRules }}


### PR DESCRIPTION
### Description of the change

This PR removes references to deprecated helpers that were removed at https://github.com/bitnami/charts/pull/33496

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
