### PR TITLE
[bitnami/keycloak] fix: consider httpRelativePath for metrics

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.2.0
+version: 25.2.1

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
   jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel | quote }}
   endpoints:
     - port: tcp-metrics
-      path: "/metrics"
+      path: "{{ trimSuffix "/" .Values.httpRelativePath }}/metrics"
       {{- if .Values.tls.enabled }}
       scheme: https
       {{- if .Values.metrics.serviceMonitor.tlsConfig }}


### PR DESCRIPTION
### Description of the change

When a relative path is set, this path is used as a prefix to the metrics path: https://www.keycloak.org/server/management-interface#_relative_path

This issue was introduced with the recent metrics refactoring.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
