### PR TITLE
[bitnami/apache] Remove hardcoded references to image repository

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.4.5 (2025-08-07)
+## 11.4.6 (2025-08-08)
 
-* [bitnami/apache] :zap: :arrow_up: Update dependency references ([#35544](https://github.com/bitnami/charts/pull/35544))
+* [bitnami/apache] Remove hardcoded references to image repository ([#35691](https://github.com/bitnami/charts/pull/35691))
+
+## <small>11.4.5 (2025-08-07)</small>
+
+* [bitnami/apache] :zap: :arrow_up: Update dependency references (#35544) ([7c8eb6c](https://github.com/bitnami/charts/commit/7c8eb6cff8c8d2bd64c5d7af39abf1ce281a802d)), closes [#35544](https://github.com/bitnami/charts/issues/35544)
 
 ## <small>11.4.4 (2025-08-07)</small>
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.4.5
+version: 11.4.6

--- a/bitnami/apache/templates/NOTES.txt
+++ b/bitnami/apache/templates/NOTES.txt
@@ -41,12 +41,9 @@ APP VERSION: {{ .Chart.AppVersion }}
 {{- if not (include "apache.useHtdocs" .) }}
 WARNING: You did not provide a custom web application. Apache will be deployed with a default page. Check the README section "Deploying your custom web application" in https://github.com/bitnami/charts/blob/main/bitnami/apache/README.md#deploying-a-custom-web-application.
 {{- end }}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html
-{{- end }}
 
-{{ include "apache.validateValues" . }}
+{{- include "apache.validateValues" . }}
+{{- include "apache.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "cloneHtdocsFromGit" "metrics" "") "context" $) }}
 {{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.git .Values.metrics.image) "context" $) }}
 {{- include "common.errors.insecureImages" (dict "images" (list .Values.image .Values.metrics.image) "context" $) }}

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -144,3 +144,12 @@ Get the httpd.conf config map name.
     {{- printf "%s-httpd-conf" (include "common.names.fullname" . ) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "apache.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.metrics.image }}
+{{- include "common.warnings.rollingTag" .Values.git }}
+{{- end -}}


### PR DESCRIPTION
### Description of the change

This PR removes hardcoded references to the image repository in the chart templates.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
