### PR TITLE
[bitnami/vault] Add ability to disable the cluster role binding for server rbac

### DIFF
--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 1.8.1
+version: 1.9.0

--- a/bitnami/vault/README.md
+++ b/bitnami/vault/README.md
@@ -372,6 +372,7 @@ The [Bitnami vault](https://github.com/bitnami/containers/tree/main/bitnami/vaul
 | Name                                                 | Description                                                      | Value   |
 | ---------------------------------------------------- | ---------------------------------------------------------------- | ------- |
 | `server.rbac.create`                                 | Specifies whether RBAC resources should be created               | `true`  |
+| `server.rbac.createClusterRoleBinding`               | Specifies whether a ClusterRoleBinding should be created         | `true`  |
 | `server.rbac.leaderElection.rules`                   | Specifies the leader election role rules                         | `[]`    |
 | `server.rbac.discovery.rules`                        | Specifies the discovery role rules                               | `[]`    |
 | `server.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true`  |

--- a/bitnami/vault/templates/server/clusterrolebinding.yaml
+++ b/bitnami/vault/templates/server/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.server.enabled .Values.server.rbac.create }}
+{{- if and .Values.server.enabled .Values.server.rbac.create .Values.server.rbac.createClusterRoleBinding }}
 kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/vault/values.yaml
+++ b/bitnami/vault/values.yaml
@@ -683,6 +683,10 @@ server:
     ##
     create: true
 
+    ## @param server.rbac.createClusterRoleBinding Specifies whether a ClusterRoleBinding should be created
+    ##
+    createClusterRoleBinding: true
+
     leaderElection:
       ## @param server.rbac.leaderElection.rules [array] Specifies the leader election role rules
       ## Example:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allows Users to disable the cluster role binding created by the server rbac.

### Benefits

It is not allowed in our internal clusters to create cluster role bindings. With this option the server rbac can still be used in our situation.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
