### PR TITLE
[bitnami/clickhouse] fix: avoid duplicate targets

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 9.4.4 (2025-08-19)
 
-* Clickhouse fix scrape ([#36143](https://github.com/bitnami/charts/pull/36143))
+* [bitnami/clickhouse] fix: avoid duplicate targets ([#36143](https://github.com/bitnami/charts/pull/36143))
 
 ## <small>9.4.3 (2025-08-14)</small>
 

--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.4.3 (2025-08-14)
+## 9.4.4 (2025-08-19)
 
-* [bitnami/clickhouse] :zap: :arrow_up: Update dependency references ([#35883](https://github.com/bitnami/charts/pull/35883))
+* Clickhouse fix scrape ([#36143](https://github.com/bitnami/charts/pull/36143))
+
+## <small>9.4.3 (2025-08-14)</small>
+
+* [bitnami/clickhouse] :zap: :arrow_up: Update dependency references (#35883) ([d7ba4ec](https://github.com/bitnami/charts/commit/d7ba4ec682c5280e405233595a5f6580a5d63c95)), closes [#35883](https://github.com/bitnami/charts/issues/35883)
 
 ## <small>9.4.2 (2025-08-12)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 9.4.3
+version: 9.4.4

--- a/bitnami/clickhouse/templates/service.yaml
+++ b/bitnami/clickhouse/templates/service.yaml
@@ -17,7 +17,7 @@ metadata:
   labels: {{- include "common.labels.standard" (dict "customLabels" .context.Values.commonLabels "context" .context) | nindent 4 }}
     app.kubernetes.io/component: clickhouse
     app.kubernetes.io/part-of: clickhouse
-    {{- if and .context.Values.metrics.enabled .context.Values.metrics.serviceMonitor.enabled }}
+    {{- if and .context.Values.metrics.enabled (not .context.Values.metrics.serviceMonitor.enabled) }}
     {{- /* Adding extra selector for the ServiceMonitor object to avoid duplicate targets  */}}
     prometheus.io/scrape: "true"
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Scrape annotation should only be added when ServiceMonitor is disabled.

### Benefits

Avoid duplication for prometheus scrape targets.

### Possible drawbacks

no.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
