### PR TITLE
[bitnami/charts/issues/35435] Fix Redis configuration when using sentinel and 1 replica

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.0.5 (2025-08-23)
+## 22.0.6 (2025-08-26)
 
-* [bitnami/redis] :zap: :arrow_up: Update dependency references ([#36173](https://github.com/bitnami/charts/pull/36173))
+* [bitnami/charts/issues/35435] Fix Redis configuration when using sentinel and 1 replica ([#36170](https://github.com/bitnami/charts/pull/36170))
+
+## <small>22.0.5 (2025-08-23)</small>
+
+* [bitnami/redis] :zap: :arrow_up: Update dependency references (#36173) ([338d02f](https://github.com/bitnami/charts/commit/338d02f5109959766bf496c2d84541a54eab32a9)), closes [#36173](https://github.com/bitnami/charts/issues/36173)
 
 ## <small>22.0.4 (2025-08-18)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 22.0.5
+version: 22.0.6

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -155,7 +155,11 @@ data:
     [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
 
     # check if there is a master
+    {{- if and .Values.sentinel.externalAccess.enabled .Values.sentinel.externalAccess.service.loadBalancerIP }}
     master_in_persisted_conf="$(get_service_ip "$SVC_NAME")"
+    {{- else }}
+    master_in_persisted_conf="$(get_full_hostname "$HOSTNAME")"
+    {{- end }}
     master_port_in_persisted_conf="$REDIS_MASTER_PORT_NUMBER"
     master_in_sentinel="$(get_sentinel_master_info)"
     redisRetVal=$?


### PR DESCRIPTION
### Description of the change

Fix Redis configuration when enabling sentinel and one replica. Issue is described here https://github.com/bitnami/charts/issues/35435.

### Benefits

Chart is now initialized properly 

```
➜  redis git:(bitnami/charts/issues/35435) git diff values.yaml
diff --git a/bitnami/redis/values.yaml b/bitnami/redis/values.yaml
index 017ee3652a..0f6e08ad55 100644
--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -682,7 +682,7 @@ replica:
   kind: StatefulSet
   ## @param replica.replicaCount Number of Redis(R) replicas to deploy
   ##
-  replicaCount: 3
+  replicaCount: 1
   ## @param replica.revisionHistoryLimit The number of old history to retain to allow rollback
   ## NOTE: Explicitly setting this field to 0, will result in cleaning up all the history, breaking ability to rollback
   revisionHistoryLimit: 10
@@ -1172,7 +1172,7 @@ sentinel:
   ## IMPORTANT: this will disable the master and replicas services and
   ## create a single Redis(R) service exposing both the Redis and Sentinel ports
   ##
-  enabled: false
+  enabled: true
   ## Bitnami Redis(R) Sentinel image version
   ## ref: https://hub.docker.com/r/bitnami/redis-sentinel/tags/
   ## @param sentinel.image.registry [default: REGISTRY_NAME] Redis(R) Sentinel image registry

➜  redis git:(bitnami/charts/issues/35435) k logs pod/redis-node-0                                                                                   
Defaulted container "redis" out of: redis, sentinel
 10:48:59.54 INFO  ==> about to run the command: REDISCLI_AUTH=$REDIS_PASSWORD  timeout 90 redis-cli -h redis.test.svc.cluster.local -p 26379 sentinel get-master-addr-by-name mymaster
Could not connect to Redis at redis.test.svc.cluster.local:26379: Connection refused
Could not connect to Redis at redis.test.svc.cluster.local:26379: Connection refused
 10:49:09.73 INFO  ==> Configuring the node as master
1:C 22 Aug 2025 10:49:09.822 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 22 Aug 2025 10:49:09.822 * Redis version=8.2.1, bits=64, commit=00000000, modified=1, pid=1, just started
1:C 22 Aug 2025 10:49:09.822 * Configuration loaded
1:M 22 Aug 2025 10:49:09.822 * monotonic clock: POSIX clock_gettime
1:M 22 Aug 2025 10:49:09.823 * Running mode=standalone, port=6379.
1:M 22 Aug 2025 10:49:09.824 * Server initialized
1:M 22 Aug 2025 10:49:09.828 * Creating AOF base file appendonly.aof.1.base.rdb on server start
1:M 22 Aug 2025 10:49:09.832 * Creating AOF incr file appendonly.aof.1.incr.aof on server start
1:M 22 Aug 2025 10:49:09.832 * Ready to accept connections tcp
```

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/35435

### Additional information

The origin of the issue are these PRs

https://github.com/bitnami/charts/pull/34806
https://github.com/bitnami/charts/pull/35364

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
