### PR TITLE
[bitnami/mastodon] Upgrade to Redis subchart 22

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 13.0.13 (2025-08-08)
+## 14.0.0 (2025-08-11)
 
-* [bitnami/mastodon] :zap: :arrow_up: Update dependency references ([#35703](https://github.com/bitnami/charts/pull/35703))
+* [bitnami/mastodon] Upgrade to Redis subchart 22 ([#35721](https://github.com/bitnami/charts/pull/35721))
+
+## <small>13.0.13 (2025-08-08)</small>
+
+* [bitnami/mastodon] :zap: :arrow_up: Update dependency references (#35703) ([81c0893](https://github.com/bitnami/charts/commit/81c089304112a09197f32b434f0de43800515c3e)), closes [#35703](https://github.com/bitnami/charts/issues/35703)
 
 ## <small>13.0.12 (2025-08-07)</small>
 

--- a/bitnami/mastodon/Chart.lock
+++ b/bitnami/mastodon/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.2.14
+  version: 22.0.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.7.24
@@ -17,5 +17,5 @@ dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:21ac866da341bcb1f00f2bc4496cf767806a0b984e2107b58bb8445141aefe66
-generated: "2025-08-08T13:02:03.127893083Z"
+digest: sha256:2960c5ac73302f427eba492346953f909500c71ecc79690619992d836c255f58
+generated: "2025-08-11T09:36:46.505886+02:00"

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -51,4 +51,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 13.0.13
+version: 14.0.0

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -896,6 +896,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 14.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 22.0.0, which updates Redis&reg; from 8.0 to 8.2. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 13.0.0
 
 This major updates the `minio` subchart to its newest major, 17.0.0. For more information on this subchart's major, please refer to [minio upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/minio#to-1700).


### PR DESCRIPTION
### Description of the change

Upgrade to Redis subchart 22 (app version 8.2).

### Benefits

Use the latest version of Redis subchart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)