### PR TITLE
[bitnami/common] Replace "+" to "_" in value of app.kubernetes.io/version…

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.31.6 (2025-09-19)
+## 2.31.6 (2025-09-22)
 
 * [bitnami/common] Replace "+" to "_" in value of app.kubernetes.io/version… ([#36272](https://github.com/bitnami/charts/pull/36272))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 2.31.4 (2025-08-12)
+## 2.31.6 (2025-09-19)
 
-* [bitnami/common] feat: adapt common.errors.insecureImages for BSI ([#35751](https://github.com/bitnami/charts/pull/35751))
+* [bitnami/common] Replace "+" to "_" in value of app.kubernetes.io/version… ([#36272](https://github.com/bitnami/charts/pull/36272))
+
+## <small>2.31.4 (2025-08-12)</small>
+
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/common] docs: remove references to deprecated helpers on README (#35412) ([6239867](https://github.com/bitnami/charts/commit/623986710e3b80f11076d3ded1dc1681d8df62c5)), closes [#35412](https://github.com/bitnami/charts/issues/35412)
+* [bitnami/common] feat: adapt common.errors.insecureImages for BSI (#35751) ([c6bc598](https://github.com/bitnami/charts/commit/c6bc59845497f84f740e47075f8af840f150536e)), closes [#35751](https://github.com/bitnami/charts/issues/35751)
 
 ## <small>2.31.3 (2025-06-12)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.31.4
+appVersion: 2.31.6
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -22,4 +22,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.31.5
+version: 2.31.6

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -22,7 +22,7 @@ helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}
-app.kubernetes.io/version: {{ . | quote }}
+app.kubernetes.io/version: {{ . | replace "+" "_" | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -22,7 +22,7 @@ helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}
-app.kubernetes.io/version: {{ . | replace "+" "_" | quote }}
+app.kubernetes.io/version: {{ . | replace "+" "-" | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

This PR replace "+" symbol to "_" in label `app.kubernetes.io/version`.

### Benefits

Valid SemVer version set appVersion in Chart.yaml used in Kubernetes labels

### Possible drawbacks

N/A

### Applicable issues

- fixes #34112 

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
