### PR TITLE
[bitnami/schema-registry] Fix Schema Registry with SCRAM-SHA-512 and external MSK fails due to mandatory jksSecret

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 26.0.4 (2025-08-07)
+## 26.0.5 (2025-08-13)
 
-* [bitnami/schema-registry] :zap: :arrow_up: Update dependency references ([#35675](https://github.com/bitnami/charts/pull/35675))
+* [bitnami/schema-registry] Fix Schema Registry with SCRAM-SHA-512 and external MSK fails due to mandatory jksSecret ([#35772](https://github.com/bitnami/charts/pull/35772))
+
+## <small>26.0.4 (2025-08-07)</small>
+
+* [bitnami/schema-registry] :zap: :arrow_up: Update dependency references (#35675) ([fd44940](https://github.com/bitnami/charts/commit/fd44940e5ae1d5f6fe355662959b32b78bd80de5)), closes [#35675](https://github.com/bitnami/charts/issues/35675)
 
 ## <small>26.0.3 (2025-08-01)</small>
 

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 26.0.4
+version: 26.0.5

--- a/bitnami/schema-registry/templates/_helpers.tpl
+++ b/bitnami/schema-registry/templates/_helpers.tpl
@@ -123,7 +123,6 @@ Compile all warnings into a single message, and call fail.
 {{- define "schema-registry.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "schema-registry.validateValues.authentication.sasl" .) -}}
-{{- $messages := append $messages (include "schema-registry.validateValues.authentication.tls" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -150,15 +149,6 @@ schema-registry: externalKafka.sasl.user externalKafka.sasl.password
       - externalKafka.sasl.user
       - externalKafka.sasl.password
       - externalKafka.sasl.existingSecret (takes precedence over password)
-{{- end -}}
-{{- end -}}
-
-{{/* Validate values of Schema Registry - TLS authentication */}}
-{{- define "schema-registry.validateValues.authentication.tls" -}}
-{{- $kafkaProtocol := upper (ternary .Values.kafka.listeners.client.protocol .Values.externalKafka.listener.protocol .Values.kafka.enabled) -}}
-{{- if and (contains "SSL" $kafkaProtocol) (not .Values.auth.kafka.jksSecret) }}
-kafka: auth.kafka.jksSecret
-    A secret containing the Schema Registry JKS files is required when TLS encryption in enabled
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              {{- if contains "SSL" $kafkaProtocol }}
+              {{- if and (contains "SSL" $kafkaProtocol) .Values.auth.kafka.jksSecret }}
               ID="${MY_POD_NAME#"{{ $fullname }}-"}"
               if [[ -f "/certs/schema-registry.truststore.jks" ]] && [[ -f "/certs/schema-registry-${ID}.keystore.jks" ]]; then
                   mkdir -p /opt/bitnami/schema-registry/certs
@@ -274,7 +274,7 @@ spec:
               mountPath: /bitnami/schema-registry/etc/schema-registry/log4j.properties
               subPath: log4j.properties
             {{- end }}
-            {{- if contains "SSL" $kafkaProtocol }}
+            {{- if and (contains "SSL" $kafkaProtocol) .Values.auth.kafka.jksSecret }}
             - name: certificates
               mountPath: /certs
               readOnly: true
@@ -305,12 +305,12 @@ spec:
           configMap:
             name: {{ include "schema-registry.log4j.configmapName" . }}
         {{ end }}
-        {{- if or (contains "SSL" $kafkaProtocol) .Values.auth.tls.enabled }}
+        {{- if and (or (contains "SSL" $kafkaProtocol) .Values.auth.tls.enabled) .Values.auth.kafka.jksSecret }}
         - name: certificates
           projected:
             defaultMode: 0400
             sources:
-            {{- if contains "SSL" $kafkaProtocol }}
+            {{- if and (contains "SSL" $kafkaProtocol) .Values.auth.kafka.jksSecret }}
             - secret:
                 name: {{ printf "%s" (tpl .Values.auth.kafka.jksSecret $) }}
             {{- end }}

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -305,7 +305,7 @@ spec:
           configMap:
             name: {{ include "schema-registry.log4j.configmapName" . }}
         {{ end }}
-        {{- if and (or (contains "SSL" $kafkaProtocol) .Values.auth.tls.enabled) .Values.auth.kafka.jksSecret }}
+        {{- if or (and (contains "SSL" $kafkaProtocol) .Values.auth.kafka.jksSecret) .Values.auth.tls.enabled }}
         - name: certificates
           projected:
             defaultMode: 0400


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR resolves an issue where the chart's templating logic incorrectly requires a JKS secret when using SASL_SSL with SCRAM authentication.

In environments like AWS MSK, SCRAM authentication uses TLS for encryption but does not require mutual TLS (mTLS) for client authentication. The original chart logic, however, assumes that any protocol containing "SSL" necessitates JKS files, causing the deployment to fail.

This change modifies the templating to only require a JKS secret when mutual TLS is explicitly enabled, allowing users to configure SASL_SSL for SCRAM-based environments without providing an unnecessary secret.

### Benefits

<!-- What benefits will be realized by the code change? -->

jks value changed optional condition

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #35731

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
