### PR TITLE
[bitnami/kube-prometheus] Bump chart version

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -50,4 +50,4 @@ maintainers:
 name: kube-prometheus
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 11.2.18
+version: 11.3.1


### PR DESCRIPTION
At https://github.com/bitnami/charts/pull/35410, the chart version was wrongly lowered from `11.3.0` to `11.2.18` instead of `11.3.1`, which should be the proper version.