### PR TITLE
[bitnami/redis-cluster] Fix service binding password mismatch (#15626)

### DIFF
--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 13.0.6 (2025-09-03)
+## 13.0.6 (2025-09-04)
 
-* [bitnami/redis-cluster] :zap: :arrow_up: Fix service binding password mismatch ([#36230](https://github.com/bitnami/charts/pull/36230)), closes [#15626](https://github.com/bitnami/charts/issues/15626)
+* [bitnami/redis-cluster] Fix service binding password mismatch (#15626) ([#36230](https://github.com/bitnami/charts/pull/36230))
 
-## 13.0.4 (2025-08-23)
+## <small>13.0.4 (2025-08-23)</small>
 
-* [bitnami/redis-cluster] :zap: :arrow_up: Update dependency references ([#36172](https://github.com/bitnami/charts/pull/36172))
+* [bitnami/redis-cluster] :zap: :arrow_up: Update dependency references (#36172) ([2060aa9](https://github.com/bitnami/charts/commit/2060aa94b82bd7e0b030a310acf5c45f3b3dceda)), closes [#36172](https://github.com/bitnami/charts/issues/36172)
 
 ## <small>13.0.3 (2025-08-18)</small>
 

--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13.0.6 (2025-09-03)
+
+* [bitnami/redis-cluster] :zap: :arrow_up: Fix service binding password mismatch ([#36230](https://github.com/bitnami/charts/pull/36230)), closes [#15626](https://github.com/bitnami/charts/issues/15626)
+
 ## 13.0.4 (2025-08-23)
 
 * [bitnami/redis-cluster] :zap: :arrow_up: Update dependency references ([#36172](https://github.com/bitnami/charts/pull/36172))

--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 13.0.6 (2025-09-04)
+## 13.0.6 (2025-09-08)
 
 * [bitnami/redis-cluster] Fix service binding password mismatch (#15626) ([#36230](https://github.com/bitnami/charts/pull/36230))
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 13.0.5
+version: 13.0.6

--- a/bitnami/redis-cluster/templates/_helpers.tpl
+++ b/bitnami/redis-cluster/templates/_helpers.tpl
@@ -145,7 +145,9 @@ Return Redis&reg; password
 {{- else if not (empty .Values.password) -}}
     {{- .Values.password -}}
 {{- else -}}
-    {{- randAlphaNum 10 -}}
+    {{- $password_tmp := default .Values.password (randAlphaNum 10) -}}
+    {{- $_ := set .Values "password" $password_tmp -}}
+    {{- .Values.password -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/redis-cluster/templates/_helpers.tpl
+++ b/bitnami/redis-cluster/templates/_helpers.tpl
@@ -145,7 +145,7 @@ Return Redis&reg; password
 {{- else if not (empty .Values.password) -}}
     {{- .Values.password -}}
 {{- else -}}
-    {{- $password_tmp := default .Values.password (randAlphaNum 10) -}}
+    {{- $password_tmp := randAlphaNum 10 -}}
     {{- $_ := set .Values "password" $password_tmp -}}
     {{- .Values.password -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Ensure password is generated only once and reused across templates.

Currently, the Helm chart calls:

```
{{ include "redis-cluster.password" (...) }}
```

in multiple places.

Since include re-runs the template each time, two different random passwords are generated when rendering separate files. This breaks components that expect to share the same credentials.

So the proposed solution is to update the `redis-cluster.password` helper so that it generates the password once and stores it in `.Values.password` (only if `.Values.password` is empty). Subsequent calls reuse this stored value, ensuring consistency across all templates.

### Benefits

Be able to use service binding.

### Applicable issues

- fixes #15626

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

### Test

```
git clone https://github.com/bitnami/charts

helm dependency build charts/bitnami/redis

helm template redis-cluster charts/bitnami/redis-cluster/ --output-dir build-redis-cluster --set serviceBindings.enabled=true
```
