### PR TITLE
fix(values-ascii-check): amend regexp to detect non-ascii characters

### DIFF
--- a/.github/workflows/values-ascii-check.yml
+++ b/.github/workflows/values-ascii-check.yml
@@ -30,7 +30,7 @@ jobs:
           values_files="$(echo "$files_changed" | grep -o ".*values\.yaml$" | sort | uniq || true)"
           # Create an empty file, useful when the PR changes ignored files
           touch "${TEMP_OUTPUT}"
-          grep -nHP "[\x80-\xFF]" "${values_files[@]}" | sort -u > ${TEMP_OUTPUT} || true
+          LC_ALL=C grep -nHP '[^\x00-\x7F]' "${values_files[@]}" | sort -u > ${TEMP_OUTPUT} || true
           while read -r line; do
             # line format:
             #   file:row:message


### PR DESCRIPTION
### Description of the change

`LC_ALL=C ` ensures `grep` treats the file as a stream of bytes and makes the regex `[^\x00-\x7F]` reliable.

### Benefits

Avoid non ASCII characters in values files.

### Possible drawbacks

None
