### PR TITLE
[bitnami/mlflow] Add support for generic ephemeral volume

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.2.0 (2025-09-24)
+## 5.2.0 (2025-09-25)
 
 * [bitnami/mlflow] Add support for generic ephemeral volume ([#36291](https://github.com/bitnami/charts/pull/36291))
 

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.1.17 (2025-08-27)
+## 5.2.0 (2025-09-24)
 
-* [bitnami/mlflow] :zap: :arrow_up: Update dependency references ([#36208](https://github.com/bitnami/charts/pull/36208))
+* [bitnami/mlflow] Add support for generic ephemeral volume ([#36291](https://github.com/bitnami/charts/pull/36291))
+
+## <small>5.1.17 (2025-08-27)</small>
+
+* [bitnami/mlflow] :zap: :arrow_up: Update dependency references (#36208) ([f8162a6](https://github.com/bitnami/charts/commit/f8162a6f72e04a852ac8cdf87fb3534e5868f13c)), closes [#36208](https://github.com/bitnami/charts/issues/36208)
 
 ## <small>5.1.16 (2025-08-22)</small>
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -46,4 +46,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 5.1.18
+version: 5.2.0

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -284,26 +284,21 @@ To back up and restore Helm chart deployments on Kubernetes, you need to back up
 
 ### MLflow Tracking Persistence Parameters
 
-| Name                                 | Description                                                                                             | Value               |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------- |
-| `tracking.persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `true`              |
-| `tracking.persistence.mountPath`     | Path to mount the volume at.                                                                            | `/bitnami/mlflow`   |
-| `tracking.persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
-| `tracking.persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |
-| `tracking.persistence.labels`        | Persistent Volume labels                                                                                | `{}`                |
-| `tracking.persistence.annotations`   | Persistent Volume Claim annotations                                                                     | `{}`                |
-| `tracking.persistence.accessModes`   | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
-| `tracking.persistence.size`          | Size of data volume                                                                                     | `8Gi`               |
-| `tracking.persistence.existingClaim` | The name of an existing PVC to use for persistence                                                      | `""`                |
-| `tracking.persistence.selector`      | Selector to match an existing Persistent Volume for MLflow data PVC                                     | `{}`                |
-| `tracking.persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
-
-### MLflow Tracking Generic Ephemeral Volume Parameters
-
-| Name                                               | Description                                                      | Value   |
-| -------------------------------------------------- | ---------------------------------------------------------------- | ------- |
-| `tracking.tmpVolume.ephemeral.enabled`             | Use a generic ephemeral volume for `/tmp` instead of `emptyDir`  | `false` |
-| `tracking.tmpVolume.ephemeral.volumeClaimTemplate` | Custom `volumeClaimTemplate` for the ephemeral volume (YAML map) | `{}`    |
+| Name                                               | Description                                                                                             | Value               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
+| `tracking.persistence.enabled`                     | Enable persistence using Persistent Volume Claims                                                       | `true`              |
+| `tracking.persistence.mountPath`                   | Path to mount the volume at.                                                                            | `/bitnami/mlflow`   |
+| `tracking.persistence.subPath`                     | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
+| `tracking.persistence.storageClass`                | Storage class of backing PVC                                                                            | `""`                |
+| `tracking.persistence.labels`                      | Persistent Volume labels                                                                                | `{}`                |
+| `tracking.persistence.annotations`                 | Persistent Volume Claim annotations                                                                     | `{}`                |
+| `tracking.persistence.accessModes`                 | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
+| `tracking.persistence.size`                        | Size of data volume                                                                                     | `8Gi`               |
+| `tracking.persistence.existingClaim`               | The name of an existing PVC to use for persistence                                                      | `""`                |
+| `tracking.persistence.selector`                    | Selector to match an existing Persistent Volume for MLflow data PVC                                     | `{}`                |
+| `tracking.persistence.dataSource`                  | Custom PVC data source                                                                                  | `{}`                |
+| `tracking.tmpVolume.ephemeral.enabled`             | Use a generic ephemeral volume for `/tmp` instead of `emptyDir`                                         | `false`             |
+| `tracking.tmpVolume.ephemeral.volumeClaimTemplate` | Custom `volumeClaimTemplate` for the ephemeral volume (YAML map)                                        | `{}`                |
 
 ### MLflow Tracking Other Parameters
 

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -298,6 +298,13 @@ To back up and restore Helm chart deployments on Kubernetes, you need to back up
 | `tracking.persistence.selector`      | Selector to match an existing Persistent Volume for MLflow data PVC                                     | `{}`                |
 | `tracking.persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
 
+### MLflow Tracking Generic Ephemeral Volume Parameters
+
+| Name                                               | Description                                                      | Value   |
+| -------------------------------------------------- | ---------------------------------------------------------------- | ------- |
+| `tracking.tmpVolume.ephemeral.enabled`             | Use a generic ephemeral volume for `/tmp` instead of `emptyDir`  | `false` |
+| `tracking.tmpVolume.ephemeral.volumeClaimTemplate` | Custom `volumeClaimTemplate` for the ephemeral volume (YAML map) | `{}`    |
+
 ### MLflow Tracking Other Parameters
 
 | Name                                                   | Description                                                      | Value   |

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -364,7 +364,13 @@ spec:
         {{- end }}
       volumes:
         - name: tmp
+        {{- if .Values.tracking.tmpVolume.ephemeral.enabled }}
+          ephemeral:
+            volumeClaimTemplate:
+              {{- include "common.tplvalues.render" (dict "value" .Values.tracking.tmpVolume.ephemeral.volumeClaimTemplate "context" $) | nindent 14 }}
+        {{- else }}
           emptyDir: {}
+        {{- end }}
         - name: mlruns
           emptyDir: {}
         - name: mlartifacts

--- a/bitnami/mlflow/values.schema.json
+++ b/bitnami/mlflow/values.schema.json
@@ -1023,6 +1023,26 @@
                         }
                     }
                 },
+                "tmpVolume": {
+                    "type": "object",
+                    "properties": {
+                        "ephemeral": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Use a generic ephemeral volume for `/tmp` instead of `emptyDir`"
+                                },
+                                "volumeClaimTemplate": {
+                                    "type": "object",
+                                    "default": {},
+                                    "description": "Custom `volumeClaimTemplate` for the ephemeral volume (YAML map)"
+                                }
+                            }
+                        }
+                    }
+                },
                 "serviceAccount": {
                     "type": "object",
                     "properties": {

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -766,9 +766,9 @@ tracking:
   ##
   tmpVolume:
     ephemeral:
-      ## @param tracking.tmpVolume.ephemeral Use a generic ephemeral volume for `/tmp` instead of `emptyDir`
+      ## @param tracking.tmpVolume.ephemeral.enabled Use a generic ephemeral volume for `/tmp` instead of `emptyDir`
       enabled: false
-      ## @param tracking.tmpVolume.volumeClaimTemplate Custom `volumeClaimTemplate` for the ephemeral volume (YAML map)
+      ## @param tracking.tmpVolume.ephemeral.volumeClaimTemplate Custom `volumeClaimTemplate` for the ephemeral volume (YAML map)
       volumeClaimTemplate: {}
 
   ## @section MLflow Tracking Other Parameters

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -760,6 +760,17 @@ tracking:
     ## @param tracking.persistence.dataSource Custom PVC data source
     ##
     dataSource: {}
+
+  ## MLflow Tracking Generic Ephemeral Volume Parameters
+  ## ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+  ##
+  tmpVolume:
+    ephemeral:
+      ## @param tracking.tmpVolume.ephemeral Use a generic ephemeral volume for `/tmp` instead of `emptyDir`
+      enabled: false
+      ## @param tracking.tmpVolume.volumeClaimTemplate Custom `volumeClaimTemplate` for the ephemeral volume (YAML map)
+      volumeClaimTemplate: {}
+
   ## @section MLflow Tracking Other Parameters
   ##
   serviceAccount:
@@ -776,6 +787,7 @@ tracking:
     ## @param tracking.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
     automountServiceAccountToken: false
+
   ## @section MLflow Tracking Metrics Parameters
   ##
   metrics:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change introduces a new feature to configure the /tmp volume as a generic ephemeral volume, which is backed by a PersistentVolumeClaim (PVC).

### Benefits

<!-- What benefits will be realized by the code change? -->
Better Resource Management: Administrators can now manage the storage for /tmp using standard Kubernetes storage mechanisms. This allows for applying storage quotas, using specific performance tiers via StorageClass, and isolating /tmp storage from the node's ephemeral disk.

Increased Flexibility: Users can customize the storage characteristics for /tmp by defining their own volumeClaimTemplate, specifying properties like storage size (resources.requests.storage), accessModes, and storageClassName.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #36283 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
