### PR TITLE
[bitnami/tensorflow-resnet] bugfix: update model download url

### DIFF
--- a/bitnami/tensorflow-resnet/CHANGELOG.md
+++ b/bitnami/tensorflow-resnet/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.11 (2025-07-12)
+## 4.3.12 (2025-08-11)
 
-* [bitnami/tensorflow-resnet] :zap: :arrow_up: Update dependency references ([#35028](https://github.com/bitnami/charts/pull/35028))
+* [bitnami/tensorflow-resnet] bugfix: update model download url ([#35733](https://github.com/bitnami/charts/pull/35733))
+
+## <small>4.3.11 (2025-07-12)</small>
+
+* [bitnami/tensorflow-resnet] :zap: :arrow_up: Update dependency references (#35028) ([d63dca4](https://github.com/bitnami/charts/commit/d63dca42f20a209abb1f8dfcad81381aba296752)), closes [#35028](https://github.com/bitnami/charts/issues/35028)
 
 ## <small>4.3.10 (2025-06-12)</small>
 

--- a/bitnami/tensorflow-resnet/Chart.lock
+++ b/bitnami/tensorflow-resnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.0
-digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
-generated: "2025-05-06T11:08:38.988123814+02:00"
+  version: 2.31.3
+digest: sha256:f9c314553215490ea1b94c70082cb152d6ff5916ce185b4e00f5287f81545b4c
+generated: "2025-08-11T12:50:40.985602+02:00"

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: tensorflow-resnet
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
-version: 4.3.11
+version: 4.3.12

--- a/bitnami/tensorflow-resnet/templates/deployment.yaml
+++ b/bitnami/tensorflow-resnet/templates/deployment.yaml
@@ -71,16 +71,20 @@ spec:
           image: {{ include "tensorflow-resnet.client.image" . }}
           imagePullPolicy: {{ .Values.client.image.pullPolicy | quote }}
           command:
-            - "/bin/sh"
-            - "-c"
+            - /bin/sh
+            - -ec
             - |
               if [ -f /seed/.initialized ]; then
-                echo "Already initialized. Skipping"
+                  echo "Already initialized. Skipping"
               else
-                curl -o /seed/resnet_50_classification_1.tar.gz https://storage.googleapis.com/tfhub-modules/tensorflow/resnet_50/classification/1.tar.gz
-                cd /seed/ && mkdir 1 && tar -xzf resnet_50_classification_1.tar.gz -C 1
-                rm resnet_50_classification_1.tar.gz
-                touch /seed/.initialized
+                  curl -Lo /seed/model.tar.gz https://www.kaggle.com/api/v1/models/tensorflow/resnet-50/tensorFlow2/classification/1/download
+                  cd /seed/ && mkdir 1 && tar -xzf model.tar.gz -C 1
+                  if [ $? -ne 0 ]; then
+                      echo "Failed to download model"
+                      exit 1
+                  fi
+                  rm model.tar.gz
+                  touch /seed/.initialized
               fi
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

This PR updates the download URL used to download the `resnet-50` model. More info at https://www.kaggle.com/models/tensorflow/resnet-50/tensorFlow2/classification/1?tfhub-redirect=true

### Benefits

The `resnet-50` model can be properly downloaded.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
