### PR TITLE
[bitnami/kubernetes-event-exporter] fix: kubernetes-event-exporter default config layout shows empty logs

### DIFF
--- a/.vib/kubernetes-event-exporter/runtime-parameters.yaml
+++ b/.vib/kubernetes-event-exporter/runtime-parameters.yaml
@@ -7,7 +7,7 @@ config:
     - name: dump
       file:
         path: /dev/stdout
-        layout: {}
+        layout: null
   route:
     routes:
       - match:

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.6.2
+version: 3.6.3

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -142,7 +142,7 @@ config:
         ##   component: "{{ .Source.Component }}"
         ##   host: "{{ .Source.Host }}"
         ##
-        layout: {}
+        layout: null
   route:
     routes:
       - match:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Set the default log `layout` to `null` instead of `{}` in the event-exporter `config.receivers.file` default values. 
For more history, a previous PR has been opened [here](https://github.com/bitnami/charts/pull/35193), that I messed up after forgetting signing-off my commits...

### Benefits

<!-- What benefits will be realized by the code change? -->
When using this Helm chart without overwriting `config.receivers.file`, the default log `layout` being empty (`{}`):
``` yaml
receivers:
- file:
    layout: {}
    path: /dev/stdout
  name: dump
```

The config above will cause the logs to be empty. 

The workaround to avoid this issue is to specify a `config.receivers.file` while using the helm chart. For example:
`{"receivers": [{"name": "dump", "file": {"path": "/dev/stdout"}}}`, which will generate the following `config.receiver`:
``` yaml
receivers:
- file:
    path: /dev/stdout
  name: dump
```

This change avoid using the workaround above and let the user not overwriting the `config` to use the default one.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #34880

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
See #34880 for more information about the issue that this PR fixes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)