### PR TITLE
[bitnami/nginx-ingress-controller] Deprecate Helm chart

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -17,8 +17,9 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: NGINX Ingress Controller is an Ingress controller that manages external
-  access to HTTP services in a Kubernetes cluster using NGINX.
+# The NGINX Ingress Controller chart is deprecated and no longer maintained
+deprecated: true
+description: DEPRECATED NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:
@@ -29,10 +30,8 @@ keywords:
 - www
 - reverse proxy
 kubeVersion: '>= 1.20.0-0'
-maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+maintainers: []
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 12.0.8
+version: 12.0.9

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -8,6 +8,10 @@ NGINX Ingress Controller is an Ingress controller that manages external access t
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+This product is unmaintained by the upstream; see https://github.com/kubernetes/ingress-NGINX?tab=readme-ov-file#retiring
+
 ## TL;DR
 
 ```console

--- a/bitnami/nginx-ingress-controller/templates/NOTES.txt
+++ b/bitnami/nginx-ingress-controller/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+This product is unmaintained by the upstream; see https://github.com/kubernetes/ingress-NGINX?tab=readme-ov-file#retiring
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
This product is unmaintained by the upstream; see https://github.com/kubernetes/ingress-NGINX?tab=readme-ov-file#retiring