### PR TITLE
[bitnami/clickhouse] Clickhouse "configuration" value template

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.4.4 (2025-08-26)
+## 9.4.7 (2026-04-15)
 
-* [bitnami/clickhouse] :zap: :arrow_up: Update dependency references ([#36201](https://github.com/bitnami/charts/pull/36201))
+* [bitnami/clickhouse] Clickhouse "configuration" value template ([#36510](https://github.com/bitnami/charts/pull/36510))
+
+## <small>9.4.4 (2025-08-27)</small>
+
+* [bitnami/clickhouse] :zap: :arrow_up: Update dependency references (#36201) ([679acf7](https://github.com/bitnami/charts/commit/679acf7eb5d0e5b52a730f7fa290f2d65308f8a4)), closes [#36201](https://github.com/bitnami/charts/issues/36201)
 
 ## <small>9.4.3 (2025-08-14)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 9.4.6
+version: 9.4.7

--- a/bitnami/clickhouse/templates/configmap.yaml
+++ b/bitnami/clickhouse/templates/configmap.yaml
@@ -17,5 +17,5 @@ metadata:
   {{- end }}
 data:
   config.xml: |
-    {{- include "common.tplvalues.render" (dict "value" .Values.configuration "context" .) }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.configuration "context" .) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change stops the Helm template from silently failing.

### Benefits

Using the configuration option no longer fails because of a Helm template error. I choose `nindent 4` because it seems standard (although `nindent 0` also works).

```
helm install ./charts/bitnami/clickhouse --values <(cat <<EOF
commonAnnotations: 
  testkey: "testvalue"
configuration:
  testkey: "testvalue"
EOF
) --generate-name

Error: INSTALLATION FAILED: YAML parse error on clickhouse/templates/configmap.yaml: error converting YAML to JSON: yaml: line 17: did not find expected comment or line break
```

After the change, we no longer see installation failed and there are no failed pods.

### Possible drawbacks

Using the configuration option now fails at a later stage if the Clickhouse docs are wrong or features change: https://clickhouse.com/docs/operations/configuration-files

> It is possible to mix XML and YAML configuration files, for example you could have a main configuration file config.xml and additional configuration files config.d/network.xml, config.d/timezone.yaml and config.d/keeper.yaml. Mixing XML and YAML within a single configuration file is not supported. XML configuration files should use <clickhouse>...</clickhouse> as the top-level tag. In YAML configuration files, clickhouse: is optional, if absent the parser inserts it automatically.
There seems to be no container error despite the fact that we are defining YAML in an XML file. This somewhat matches the Clickhouse docs.


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #36499

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
