### PR TITLE
[bitnami/thanos] Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 17.4.1 (2026-03-20)
+## 17.4.1 (2026-03-23)
 
 * [bitnami/thanos] Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false ([#36485](https://github.com/bitnami/charts/pull/36485))
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 17.4.0 (2026-02-08)
+## 17.4.1 (2026-03-20)
+
+* [bitnami/thanos]: Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false ([#36485](https://github.com/bitnami/charts/pull/36485), closes [#36474](https://github.com/bitnami/charts/issues/36474))
+
+## <small>17.4.0 (2026-02-08)</small>
 
 * [bitnami/thanos]: Adds compactor.deploymentAnnotation to thanos compactor options ([#36453](https://github.com/bitnami/charts/pull/36453))
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 17.4.1 (2026-03-20)
 
-* [bitnami/thanos]: Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false ([#36485](https://github.com/bitnami/charts/pull/36485), closes [#36474](https://github.com/bitnami/charts/issues/36474))
+* [bitnami/thanos] Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false ([#36485](https://github.com/bitnami/charts/pull/36485))
 
-## <small>17.4.0 (2026-02-08)</small>
+## 17.4.0 (2026-02-09)
 
-* [bitnami/thanos]: Adds compactor.deploymentAnnotation to thanos compactor options ([#36453](https://github.com/bitnami/charts/pull/36453))
+* [bitnami/thanos]: Adds compactor.deploymentAnnotation to thanos compactor options (#36453) ([c21afd6](https://github.com/bitnami/charts/commit/c21afd6f1b2e696f925869962cf1353a054ac15f)), closes [#36453](https://github.com/bitnami/charts/issues/36453)
 
 ## <small>17.3.4 (2026-01-12)</small>
 
@@ -461,7 +461,7 @@
 
 ## <small>15.0.2 (2024-04-03)</small>
 
-* [bitnami/thanos]Fix: Make prometheus rules reliable with release name (#24655) ([a2a6eab](https://github.com/bitnami/charts/commit/a2a6eabda632d12ded2b2d0959c44aca2b73fab8)), closes [#24655](https://github.com/bitnami/charts/issues/24655) [#24651](https://github.com/bitnami/charts/issues/24651) [#24651](https://github.com/bitnami/charts/issues/24651)
+* [bitnami/thanos]Fix: Make prometheus rules reliable with release name (#24655) ([a2a6eab](https://github.com/bitnami/charts/commit/a2a6eabda632d12ded2b2d0959c44aca2b73fab8)), closes [#24655](https://github.com/bitnami/charts/issues/24655) [#24651](https://github.com/bitnami/charts/issues/24651)
 * Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>15.0.1 (2024-04-03)</small>
@@ -1547,7 +1547,7 @@
 
 ## <small>3.8.6 (2021-02-15)</small>
 
-* [bitnami/thanos] fix query TLS client in a modular way (#5437) (#5457) ([bbbf490](https://github.com/bitnami/charts/commit/bbbf490439643e885529c1c4f25aeb7c9c29dc93)), closes [#5437](https://github.com/bitnami/charts/issues/5437) [#5457](https://github.com/bitnami/charts/issues/5457) [#5437](https://github.com/bitnami/charts/issues/5437)
+* [bitnami/thanos] fix query TLS client in a modular way (#5437) (#5457) ([bbbf490](https://github.com/bitnami/charts/commit/bbbf490439643e885529c1c4f25aeb7c9c29dc93)), closes [#5437](https://github.com/bitnami/charts/issues/5437) [#5457](https://github.com/bitnami/charts/issues/5457)
 
 ## <small>3.8.5 (2021-02-12)</small>
 
@@ -1729,7 +1729,7 @@
 
 ## 2.2.0 (2020-08-12)
 
-* [bitnami/thanos] Add cache configuration blocks to Thanos store. Index and Bucket (#3387) ([2f2e1dd](https://github.com/bitnami/charts/commit/2f2e1ddcc594c1a6538c1820867862775e009740)), closes [#3387](https://github.com/bitnami/charts/issues/3387) [#3384](https://github.com/bitnami/charts/issues/3384) [#3384](https://github.com/bitnami/charts/issues/3384)
+* [bitnami/thanos] Add cache configuration blocks to Thanos store. Index and Bucket (#3387) ([2f2e1dd](https://github.com/bitnami/charts/commit/2f2e1ddcc594c1a6538c1820867862775e009740)), closes [#3387](https://github.com/bitnami/charts/issues/3387) [#3384](https://github.com/bitnami/charts/issues/3384)
 
 ## <small>2.1.1 (2020-08-07)</small>
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.4.0
+version: 17.4.1

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -137,10 +137,10 @@ spec:
             {{- if $.Values.storegateway.useEndpointGroup }}
             - --endpoint-group={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
             {{- else }}
-              {{- if $.Values.query.dnsDiscovery.enabled }}
-              - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
-              {{- else }}
-              - --endpoint={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
+            {{- if $.Values.query.dnsDiscovery.enabled }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
+            {{- else }}
+            - --endpoint={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
             {{- end }}
             {{- end }}
             {{- end }}


### PR DESCRIPTION
### Description of the change

This fixes an issue with YAML templates for thanos query components when `storegateway.useEndpointGroup` is false. Since https://github.com/bitnami/charts/pull/36418, some values can be indented
```
- --endpoint-group={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
  - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
  - --endpoint={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
```

We want the two possible lines to be at the same indentation as other arguments

```
- --endpoint-group={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
- --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
- --endpoint={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
```

### Benefits

Fixes broken arguments passed to the query pod when `storegateway.useEndpointGroup` is false.

### Possible drawbacks

Nothing I can think of 

### Applicable issues

- fixes #36474

### Additional information

This seems like something an automated tool could have caught but I'm not sure if such tool exists.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
