### PR TITLE
[bitnami/superset] Upgrade to Redis subchart 22

### DIFF
--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.0.2 (2025-08-07)
+## 5.0.0 (2025-08-11)
 
-* [bitnami/superset] :zap: :arrow_up: Update dependency references ([#35684](https://github.com/bitnami/charts/pull/35684))
+* [bitnami/superset] Upgrade to Redis subchart 22 ([#35723](https://github.com/bitnami/charts/pull/35723))
+
+## <small>4.0.2 (2025-08-07)</small>
+
+* [bitnami/superset] :zap: :arrow_up: Update dependency references (#35684) ([20b9701](https://github.com/bitnami/charts/commit/20b970147099aebebd66f8f2ffab2477c47810ee)), closes [#35684](https://github.com/bitnami/charts/issues/35684)
 
 ## <small>4.0.1 (2025-07-30)</small>
 

--- a/bitnami/superset/Chart.lock
+++ b/bitnami/superset/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.2.14
+  version: 22.0.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.21
+  version: 16.7.24
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:7f831f90c4f818f97a24bfb01c85a7b4e97b2983038d417303f9cdfa18d00fb0
-generated: "2025-08-07T22:26:05.021197648Z"
+digest: sha256:b759440618b2d26a8ac1fcc8952ed851540c7109c3c9ca4ccb1c5c460ad8ac6f
+generated: "2025-08-11T09:19:02.108243+02:00"

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/superset
 - https://github.com/bitnami/containers/tree/main/bitnami/superset
 - https://github.com/apache/superset
-version: 4.0.2
+version: 5.0.0

--- a/bitnami/superset/README.md
+++ b/bitnami/superset/README.md
@@ -751,6 +751,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 5.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 22.0.0, which updates Redis&reg; from 8.0 to 8.2. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 3.0.0
 
 This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.


### PR DESCRIPTION
### Description of the change

Upgrade to Redis subchart 22 (app version 8.2).

### Benefits

Use the latest version of Redis subchart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)