### PR TITLE
[bitnami/keycloak] Fix indentation in ingress TLS secret template

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 25.2.3 (2025-09-11)
+## 25.2.4 (2025-09-23)
 
-* [bitnami/keycloak]: fix sidecars in keycloak-config-cli-job ([#36247](https://github.com/bitnami/charts/pull/36247))
+* [bitnami/keycloak] Fix indentation in ingress TLS secret template ([#36282](https://github.com/bitnami/charts/pull/36282))
+
+## <small>25.2.3 (2025-09-11)</small>
+
+* [bitnami/keycloak]: fix sidecars in keycloak-config-cli-job (#36247) ([478a81c](https://github.com/bitnami/charts/commit/478a81c9e91d2c2cf867e70aeea81e10cbcab9ce)), closes [#36247](https://github.com/bitnami/charts/issues/36247)
 
 ## <small>25.2.2 (2025-09-11)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.2.3
+version: 25.2.4

--- a/bitnami/keycloak/templates/ingress-tls-secret.yaml
+++ b/bitnami/keycloak/templates/ingress-tls-secret.yaml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
- name: {{ .name }}
+  name: {{ .name }}
   namespace: {{ include "common.names.namespace" $ | quote }}
   labels: {{- include "common.labels.standard" (dict "customLabels" $.Values.commonLabels "context" $) | nindent 4 }}
     app.kubernetes.io/component: keycloak


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Correct the indentation of the `metadata.name` field from 1 space to 2 spaces.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #36244

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

---

Literally just #36281 but from my personal github to allow edits by maintainers.