### PR TITLE
[bitnami/thanos] Fix yaml syntax Thanos query for storegateway sharded

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.4.1 (2026-03-23)
+## 17.4.2 (2026-05-12)
 
-* [bitnami/thanos] Fix invalid YAML syntax on the query deployment template when `storegateway.useEndpointGroup` is false ([#36485](https://github.com/bitnami/charts/pull/36485))
+* [bitnami/thanos] Fix yaml syntax Thanos query for storegateway sharded ([#36527](https://github.com/bitnami/charts/pull/36527))
+
+## <small>17.4.1 (2026-04-17)</small>
+
+* [bitnami/thanos] Fix invalid YAML syntax on the query deployment template when `storegateway.useEndp ([a7fb7ee](https://github.com/bitnami/charts/commit/a7fb7ee67a1afdbf4de5b4afb48e7ffeeea1397c)), closes [#36485](https://github.com/bitnami/charts/issues/36485)
 
 ## 17.4.0 (2026-02-09)
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.4.1
+version: 17.4.2

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -133,7 +133,7 @@ spec:
             {{- $timeShards = len .Values.storegateway.sharded.timePartitioning }}
             {{- end }}
             {{- $shards = mul $hashShards $timeShards | int }}
-            {{- range $index, $_ := until $shards }}
+            {{- range $index, $_ := until $shards -}}
             {{- if $.Values.storegateway.useEndpointGroup }}
             - --endpoint-group={{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.storegateway.service.ports.grpc }}
             {{- else }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`storegateway.sharded.enabled=true` and `query.replicaLabel` is a multi-item list, the `{{- range $index, $_ := until $shards }`} whitespace trimming operator eats the newline after the closing {{- end }} of the `replicaLabel` range above it.

### Benefits

Fix sharded storegateway endpoints being unreachable when multiple replica labels are configured.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

When multi-item shard and replicaLabel make it issue rendering like this :
```
      - args:
        - query
        - --log.level=info
        - --log.format=logfmt
        - --grpc-address=0.0.0.0:10901
        - --http-address=0.0.0.0:10902
        - --query.replica-label=prometheus_replica
        - --query.replica-label=replica
        - --query.replica-label=prometheus
        - --query.replica-label=thanos_ruler_replica - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-0.observability.svc.cluster.local
          - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-1.observability.svc.cluster.local
          - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-2.observability.svc.cluster.local
          - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-3.observability.svc.cluster.local
          - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-4.observability.svc.cluster.local
          - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-5.observability.svc.cluster.local
        - --endpoint=dnssrv+_grpc._tcp.thanos-receive.observability.svc.cluster.local
        - --endpoint=dnssrv+_grpc._tcp.prometheus-thanos-discovery.observability.svc.cluster.local
```
Impact
That causes the first sharded storegateway `--endpoint` to be concatenated onto the same line as the last `--query.replica-label` value. The remaining endpoints (storegateway-1 onwards) then render at wrong indentation, making them unrecognised as separate list items by Kubernetes. 
The result is all sharded storegateway instances are unreachable by Thanos Querier.

expected :
```
          args:
            - query
            - --log.level=info
            - --log.format=logfmt
            - --grpc-address=0.0.0.0:10901
            - --http-address=0.0.0.0:10902
            - --query.replica-label=prometheus_replica
            - --query.replica-label=replica
            - --query.replica-label=prometheus
            - --query.replica-label=thanos_ruler_replica
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-0.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-1.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-2.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-3.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-4.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-storegateway-5.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.thanos-receive.observability.svc.cluster.local
            - --endpoint=dnssrv+_grpc._tcp.prometheus-thanos-discovery.observability.svc.cluster.local
```

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
