### PR TITLE
Fix documentation typos in README files

### DIFF
--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -1111,7 +1111,7 @@ This major version changes the default PostgreSQL image from 14.x to 15.x. Follo
 
 ### To 9.0.0
 
-This chart major version updates the PostgreSQL image's version to the latest major, `v14`, as well as standarizes the templates and values. These changes can be sumarised in the following:
+This chart major version updates the PostgreSQL image's version to the latest major, `v14`, as well as standardizes the templates and values. These changes can be summarised in the following:
 
 - Image parameters that used `imageNameImage` are now under `imageName.image`
 - `containerPort` parameters are now found by `containerPorts.xxxx`

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -544,7 +544,7 @@ This could potentially break any customization or init scripts used in your depl
 
 ### To 6.0.0
 
-This chart major version standarizes the chart templates and values, modifying some existing parameters names and adding several more. These parameter modifications can be sumarised in the following:
+This chart major version standardizes the chart templates and values, modifying some existing parameters names and adding several more. These parameter modifications can be summarised in the following:
 
 - `worker.autoscaling.CpuTargetPercentage/.replicasMax` parameters are now found by `worker.autoscaling.targetCPU/.maxReplicas`.
 - `webport/webPortHttps/cluster` parameters are now found by `containerPorts.http/.https/.cluster`.

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1749,7 +1749,7 @@ This major release bumps the MinIO chart version to [13.x.x](https://github.com/
 
 This major version changes the NetworkPolicy objects and creates one per Thanos component. The `networkPolicy` common value was removed in favor of `COMPONENT.networkPolicy`. Also, NetworkPolicy objects are deployed by default. This can be changed by setting `COMPONENT.networkPolicy.enabled=false` being `COMPONENT` one of the Thanos components.
 
-This version also removes deprecated service port values like `receive.service.http.port` in favor of `recieve.service.ports.http`, as well as `existingServiceAccount`.
+This version also removes deprecated service port values like `receive.service.http.port` in favor of `receive.service.ports.http`, as well as `existingServiceAccount`.
 
 ### To 12.0.0
 

--- a/template/README.md
+++ b/template/README.md
@@ -37,6 +37,6 @@ Some of the items that need to be implemented are:
 - podSecurityContext
 - containerSecurityContext
 
-Also it is necessary to use the `bitnami/common` chart to standarize some of the above items.
+Also it is necessary to use the `bitnami/common` chart to standardize some of the above items.
 
 :warning: Take into account this is just an example to follow, depending on the specific use case you will need to remove, add or modify those templates, beyond replacing the placeholders `%%FOO%%`


### PR DESCRIPTION
### Description of the change

Fixed spelling errors in documentation files across multiple charts:
- Fixed 'standarize' -> 'standardize' in template/README.md
- Fixed 'recieve' -> 'receive' in bitnami/thanos/README.md  
- Fixed 'standarizes' -> 'standardizes' and 'sumarised' -> 'summarised' in bitnami/spark/README.md
- Fixed 'standarizes' -> 'standardizes' and 'sumarised' -> 'summarised' in bitnami/postgresql-ha/README.md

### Benefits

- Improves documentation quality and professionalism
- Makes documentation easier to read and understand
- Fixes clear spelling errors that could confuse users

### Possible drawbacks

None - documentation-only changes that do not affect chart functionality.

### Checklist

- [x] Variables are documented (N/A - README only changes, no version bump needed)
- [x] Title of the pull request follows pattern
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)