### PR TITLE
[bitnami/redis] Fix typo in README.md

### DIFF
--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -114,6 +114,7 @@ commonConfiguration: |
   loadmodule /opt/bitnami/redis/lib/redis/modules/redisearch.so
   loadmodule /opt/bitnami/redis/lib/redis/modules/rejson.so
   loadmodule /opt/bitnami/redis/lib/redis/modules/redistimeseries.so
+```
 
 ### Bootstrapping with an External Cluster
 


### PR DESCRIPTION
The document was missing triple backticks at the end of a Markdown block, causing things to be rendered uglily.