### PR TITLE
fix(ci-workflow): Allow changelog commits on forked repositories

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -3,7 +3,7 @@
 
 name: '[CI/CD] CI Pipeline'
 on: # rebuild any PRs and main branch changes
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -166,7 +166,7 @@ jobs:
     needs: [get-chart]
     name: Automatically update README, CRDs and CHANGELOG
     permissions:
-      contents: write
+      contents: read
     outputs:
       result: ${{ steps.update-pr.outputs.result }}
     if: needs.get-chart.outputs.result == 'ok'
@@ -176,12 +176,11 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           path: charts
       - name: Clone upstream bitnami/charts repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
-          ref: ${{github.event.pull_request.base.ref}}
-          repository: ${{github.event.pull_request.base.repo.full_name}}
           path: upstream-charts
       - name: Setup git configuration
         run: |


### PR DESCRIPTION
### Description of the change

Use bitnami-bot user to commit changes on forked repositories.

### Benefits

We can update the changelog in forked repositories

### Possible drawbacks

None

### Applicable issues

- Pushes done by this workflow on forked repositories are currently failing.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
