### PR TITLE
[bitnami/jaeger] Add missing serviceAccountName in deployments

### DIFF
--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 6.0.6
+version: 6.0.7

--- a/bitnami/jaeger/templates/collector/deployment.yaml
+++ b/bitnami/jaeger/templates/collector/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- end }}
     spec:
       {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.collector.automountServiceAccountToken }}
       {{- if .Values.collector.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.collector.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/jaeger/templates/query/deployment.yaml
+++ b/bitnami/jaeger/templates/query/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- end }}
     spec:
       {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.query.automountServiceAccountToken }}
       {{- if .Values.query.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.query.hostAliases "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

Fixes an issue in the bitnami/jaeger chart where service account would not be set in the collector and query deployments, which caused them to always be configured using the `default` serviceAccount.

### Benefits

Deployments use the correct serviceAccount

### Possible drawbacks

None known.

### Applicable issues

- fixes #36509

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
