### PR TITLE
[bitnami/appsmith] Upgrade to Redis subchart 22

### DIFF
--- a/bitnami/appsmith/CHANGELOG.md
+++ b/bitnami/appsmith/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
-## 6.0.22 (2025-08-05)
+## 7.0.0 (2025-08-11)
 
-* [bitnami/appsmith] Update MongoDB subchart ([#35415](https://github.com/bitnami/charts/pull/35415))
+* [bitnami/appsmith] Upgrade to Redis subchart 22 ([#35729](https://github.com/bitnami/charts/pull/35729))
+
+## <small>6.0.22 (2025-08-05)</small>
+
+* [bitnami/*] docs: update BSI warning on charts' notes (#35340) ([07483a5](https://github.com/bitnami/charts/commit/07483a5ed964b409266dc025e4b55bf2eb0f621c)), closes [#35340](https://github.com/bitnami/charts/issues/35340)
+* [bitnami/appsmith] Fix example errors in README.md (#35337) ([660a40e](https://github.com/bitnami/charts/commit/660a40e668b8bd4f0a420f93ae82f0c62bff91f0)), closes [#35337](https://github.com/bitnami/charts/issues/35337)
+* [bitnami/appsmith] Update MongoDB subchart (#35415) ([b4f1dfe](https://github.com/bitnami/charts/commit/b4f1dfe88d28f989854e22b6c5067c501799df85)), closes [#35415](https://github.com/bitnami/charts/issues/35415)
+* Add CVE-2025-41240 to upgrading notes and changelog ([fcfc031](https://github.com/bitnami/charts/commit/fcfc031f38bb74bdd43e559a271b7debf4f3a8c7))
 
 ## <small>6.0.21 (2025-07-23)</small>
 

--- a/bitnami/appsmith/Chart.lock
+++ b/bitnami/appsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.2.14
+  version: 22.0.1
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.5.36
+  version: 16.5.40
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:fce393dc0f34d1bee021cc695719834c718c78dd009d389c7f8b62e0bfa57e30
-generated: "2025-08-05T13:28:19.148362+02:00"
+digest: sha256:def8d17307278046628e82ed0aeee6317ac49dcc8994fce03cb46865db039363
+generated: "2025-08-11T09:55:04.41406+02:00"

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.x.x
+  version: 22.x.x
 - condition: mongodb.enabled
   name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -41,4 +41,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 6.0.22
+version: 7.0.0

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -764,6 +764,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 7.0.0
+
+This major updates the Redis&reg; subchart to its newest major, 22.0.0, which updates Redis&reg; from 8.0 to 8.2. [Here](https://redis.io/docs/latest/operate/oss_and_stack/install/upgrade/cluster/) you can find more information about the changes introduced in that version. No major issues are expected during the upgrade.
+
 ### To 6.0.19
 
 This version addresses CVE-2025-41240. For more details, please refer to the advisory at [https://github.com/bitnami/charts/security/advisories/GHSA-wgg9-9qgw-529w](https://github.com/bitnami/charts/security/advisories/GHSA-wgg9-9qgw-529w).


### PR DESCRIPTION
### Description of the change

Upgrade to Redis subchart 22 (app version 8.2).

### Benefits

Use the latest version of Redis subchart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)