### PR TITLE
[bitnami/mlflow] Apply tpl to ingress hostname, external S3 and DB host

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -46,4 +46,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 5.2.0
+version: 5.3.0

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Fullname of the tracking service
 {{- end -}}
 
 {{/*
+Render and return the MLflow tracking ingress hostname.
+*/}}
+{{- define "mlflow.v0.tracking.hostname" -}}
+{{- include "common.tplvalues.render" (dict "value" .Values.tracking.ingress.hostname "context" $) -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "mlflow.v0.tracking.serviceAccountName" -}}
@@ -446,7 +453,7 @@ Return the PostgreSQL Hostname
         {{- print (include "mlflow.v0.postgresql.fullname" .) -}}
     {{- end -}}
 {{- else -}}
-    {{- print .Values.externalDatabase.host -}}
+    {{- include "common.tplvalues.render" (dict "value" .Values.externalDatabase.host "context" $) -}}
 {{- end -}}
 {{- end -}}
 
@@ -632,7 +639,7 @@ Return the S3 bucket
     {{- if .Values.minio.enabled -}}
         {{- print .Values.minio.defaultBuckets -}}
     {{- else -}}
-        {{- print .Values.externalS3.bucket -}}
+        {{- include "common.tplvalues.render" (dict "value" .Values.externalS3.bucket "context" $) -}}
     {{- end -}}
 {{- end -}}
 

--- a/bitnami/mlflow/templates/tracking/ingress-tls-secrets.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress-tls-secrets.yaml
@@ -25,9 +25,10 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.tracking.ingress.tls .Values.tracking.ingress.selfSigned }}
-{{- $secretName := printf "%s-tls" .Values.tracking.ingress.hostname }}
+{{- $renderedHostname := include "mlflow.v0.tracking.hostname" . }}
+{{- $secretName := printf "%s-tls" $renderedHostname }}
 {{- $ca := genCA "mlflow-ca" 365 }}
-{{- $cert := genSignedCert .Values.tracking.ingress.hostname nil (list .Values.tracking.ingress.hostname) 365 $ca }}
+{{- $cert := genSignedCert $renderedHostname nil (list $renderedHostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -4,6 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.tracking.enabled .Values.tracking.ingress.enabled }}
+{{- $renderedHostname := include "mlflow.v0.tracking.hostname" . }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -21,8 +22,8 @@ spec:
   ingressClassName: {{ .Values.tracking.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-    {{- if .Values.tracking.ingress.hostname }}
-    - host: {{ .Values.tracking.ingress.hostname }}
+    {{- if $renderedHostname }}
+    - host: {{ $renderedHostname }}
       http:
         paths:
           {{- if .Values.tracking.ingress.extraPaths }}
@@ -47,8 +48,8 @@ spec:
   tls:
     {{- if and .Values.tracking.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.tracking.ingress.annotations )) .Values.tracking.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.tracking.ingress.hostname | quote }}
-      secretName: {{ printf "%s-tls" .Values.tracking.ingress.hostname }}
+        - {{ $renderedHostname | quote }}
+      secretName: {{ printf "%s-tls" $renderedHostname }}
     {{- end }}
     {{- if .Values.tracking.ingress.extraTls }}
     {{- include "common.tplvalues.render" (dict "value" .Values.tracking.ingress.extraTls "context" $) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Ingress hostname is now rendered with `common.tplvalues.render` anywhere it is referenced in `ingress.yaml` and `ingress-tls-secrets.yaml`.
- External S3 bucket value is rendered via `common.tplvalues.render` in the S3 helper.
- External database host is rendered via `common.tplvalues.render` in the DB helper.

### Benefits

- Enhanced Flexibility
Allows for dynamic configuration of resource names (e.g., hostnames, buckets) using Go template syntax like `{{ .Release.Name }}` instead of static values.

- Improved Chart Reusability
Enables deploying the same chart across multiple environments (e.g., dev, staging) from a single configuration without causing naming collisions.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
