### PR TITLE
Split CI workflow and add more verification steps

### DIFF
--- a/.github/actions/get-chart/action.yaml
+++ b/.github/actions/get-chart/action.yaml
@@ -1,0 +1,89 @@
+name: 'Get Chart'
+description: 'Composite action to discover the modified chart'
+
+inputs:
+  pr-number:
+    required: true
+    description: Pull request number.
+  pr-url:
+    required: true
+    description: Pull request URL.
+  token:
+    required: true
+    default: "${{ github.token }}"
+outputs:
+  chart:
+    description: Path to the modified chart
+    value: ${{ steps.get-chart.outputs.chart }}
+  result:
+    description: '"ok", "fail" if more than one chart is modified or "skip" if not charts are changed' 
+    value: ${{ steps.get-chart.outputs.result }}
+  values-updated:
+    description: '"true" if the values.yaml file has been modified'
+    value: ${{ steps.get-chart.outputs.values-updated }}
+runs:
+  using: 'composite'
+  steps:
+    - id: get-chart
+      name: Get modified charts
+      env:
+        PULL_REQUEST_NUMBER: "${{ inputs.pr-number }}"
+        PULL_REQUEST_URL: "${{ inputs.pr-url }}"
+        GITHUB_TOKEN: "${{ inputs.token }}"
+      shell: bash
+      run: |
+        # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
+        files_changed_data="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/files")"
+        files_changed="$(echo "$files_changed_data" | jq -r '.[] | .filename')"
+        # Adding || true to avoid "Process exited with code 1" errors
+        charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
+        # Using grep -c as a better alternative to wc -l when dealing with empty strings."
+        num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
+        num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|match("bitnami/[^/]+/Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
+        non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
+
+        if [[ $(curl -Lks "${PULL_REQUEST_URL}" | jq '.state | index("closed")') != *null* ]]; then
+          # The PR for which this workflow run was launched is now closed -> SKIP
+          echo "error=The PR for which this workflow run was launched is now closed. The tests will be skipped." >> "$GITHUB_OUTPUT"
+          echo "result=skip" >> "$GITHUB_OUTPUT"
+        elif [[ "$non_readme_files" -le "0" ]]; then
+          # The only changes are .md files -> SKIP
+          echo "result=skip" >> "$GITHUB_OUTPUT"
+        elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
+          # Changes done in charts but version not bumped -> ERROR
+          echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed}. Version bumps detected: ${num_version_bumps}" >> "$GITHUB_OUTPUT"
+          echo "result=fail" >> "$GITHUB_OUTPUT"
+        elif [[ "$num_charts_changed" -eq "1" ]]; then
+          # Changes done in only one chart -> OK
+          echo "result=ok" >> "$GITHUB_OUTPUT"
+          # Extra output: chart name
+          chart_name="${charts_dirs_changed//bitnami\/}"
+          echo "chart=${chart_name}" >> "$GITHUB_OUTPUT"
+          # Extra output: values-updated
+          # shellcheck disable=SC2076
+          if [[ "${files_changed[*]}" =~ "bitnami/${chart_name}/values.yaml" ]]; then
+            echo "values-updated=true" >> "$GITHUB_OUTPUT"
+          fi
+        elif [[ "$num_charts_changed" -le "0" ]]; then
+          # Changes done in the bitnami/ folder but not inside a chart subfolder -> SKIP
+          echo "error=No changes detected in charts. The rest of the tests will be skipped." >> "$GITHUB_OUTPUT"
+          echo "result=skip" >> "$GITHUB_OUTPUT"
+        else
+          # Changes done in more than chart -> SKIP
+          echo "error=Changes detected in more than one chart directory. It is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> "$GITHUB_OUTPUT"
+          echo "result=skip" >> "$GITHUB_OUTPUT"
+        fi
+    # Using actions/github-scripts because using exit 1 in the script above would not provide any output
+    # Source: https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/3
+    - id: show-error
+      name: Show error
+      if: ${{ steps.get-chart.outputs.result != 'ok' }}
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+      with:
+        script: |
+          let message='${{ steps.get-chart.outputs.error }}';
+          if ('${{ steps.get-chart.outputs.result }}' === 'fail' ) {
+            core.setFailed(message);
+          } else {
+            core.warning(message);
+          }

--- a/.github/workflows/ci-update.yml
+++ b/.github/workflows/ci-update.yml
@@ -1,7 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
-name: '[CI/CD] CI Pipeline'
+name: '[CI/CD] CI Update'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:
@@ -29,146 +29,16 @@ jobs:
       values-updated: ${{ steps.get-chart.outputs.values-updated }}
     steps:
       - id: get-chart
-        name: Get modified charts
-        env:
-          PULL_REQUEST_NUMBER: "${{ github.event.pull_request.number }}"
-          PULL_REQUEST_URL: "${{ github.event.pull_request.url }}"
-          GITHUB_TOKEN: "${{ github.token }}"
-        run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          files_changed_data="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/files")"
-          files_changed="$(echo "$files_changed_data" | jq -r '.[] | .filename')"
-          # Adding || true to avoid "Process exited with code 1" errors
-          charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
-          # Using grep -c as a better alternative to wc -l when dealing with empty strings."
-          num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
-          num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|match("bitnami/[^/]+/Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
-          non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
-
-          if [[ $(curl -Lks "${PULL_REQUEST_URL}" | jq '.state | index("closed")') != *null* ]]; then
-            # The PR for which this workflow run was launched is now closed -> SKIP
-            echo "error=The PR for which this workflow run was launched is now closed. The tests will be skipped." >> "$GITHUB_OUTPUT"
-            echo "result=skip" >> "$GITHUB_OUTPUT"
-          elif [[ "$non_readme_files" -le "0" ]]; then
-            # The only changes are .md files -> SKIP
-            echo "result=skip" >> "$GITHUB_OUTPUT"
-          elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
-            # Changes done in charts but version not bumped -> ERROR
-            echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed}. Version bumps detected: ${num_version_bumps}" >> "$GITHUB_OUTPUT"
-            echo "result=fail" >> "$GITHUB_OUTPUT"
-          elif [[ "$num_charts_changed" -eq "1" ]]; then
-            # Changes done in only one chart -> OK
-            echo "result=ok" >> "$GITHUB_OUTPUT"
-            # Extra output: chart name
-            chart_name="${charts_dirs_changed//bitnami\/}"
-            echo "chart=${chart_name}" >> "$GITHUB_OUTPUT"
-            # Extra output: values-updated
-            # shellcheck disable=SC2076
-            if [[ "${files_changed[*]}" =~ "bitnami/${chart_name}/values.yaml" ]]; then
-              echo "values-updated=true" >> "$GITHUB_OUTPUT"
-            fi
-          elif [[ "$num_charts_changed" -le "0" ]]; then
-            # Changes done in the bitnami/ folder but not inside a chart subfolder -> SKIP
-            echo "error=No changes detected in charts. The rest of the tests will be skipped." >> "$GITHUB_OUTPUT"
-            echo "result=skip" >> "$GITHUB_OUTPUT"
-          else
-            # Changes done in more than chart -> SKIP
-            echo "error=Changes detected in more than one chart directory. It is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> "$GITHUB_OUTPUT"
-            echo "result=skip" >> "$GITHUB_OUTPUT"
-          fi
-      # Using actions/github-scripts because using exit 1 in the script above would not provide any output
-      # Source: https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/3
-      - id: show-error
-        name: Show error
-        if: ${{ steps.get-chart.outputs.result != 'ok' }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        uses: bitnami/charts/.github/actions/get-chart@main
         with:
-          script: |
-            let message='${{ steps.get-chart.outputs.error }}';
-            if ('${{ steps.get-chart.outputs.result }}' === 'fail' ) {
-              core.setFailed(message);
-            } else {
-              core.warning(message);
-            }
-  chart-tests:
-    runs-on: ubuntu-latest
-    needs: [get-chart]
-    name: Look for hardcoded images
-    if: needs.get-chart.outputs.result == 'ok'
-    steps:
-      - name: Checkout bitnami/charts
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          path: charts
-      - id: check-hardcoded-images
-        name: Look for hardcoded images
-        env:
-          CHART: ${{ needs.get-chart.outputs.chart }}
-        run: |
-          cd "${GITHUB_WORKSPACE}/charts" || exit 1
-
-          hardcoded_images=()
-          while read -r image; do
-            if [[ -n "$image" && $image != {{*}} ]]; then
-              hardcoded_images+=("${image}")
-            fi
-          done <<< "$(grep --exclude "NOTES.txt" -REoh "\s*image:\s+[\"']*.+[\"']*\s*$" "bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
-          echo "${hardcoded_images[@]}"
-          if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then
-            echo "error=Found hardcoded images in the chart templates: ${hardcoded_images[*]}"
-            exit 1
-          fi
-      - id: check-image-warning-list
-        name: Check image warning list
-        env:
-          CHART: ${{ needs.get-chart.outputs.chart }}
-        run: |
-          cd "${GITHUB_WORKSPACE}/charts" || exit 1
-
-          if [[ "$CHART" != "common" && "$CHART" != "fluentd" ]]; then
-            readarray -t tag_paths < <(yq e '.. | (path | join("."))' "bitnami/${CHART}/values.yaml" | grep -E '\.tag$' | sed 's/.tag$//g' | sort -u)
-            readarray -t registry_paths < <(yq e '.. | (path | join("."))' "bitnami/${CHART}/values.yaml" | grep '\.registry$' | sed 's/.registry$//g' | sort -u)
-
-            # We assume that image objects are those that contain both keys 'tag' and 'registry'
-            images_paths=()
-            for path in "${tag_paths[@]}"; do
-              if echo "${registry_paths[@]}" | grep -w -q "$path"; then
-               [[ -n "$path" ]] && images_paths+=("$path")
-              fi
-            done
-
-            # Get the images defined in the image warning helper
-            readarray -d ' ' -t images_list_tmp < <(grep -E 'common.warnings.modifiedImages' "bitnami/${CHART}/templates/NOTES.txt" | sed -E 's/.*\(list (.+)\) "context".*/\1/' | sed 's/.Values.//g')
-
-            # Remove any empty element from the array
-            images_list=()
-            for i in "${images_list_tmp[@]}"; do
-              if echo "$i" | grep -q -E "\S+"; then
-                images_list+=("$i")
-              fi
-            done
-
-            # Compare the image objects and the image warning list
-            if [[ ${#images_list[@]} -eq ${#images_paths[@]} ]]; then
-              for path in "${images_list[@]}"; do
-                if ! echo "${images_paths[*]}" | grep -w -q "$path"; then
-                  echo "Found inconsistencies in the images warning list: '${images_list[*]}' should be equal to '${images_paths[*]}'"
-                  exit 1
-                fi
-              done
-            else
-              echo "Found inconsistencies in the images warning list: '${images_list[*]}' should be equal to '${images_paths[*]}'"
-              exit 1
-            fi
-          fi
+          pr-url: "${{ github.event.pull_request.url }}"
+          pr-number: "${{ github.event.pull_request.number }}"
   update-pr:
     runs-on: ubuntu-latest
     needs: [get-chart]
     name: Automatically update README, CRDs and CHANGELOG
     permissions:
       contents: read
-    outputs:
-      result: ${{ steps.update-pr.outputs.result }}
     if: needs.get-chart.outputs.result == 'ok'
     steps:
       - name: Checkout bitnami/charts

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1,0 +1,191 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[CI/CD] Verify'
+on: # rebuild any PRs and main branch changes
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+    branches:
+      - main
+      - bitnami:main
+# Remove all permissions by default
+permissions: {}
+# Avoid concurrency over the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+jobs:
+  get-chart:
+    runs-on: ubuntu-latest
+    name: Get modified charts
+    permissions:
+      pull-requests: read
+    outputs:
+      chart: ${{ steps.get-chart.outputs.chart }}
+      result: ${{ steps.get-chart.outputs.result }}
+      values-updated: ${{ steps.get-chart.outputs.values-updated }}
+    steps:
+      - id: get-chart
+        uses: bitnami/charts/.github/actions/get-chart@main
+        with:
+          pr-url: "${{ github.event.pull_request.url }}"
+          pr-number: "${{ github.event.pull_request.number }}"
+  chart-tests:
+    runs-on: ubuntu-latest
+    needs: [get-chart]
+    name: Look for hardcoded images
+    if: needs.get-chart.outputs.result == 'ok'
+    steps:
+      - name: Checkout bitnami/charts
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          path: charts
+      - id: check-hardcoded-images
+        name: Look for hardcoded images
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          cd "${GITHUB_WORKSPACE}/charts" || exit 1
+
+          hardcoded_images=()
+          while read -r image; do
+            if [[ -n "$image" && $image != {{*}} ]]; then
+              hardcoded_images+=("${image}")
+            fi
+          done <<< "$(grep --exclude "NOTES.txt" -REoh "\s*image:\s+[\"']*.+[\"']*\s*$" "bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
+          echo "${hardcoded_images[@]}"
+          if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then
+            echo "error=Found hardcoded images in the chart templates: ${hardcoded_images[*]}"
+            exit 1
+          fi
+      - id: check-image-warning-list
+        name: Check image warning list
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          cd "${GITHUB_WORKSPACE}/charts" || exit 1
+
+          if [[ "$CHART" != "common" && "$CHART" != "fluentd" ]]; then
+            readarray -t tag_paths < <(yq e '.. | (path | join("."))' "bitnami/${CHART}/values.yaml" | grep -E '\.tag$' | sed 's/.tag$//g' | sort -u)
+            readarray -t registry_paths < <(yq e '.. | (path | join("."))' "bitnami/${CHART}/values.yaml" | grep '\.registry$' | sed 's/.registry$//g' | sort -u)
+
+            # We assume that image objects are those that contain both keys 'tag' and 'registry'
+            images_paths=()
+            for path in "${tag_paths[@]}"; do
+              if echo "${registry_paths[@]}" | grep -w -q "$path"; then
+               [[ -n "$path" ]] && images_paths+=("$path")
+              fi
+            done
+
+            # Get the images defined in the image warning helper
+            readarray -d ' ' -t images_list_tmp < <(grep -E 'common.warnings.modifiedImages' "bitnami/${CHART}/templates/NOTES.txt" | sed -E 's/.*\(list (.+)\) "context".*/\1/' | sed 's/.Values.//g')
+
+            # Remove any empty element from the array
+            images_list=()
+            for i in "${images_list_tmp[@]}"; do
+              if echo "$i" | grep -q -E "\S+"; then
+                images_list+=("$i")
+              fi
+            done
+
+            # Compare the image objects and the image warning list
+            if [[ ${#images_list[@]} -eq ${#images_paths[@]} ]]; then
+              for path in "${images_list[@]}"; do
+                if ! echo "${images_paths[*]}" | grep -w -q "$path"; then
+                  echo "Found inconsistencies in the images warning list: '${images_list[*]}' should be equal to '${images_paths[*]}'"
+                  exit 1
+                fi
+              done
+            else
+              echo "Found inconsistencies in the images warning list: '${images_list[*]}' should be equal to '${images_paths[*]}'"
+              exit 1
+            fi
+          fi
+  verify:
+    runs-on: ubuntu-latest
+    needs: [get-chart]
+    name: Run linter and kubescape
+    permissions:
+      contents: read
+    if: needs.get-chart.outputs.result == 'ok'
+    steps:
+      - name: Checkout bitnami/charts
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: charts-pr
+      - name: Checkout bitnami/charts
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{github.event.pull_request.base.ref}}
+          repository: ${{github.event.pull_request.base.repo.full_name}}
+          fetch-depth: 1
+          path: charts-main
+      - name: Install helm
+        run: |
+          HELM_TARBALL="helm-v3.8.1-linux-amd64.tar.gz"
+          curl -SsLfO "https://get.helm.sh/${HELM_TARBALL}" && sudo tar xf "$HELM_TARBALL" --strip-components 1 -C /usr/local/bin
+      - name: Install Kubescape
+        run: |
+          curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash -s -- -v v3.0.41
+      - name: Run helm-dep-build
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          charts_paths=("charts-main" "charts-pr")
+          for charts_path in "${charts_paths[@]}"; do
+            if [ -d "${charts_path}/bitnami/${CHART}" ]; then
+              helm dep build "${charts_path}/bitnami/${CHART}"
+              if [ -d "${charts_path}/bitnami/${CHART}/charts" ]; then
+                pushd ${charts_path}/bitnami/${CHART}/charts
+                for filename in *.tgz; do
+                  tar -xf "$filename"
+                  rm -f "$filename"
+                done
+                popd
+              fi
+            fi
+          done
+      - name: Run helm-lint
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+            helm lint "charts-pr/bitnami/${CHART}"
+      - id: validate-scores
+        name: Validate score
+        # Skip step when user 'skip-score' label is used
+        if: |
+          !(
+            contains(github.event.pull_request.labels.*.name, 'skip-score') ||
+            (github.event.action == 'labeled' && github.event.label.name == 'skip-score')
+          )
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          export PATH="$PATH:$HOME/.kubescape/bin"
+          FRAMEWORKS="MITRE,NSA,SOC2,cis-v1.10.0"
+          if [ -d "charts-main/bitnami/${CHART}" ]; then
+            report_dir="$(mktemp -d)"
+            charts_paths=("charts-pr" "charts-main")
+            for chart_path in "${charts_paths[@]}"; do
+              echo "Scanning ${chart_path}/bitnami/${CHART}"
+              report_file="${report_dir}/${chart_path}.json"
+              kubescape scan framework "${FRAMEWORKS}" "${chart_path}/bitnami/${CHART}" --format json -o "${report_file}"
+              # Use only 2 decimals and save it wihout separator (for integer operations).
+              printf "%s%.2s" $(echo "$(jq .summaryDetails.complianceScore ${report_file})" | tr '.' ' ') | sed 's/\.$//' > "${report_dir}/${chart_path}.score"
+            done
+            score="$(<"${report_dir}/charts-pr.score")"
+            main_score="$(<"${report_dir}/charts-main.score")"
+            # To show the scores we need to add the decimals: 1234 > 12.34 
+            echo "Current score: ${score:0:${#score}-2}.${score: -2}, previous one: ${main_score:0:${#main_score}-2}.${main_score: -2}"
+            if [[ $((score - main_score)) -lt 0 ]]; then
+              echo "Kubescape score has worsened"
+              exit 1
+            fi
+          else
+            echo "Chart not found at bitnami/${CHART}. It will be assumed that the upstream chart does not exist."
+          fi


### PR DESCRIPTION
### Description of the change

Split CI wokflows:
* get-chart action: Common logic to get modifed charts.
* CI update: With access to secrets to commit changes on forkerd repositories with new changelog entries.
* CI verify: Run linter and kubescape.

### Benefits

Keep a minimal verification on charts.

### Possible drawbacks

None

### Additional information

NOTE: Current validation is failing because the action is not landed.
Execution examples:
* Everything OK:  https://github.com/bitnami/charts/actions/runs/18215280799/job/51863146741
* Linter KO: https://github.com/bitnami/charts/actions/runs/18215374615/job/51863438022
* Kubescape KO: https://github.com/bitnami/charts/actions/runs/18216050758/job/51865415556

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
