### PR TITLE
[bitnami/redis] Fix service binding password mismatch (#15626)

### DIFF
--- a/bitnami/redis/templates/_helpers.tpl
+++ b/bitnami/redis/templates/_helpers.tpl
@@ -205,7 +205,9 @@ Return Redis&reg; password
 */}}
 {{- define "redis.password" -}}
 {{- if or .Values.auth.enabled .Values.global.redis.password -}}
-    {{- include "common.secrets.passwords.manage" (dict "secret" (include "redis.secretName" .) "key" (include "redis.secretPasswordKey" .) "providedValues" (list "global.redis.password" "auth.password") "length" 10 "skipB64enc" true "skipQuote" true "honorProvidedValues" true "context" $) -}}
+    {{- $password_tmp := include "common.secrets.passwords.manage" (dict "secret" (include "redis.secretName" .) "key" (include "redis.secretPasswordKey" .) "providedValues" (list "global.redis.password" "auth.password") "length" 10 "skipB64enc" true "skipQuote" true "honorProvidedValues" true "context" $) -}}
+    {{- $_ := set .Values.global.redis "password" $password_tmp -}}
+    {{- .Values.global.redis.password -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### Description of the change

Ensure password is generated only once and reused across templates.

Currently, the Helm chart calls:

```
{{ include "redis.password" (...) }}
```

in multiple places.

Since include re-runs the template each time, two different random passwords are generated when rendering separate files. This breaks components that expect to share the same credentials.

So the proposed solution is to update the `redis.password` helper so that it generates the password once and stores it in `.Values.global.redis.password` (only if `.Values.global.redis.password` is empty). Subsequent calls reuse this stored value, ensuring consistency across all templates.

### Benefits

Be able to use service binding.

### Applicable issues

- fixes #15626

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
