### PR TITLE
[bitnami/keycloak] bugfix: validation when production is enabled

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 25.0.1 (2025-08-11)
+## 25.0.2 (2025-08-12)
 
-* [bitnami/keycloak] bugfix: wrong number of arguments passed to tpl ([#35726](https://github.com/bitnami/charts/pull/35726))
+* [bitnami/keycloak] bugfix: validation when production is enabled ([#35757](https://github.com/bitnami/charts/pull/35757))
+
+## <small>25.0.1 (2025-08-11)</small>
+
+* [bitnami/keycloak] bugfix: wrong number of arguments passed to tpl (#35726) ([25b6602](https://github.com/bitnami/charts/commit/25b6602175afaed1c1becce833463d4005e24598)), closes [#35726](https://github.com/bitnami/charts/issues/35726)
 
 ## 25.0.0 (2025-08-08)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.0.1
+version: 25.0.2

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -260,7 +260,7 @@ keycloak: tls.enabled
 
 {{/* Validate values of Keycloak - Production mode enabled */}}
 {{- define "keycloak.validateValues.production" -}}
-{{- if and .Values.production (not (or (not .Values.tls.enabled) (empty .Values.proxyHeaders))) -}}
+{{- if and .Values.production (not .Values.tls.enabled) (empty .Values.proxyHeaders) -}}
 keycloak: production
     In order to enable Production mode, you also need to enable
     HTTPS/TLS (--set tls.enabled=true) or use proxy headers (--set proxyHeaders=FOO).


### PR DESCRIPTION
### Description of the change

This PR fixes the validation we use to ensure that, when production is enabled, TLS or proxy headers are also set.

### Benefits

Validation works as expected.

### Possible drawbacks

None

### Applicable issues

- fixes #35749

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
