### PR TITLE
[bitnami/redmine] Remove references to deprecated helpers

### DIFF
--- a/bitnami/redmine/CHANGELOG.md
+++ b/bitnami/redmine/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 33.0.3 (2025-07-15)
+## 33.0.4 (2025-08-05)
 
-* [bitnami/redmine] :zap: :arrow_up: Update dependency references ([#35127](https://github.com/bitnami/charts/pull/35127))
+* [bitnami/redmine] Remove references to deprecated helpers ([#35411](https://github.com/bitnami/charts/pull/35411))
+
+## <small>33.0.3 (2025-07-15)</small>
+
+* [bitnami/redmine] :zap: :arrow_up: Update dependency references (#35127) ([8206761](https://github.com/bitnami/charts/commit/820676126056a853e4b830649cde5e57ee9b4d1d)), closes [#35127](https://github.com/bitnami/charts/issues/35127)
 
 ## <small>33.0.2 (2025-07-08)</small>
 

--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.13
+  version: 16.7.21
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.0.0
+  version: 21.0.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:620e9c96f7857927db2f5c7dba409cb04046cb5c5de77803ff6d2173b074f36d
-generated: "2025-06-25T17:24:50.344786+02:00"
+digest: sha256:03dbe239e6efb1a1d4c4d21d021643a81fbdedd7f97f0c1275912d0a6017ee01
+generated: "2025-08-05T11:05:52.525867+02:00"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -13,37 +13,35 @@ annotations:
 apiVersion: v2
 appVersion: 6.0.6
 dependencies:
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
-- condition: mariadb.enabled
-  name: mariadb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
-description: Redmine is an open source management application. It includes a tracking
-  issue system, Gantt charts for a visual view of projects and deadlines, and supports
-  SCM integration for version control.
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 21.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/redmine/img/redmine-stack-220x234.png
 keywords:
-- redmine
-- project management
-- www
-- http
-- web
-- application
-- ruby
-- rails
+  - redmine
+  - project management
+  - www
+  - http
+  - web
+  - application
+  - ruby
+  - rails
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: redmine
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 33.0.3
+  - https://github.com/bitnami/charts/tree/main/bitnami/redmine
+version: 33.0.4

--- a/bitnami/redmine/templates/ingress.yaml
+++ b/bitnami/redmine/templates/ingress.yaml
@@ -21,10 +21,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- $ingressClassName := coalesce .Values.ingress.ingressClassName .Values.ingress.className }}
-  {{- if and $ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
-  ingressClassName: {{ $ingressClassName }}
-  {{ end }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}


### PR DESCRIPTION
### Description of the change

This PR removes references to deprecated helpers that were removed at https://github.com/bitnami/charts/pull/33496

- Fixes https://github.com/bitnami/charts/issues/35394

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
