### PR TITLE
[bitnami/valkey-cluster] clarify Valkey 9.0 database support in cluster mode

### DIFF
--- a/bitnami/valkey-cluster/README.md
+++ b/bitnami/valkey-cluster/README.md
@@ -43,7 +43,7 @@ The main features of each chart are the following:
 
 | Valkey                                     | Valkey Cluster                                                   |
 |--------------------------------------------|------------------------------------------------------------------|
-| Supports multiple databases                | Supports DB 0 by default, with support for multiple numbered databases in cluster mode starting with Valkey 9.0 when cluster-databases is configured. Better if you have a big dataset     |
+| Supports multiple databases                | Supports one database by default;  multiple numbered DBs in cluster from Valkey 9.0+ when configured. Better if you have a big dataset     |
 | Single write point (single primary)        | Multiple write points (multiple primary nodes)                   |
 | ![Valkey Topology](img/valkey-topology.png)| ![Valkey Cluster Topology](img/valkey-cluster-topology.png)      |
 

--- a/bitnami/valkey-cluster/README.md
+++ b/bitnami/valkey-cluster/README.md
@@ -43,7 +43,7 @@ The main features of each chart are the following:
 
 | Valkey                                     | Valkey Cluster                                                   |
 |--------------------------------------------|------------------------------------------------------------------|
-| Supports multiple databases                | Supports only one database. Better if you have a big dataset     |
+| Supports multiple databases                | Supports DB 0 by default, with support for multiple numbered databases in cluster mode starting with Valkey 9.0 when cluster-databases is configured. Better if you have a big dataset     |
 | Single write point (single primary)        | Multiple write points (multiple primary nodes)                   |
 | ![Valkey Topology](img/valkey-topology.png)| ![Valkey Cluster Topology](img/valkey-cluster-topology.png)      |
 


### PR DESCRIPTION
Valkey 9.0 introduced support for multiple numbered databases in cluster mode when cluster-databases is configured.

For example, setting cluster-databases 6 enables support for databases from DB 0 to DB 5 in cluster mode.

The current documentation still states that Valkey Cluster supports only one database, which is outdated for Valkey 9.0+.

This change updates the wording to clarify that DB 0 is still the default, while additional numbered databases can also be supported in cluster mode when cluster-databases is set.

--> **※ Ref: https://valkey.io/blog/numbered-databases/**

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->


Description of the change

Valkey 9.0 introduced support for multiple numbered databases in cluster mode when cluster-databases is configured.

For example, setting cluster-databases 6 enables support for databases from DB 0 to DB 5 in cluster mode.

The current documentation still states that Valkey Cluster supports only one database, which is outdated for Valkey 9.0+.

This change updates the wording to clarify that DB 0 is still the default, while additional numbered databases can also be supported in cluster mode when cluster-databases is set.


Here >>>
- Configured `cluster-databases 6`
- Successfully selected DB 5 in cluster mode
- Confirmed numbered databases beyond DB 0 are supported in Valkey 9.0+

<img width="481" height="152" alt="image" src="https://github.com/user-attachments/assets/72b867dc-1100-44a6-a3fc-b12effa344f1" />


<img width="727" height="463" alt="image" src="https://github.com/user-attachments/assets/63264065-968a-48b9-80c1-d3d6f8eaf165" />

It can be confirmed that the subject value changes depending on the selected numbered database.

I spent quite a bit of time confused because the official documentation stated that cluster mode only supports a single database.

To help others avoid the same confusion, it would be helpful to explicitly mention that the cluster-databases option and numbered databases are supported starting from Valkey 9.0.

Reference:

https://valkey.io/blog/numbered-databases/

Benefits
Makes the documentation accurate for Valkey 9.0+
Clarifies that DB 0 is the default behavior
Explains that additional numbered databases are available when cluster-databases is configured
Possible drawbacks
Users on versions older than Valkey 9.0 may still only support DB 0 in cluster mode
Applicable issues
fixes #
Additional information

A configuration such as cluster-databases 6 enables support for DB 0 through DB 5 in cluster mode.

Checklist

Chart version bumped in Chart.yaml according to semver. This is not necessary because the change only affects documentation.

Variables are documented in the values.yaml and added to the README.md using readme-generator-for-helm

Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title

All commits signed off and in agreement of Developer Certificate of Origin (DCO)
