### PR TITLE
[bitnami/phpmyadmin] fix override Release namespace with common value

### DIFF
--- a/bitnami/phpmyadmin/CHANGELOG.md
+++ b/bitnami/phpmyadmin/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 20.0.2 (2026-04-15)
+
+* [bitnami/phpmyadmin] fix override Release namespace with common value ([#36508](https://github.com/bitnami/charts/pull/36508))
+
 ## 20.0.0 (2025-08-18)
 
-* [bitnami/phpmyadmin] Upgrade to MariaDB 12.0 ([#36118](https://github.com/bitnami/charts/pull/36118))
+* [bitnami/phpmyadmin] Upgrade to MariaDB 12.0 (#36118) ([943f947](https://github.com/bitnami/charts/commit/943f947147a6a46158f64f29a8295f92b74a902e)), closes [#36118](https://github.com/bitnami/charts/issues/36118)
 
 ## <small>19.0.24 (2025-08-18)</small>
 

--- a/bitnami/phpmyadmin/CHANGELOG.md
+++ b/bitnami/phpmyadmin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20.0.2 (2026-04-15)
+## 20.0.2 (2026-04-22)
 
 * [bitnami/phpmyadmin] fix override Release namespace with common value ([#36508](https://github.com/bitnami/charts/pull/36508))
 

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: phpmyadmin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
-version: 20.0.1
+version: 20.0.2

--- a/bitnami/phpmyadmin/templates/certs.yaml
+++ b/bitnami/phpmyadmin/templates/certs.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-certs" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -7,7 +7,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
   annotations:

--- a/bitnami/phpmyadmin/templates/metrics-svc.yaml
+++ b/bitnami/phpmyadmin/templates/metrics-svc.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: metrics
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}

--- a/bitnami/phpmyadmin/templates/service.yaml
+++ b/bitnami/phpmyadmin/templates/service.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/phpmyadmin/templates/serviceaccount.yaml
+++ b/bitnami/phpmyadmin/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "phpmyadmin.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/phpmyadmin/templates/tls-secrets.yaml
+++ b/bitnami/phpmyadmin/templates/tls-secrets.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/phpmyadmin/templates/tls-secrets.yaml
+++ b/bitnami/phpmyadmin/templates/tls-secrets.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ $.Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -29,7 +29,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

This pull request replaces occurrences of `.Release.Namespace` in resource manifests with the variable `common.names.namespace`.

Motivation:
By using `common.names.namespace`, users can override the namespace assignment through Helm values or helper templates instead of being forced to use the namespace specified by Helm's release context. This is especially useful in environments where deploying to the `default` namespace is not allowed, or when rendering manifests outside of a Helm release (e.g., with `helm template`).

Please let me know if further changes are needed or if additional documentation would be helpful.

### Benefits

- Greater flexibility for namespace assignment
- Aligns with custom deployment workflows and cluster security requirements
- Improves compatibility with strict Kubernetes environments

### Additional information

There is a template (servicemonitor.yaml) where I am not sure how to apply this change

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
