### PR TITLE
[bitnami/keycloak]: fix sidecars in keycloak-config-cli-job

### DIFF
--- a/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
@@ -127,7 +127,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.keycloakConfigCli.resourcesPreset) | nindent 12 }}
           {{- end }}
         {{- if .Values.keycloakConfigCli.sidecars }}
-        {{- include "common.tplvalues.render" ("value" .Values.keycloakConfigCli.sidecars "context" .) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.keycloakConfigCli.sidecars "context" .) | nindent 8 }}
         {{- end }}
       volumes:
         - name: empty-dir


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This fixes a typo with a refactor done about a month ago. The typo prevents using sidecar definitions in keycloakConfigCli.
```
  keycloak:
    keycloakConfigCli:
      sidecars:
        ...
```
```
$ helm template .
...
Error: template: helm-install/charts/keycloak/templates/keycloak-config-cli-job.yaml:130:47:
executing "helm-install/charts/keycloak/templates/keycloak-config-cli-job.yaml" at <"value">:
can't give argument to non-function "value"
```

### Benefits

After the fix the helm template will generate successfully.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
