### PR TITLE
[bitnami/fluentd] Remove hardcoded references to image repository

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 7.2.4
+version: 7.2.5

--- a/bitnami/fluentd/templates/_helpers.tpl
+++ b/bitnami/fluentd/templates/_helpers.tpl
@@ -43,10 +43,7 @@ Create the name of the aggregator service account to use
 
 {{/* Check if there are rolling tags in the images */}}
 {{- define "fluentd.checkRollingTags" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html
-{{- end }}
+{{- include "common.warnings.rollingTag" .Values.image }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

This PR removes hardcoded references to the image repository in the chart templates.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
