### PR TITLE
[bitnami/airflow] Improves boolean logic of missing CRDs in the Airflow Helm chart

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## 25.1.1 (2026-04-20)
+
+* [bitnami/airflow] Improves boolean logic of missing CRDs in the Airflow Helm chart ([#36514](https://github.com/bitnami/charts/pull/36514))
+
 ## 25.1.0 (2026-01-12)
 
-* [bitnami/airflow] Allow customizing the empty-dir volume parameters ([#36432](https://github.com/bitnami/charts/pull/36432))
+* [bitnami/*][TNZ-62332] Modify charts' READMEs title (#36372) ([2012e46](https://github.com/bitnami/charts/commit/2012e46699f555bb1e10134691031975bb5ca50b)), closes [#36372](https://github.com/bitnami/charts/issues/36372)
+* [bitnami/airflow] Allow customizing the empty-dir volume parameters (#36432) ([c58edb8](https://github.com/bitnami/charts/commit/c58edb88cb9f39ae12bc06a507050c00b7b1c8cd)), closes [#36432](https://github.com/bitnami/charts/issues/36432)
+* Change wording in Chart's READMEs (#36379) ([a4ef0a6](https://github.com/bitnami/charts/commit/a4ef0a63877fcf32895869ceef0916c15a4718e5)), closes [#36379](https://github.com/bitnami/charts/issues/36379)
+* Remove TAC sentence present in some READMEs (#36381) ([e07d331](https://github.com/bitnami/charts/commit/e07d3319b61f49ddf6f431da3ed7ec0e0be3d5d0)), closes [#36381](https://github.com/bitnami/charts/issues/36381)
 
 ## <small>25.0.4 (2025-09-02)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 25.1.0
+version: 25.1.1

--- a/bitnami/airflow/templates/metrics/servicemonitor.yaml
+++ b/bitnami/airflow/templates/metrics/servicemonitor.yaml
@@ -4,6 +4,10 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if not (include "common.capabilities.apiVersions.has" ( dict "version" "monitoring.coreos.com/v1/ServiceMonitor" "context" . )) }}
+  {{- fail "To collect Prometheus metrics, the ServiceMonitor CRD from the Prometheus Operator should be be installed in your cluster, such as through the bitnami/kube-prometheus Helm chart" }}
+}}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/bitnami/airflow/templates/web/vpa.yaml
+++ b/bitnami/airflow/templates/web/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.web.autoscaling.vpa.enabled }}
+{{- if .Values.web.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Improves boolean logic of missing CRDs in the Airflow Helm chart, in particular monitoring.coreos.com/v1/ServiceMonitor and VerticalPodAutoscaler

### Benefits

Users new to the Helm chart or configuring a new Kubernetes cluster that do not have the proper CRDs will be notified earlier in the debugging process that their configuration will not collect metrics or scale vertically.

The indirection around coreos ServiceMonitor being related to the Prometheus project is reduced through an error message using the `fail` Helm templating function. 


### Possible drawbacks

Users have the `vpa` value set in their Airflow helm chart but don't actually want the VerticalPodAutoscaler installed will now see a failure in future deployments.

For example a user might copy-paste configs to use across different clusters, some without the VerticalPodAutoscaler resource type.

### Applicable issues

#36513

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
