### PR TITLE
[bitnami/cassandra] Authentication failures when connecting to Cassandra from non-seed (secondary) nodes in multi-replica deployments.  

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 12.3.10 (2025-08-11)
+## 12.3.11 (2025-08-12)
 
-* [bitnami/cassandra] :zap: :arrow_up: Update dependency references ([#35419](https://github.com/bitnami/charts/pull/35419))
+* [bitnami/cassandra] Authentication failures when connecting to Cassandra from non-seed (secondary) nodes in multi-replica deployments.   ([#35768](https://github.com/bitnami/charts/pull/35768))
+
+## <small>12.3.10 (2025-08-11)</small>
+
+* [bitnami/*] Adapt main README and change ascii (#35173) ([73d15e0](https://github.com/bitnami/charts/commit/73d15e03e04647efa902a1d14a09ea8657429cd0)), closes [#35173](https://github.com/bitnami/charts/issues/35173)
+* [bitnami/*] Adapt welcome message to BSI (#35170) ([e1c8146](https://github.com/bitnami/charts/commit/e1c8146831516fb35de736a6f3fd10e5e7a44286)), closes [#35170](https://github.com/bitnami/charts/issues/35170)
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/*] docs: update BSI warning on charts' notes (#35340) ([07483a5](https://github.com/bitnami/charts/commit/07483a5ed964b409266dc025e4b55bf2eb0f621c)), closes [#35340](https://github.com/bitnami/charts/issues/35340)
+* [bitnami/cassandra] :zap: :arrow_up: Update dependency references (#35419) ([2fdbfa9](https://github.com/bitnami/charts/commit/2fdbfa905386c977f5c2e46a9a9998fc31666815)), closes [#35419](https://github.com/bitnami/charts/issues/35419)
 
 ## <small>12.3.9 (2025-07-15)</small>
 

--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 12.3.11 (2025-08-12)
+## 12.3.11 (2025-08-13)
 
 * [bitnami/cassandra] Authentication failures when connecting to Cassandra from non-seed (secondary) nodes in multi-replica deployments.   ([#35768](https://github.com/bitnami/charts/pull/35768))
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.3.10
+version: 12.3.11

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -305,7 +305,7 @@ Dynamic Seed Discovery Init-Container
       - |
         export DYNAMIC_SEED_DIR=/opt/bitnami/cassandra/tmp &&
         install_packages netcat-traditional dnsutils &&
-        dig +short {{ .Release.Name }}-headless.{{ .Release.Namespace}}.svc.{{ .Values.clusterDomain }} | grep -v $POD_IP | \
+        dig +short {{ printf "%s-headless.%s.svc.%s" (include "common.names.fullname" .) .Release.Namespace .Values.clusterDomain | trunc 63 | trimSuffix "-" }} | grep -v $POD_IP | \
           while read NODE_IP; do \
             nc -zvw3 $NODE_IP {{ .Values.service.ports.cql }} && \
             echo "$NODE_IP" >> ${DYNAMIC_SEED_DIR}/seed-ips.lst; \


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The Cassandra init script currently uses the .Release.Name value when constructing the headless service DNS name. This causes service name mismatches when a fullnameOverride or a nameOverride is set (such as when deploying Cassandra as a subchart).

The change updates the script to use the correct full release name from include "common.names.fullname" . along with .Release.Namespace and .Values.clusterDomain, ensuring that the generated headless service name matches the actual Kubernetes service name.


### Benefits

1. Prevents random authentication failures when connecting to Cassandra from non-seed (secondary) nodes in multi-replica deployments.
2. Improves reliability and stability of Cassandra connections in Kubernetes clusters.
3. Makes the Helm chart more robust when used as a subchart in larger deployments.

### Possible drawbacks

Not to my knowledge

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #35767

### Additional information

Testing was performed on AKS clusters with 3-node Cassandra deployments, validating consistent connection success across all nodes post-fix.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
