### PR TITLE
[bitnami/keycloak] docs: remove reference to deprecated parameter on README

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -247,7 +247,7 @@ It is also possible to rely on the chart certificate auto-generation capabilitie
 
 #### Use with ingress offloading SSL
 
-If your ingress controller has the SSL Termination, you should set `proxy` to `edge`.
+If your ingress controller has the TLS/SSL Termination, you might need to properly configure the reverse proxy headers via the `proxyHeaders` parameter. Find more information in the [upstream documentation](https://www.keycloak.org/server/reverseproxy).
 
 ### Update credentials
 


### PR DESCRIPTION
### Description of the change

This PR removes a reference to the `proxy` parameter that was removed in the last major version after a long time being considered deprecated.

### Benefits

Up-to-date docs

### Possible drawbacks

None

### Applicable issues

None

### Additional information

No bump on chart version given they're just README changes.

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
