### PR TITLE
[bitnami/airflow] Upgrade to Redis subchart 22

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.2.14
+  version: 22.0.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.7.24
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:ce4750c2248a56615b455fe59e2179621379a2affb4fd78bbe3969d5b5e0110a
-generated: "2025-08-09T02:33:14.730651087Z"
+digest: sha256:b759440618b2d26a8ac1fcc8952ed851540c7109c3c9ca4ccb1c5c460ad8ac6f
+generated: "2025-08-11T09:52:31.842376+02:00"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
+  version: 22.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -42,4 +42,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 24.3.4
+version: 25.0.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -1344,6 +1344,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 25.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 22.0.0, which updates Redis&reg; from 8.0 to 8.2. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 24.0.0
 
 This major updates the Redis&reg; subchart to its newest major, 21.0.0, which updates Redis&reg; from 7.4 to 8.0. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -2363,16 +2363,6 @@ worker:
   ## ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/
   ##
   autoscaling:
-    ## @param worker.autoscaling.enabled DEPRECATED: use worker.autoscaling.hpa.enabled instead
-    ## @param worker.autoscaling.minReplicas DEPRECATED: use worker.autoscaling.hpa.minReplicas instead
-    ## @param worker.autoscaling.maxReplicas DEPRECATED: use worker.autoscaling.hpa.maxReplicas instead
-    ## @param worker.autoscaling.targetMemory DEPRECATED: use worker.autoscaling.hpa.targetMemory instead
-    ## @param worker.autoscaling.targetCPU DEPRECATED: use worker.autoscaling.hpa.targetCPU instead
-    enabled: false
-    minReplicas: ""
-    maxReplicas: ""
-    targetCPU: ""
-    targetMemory: ""
     ## @param worker.autoscaling.vpa.enabled Enable VPA for Airflow Worker
     ## @param worker.autoscaling.vpa.annotations Annotations for VPA resource
     ## @param worker.autoscaling.vpa.controlledResources List of resources that the VPA can control. Defaults to cpu and memory


### PR DESCRIPTION
### Description of the change

Upgrade to Redis subchart 22 (app version 8.2).

### Benefits

Use the latest version of Redis subchart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)