### PR TITLE
[bitnami/rabbitmq] Added support for httproute in rabbitmq chart

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 16.0.16 (2025-11-19)
+## 16.1.0 (2026-05-12)
 
-* [bitnami/rabbitmq] fix: :bug: Sanitize users with dot ([#36389](https://github.com/bitnami/charts/pull/36389))
+* [bitnami/rabbitmq] Added support for httproute in rabbitmq chart ([#36528](https://github.com/bitnami/charts/pull/36528))
+
+## <small>16.0.16 (2025-11-19)</small>
+
+* [bitnami/*] Remove annotations.category (#36224) ([2abc0f9](https://github.com/bitnami/charts/commit/2abc0f9d7e89a5453e57f029c66f581b3d5855ef)), closes [#36224](https://github.com/bitnami/charts/issues/36224)
+* [bitnami/*][TNZ-62332] Modify charts' READMEs title (#36372) ([2012e46](https://github.com/bitnami/charts/commit/2012e46699f555bb1e10134691031975bb5ca50b)), closes [#36372](https://github.com/bitnami/charts/issues/36372)
+* [bitnami/rabbitmq] fix: :bug: Sanitize users with dot (#36389) ([301592c](https://github.com/bitnami/charts/commit/301592c46422482b6a640b2b233b39818954895a)), closes [#36389](https://github.com/bitnami/charts/issues/36389)
+* Change wording in Chart's READMEs (#36379) ([a4ef0a6](https://github.com/bitnami/charts/commit/a4ef0a63877fcf32895869ceef0916c15a4718e5)), closes [#36379](https://github.com/bitnami/charts/issues/36379)
+* Remove TAC sentence present in some READMEs (#36381) ([e07d331](https://github.com/bitnami/charts/commit/e07d3319b61f49ddf6f431da3ed7ec0e0be3d5d0)), closes [#36381](https://github.com/bitnami/charts/issues/36381)
 
 ## <small>16.0.14 (2025-08-21)</small>
 
@@ -749,7 +757,7 @@
 * [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
 * [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
 * [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/rabbitmq] fix broken config option #14766 (#14859) ([75b0cf6](https://github.com/bitnami/charts/commit/75b0cf6f8958d8b35bfa2670d30e4b81e8e88d8d)), closes [#14766](https://github.com/bitnami/charts/issues/14766) [#14859](https://github.com/bitnami/charts/issues/14859) [#14766](https://github.com/bitnami/charts/issues/14766) [#14766](https://github.com/bitnami/charts/issues/14766)
+* [bitnami/rabbitmq] fix broken config option #14766 (#14859) ([75b0cf6](https://github.com/bitnami/charts/commit/75b0cf6f8958d8b35bfa2670d30e4b81e8e88d8d)), closes [#14766](https://github.com/bitnami/charts/issues/14766) [#14859](https://github.com/bitnami/charts/issues/14859) [#14766](https://github.com/bitnami/charts/issues/14766)
 
 ## <small>11.9.1 (2023-02-12)</small>
 
@@ -770,7 +778,7 @@
 ## 11.7.0 (2023-02-01)
 
 * [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/rabbitmq] Add ssl_options.password (#14463) ([9941124](https://github.com/bitnami/charts/commit/9941124a3f8d3770d3b17acfaeec0e134930dd25)), closes [#14463](https://github.com/bitnami/charts/issues/14463) [#14373](https://github.com/bitnami/charts/issues/14373) [#14373](https://github.com/bitnami/charts/issues/14373)
+* [bitnami/rabbitmq] Add ssl_options.password (#14463) ([9941124](https://github.com/bitnami/charts/commit/9941124a3f8d3770d3b17acfaeec0e134930dd25)), closes [#14463](https://github.com/bitnami/charts/issues/14463) [#14373](https://github.com/bitnami/charts/issues/14373)
 
 ## <small>11.6.1 (2023-01-31)</small>
 
@@ -778,7 +786,7 @@
 
 ## 11.6.0 (2023-01-26)
 
-* [bitnam/rabbitmq] Choice of setting configuration and extraConfiguration as secret (#14519) ([5520624](https://github.com/bitnami/charts/commit/5520624e67f0ae44928d83d31dadf5e8a217584b)), closes [#14519](https://github.com/bitnami/charts/issues/14519) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444)
+* [bitnam/rabbitmq] Choice of setting configuration and extraConfiguration as secret (#14519) ([5520624](https://github.com/bitnami/charts/commit/5520624e67f0ae44928d83d31dadf5e8a217584b)), closes [#14519](https://github.com/bitnami/charts/issues/14519) [#14444](https://github.com/bitnami/charts/issues/14444)
 
 ## <small>11.5.1 (2023-01-25)</small>
 
@@ -1594,7 +1602,7 @@
 
 ## 8.2.0 (2020-11-26)
 
-* [bitnami/rabbitmq] Start to use shutdown script waiting for synchronization (#4470) ([9524947](https://github.com/bitnami/charts/commit/95249478d9498b5b57a99b943bd995a1c901cf52)), closes [#4470](https://github.com/bitnami/charts/issues/4470) [#3931](https://github.com/bitnami/charts/issues/3931) [#3931](https://github.com/bitnami/charts/issues/3931)
+* [bitnami/rabbitmq] Start to use shutdown script waiting for synchronization (#4470) ([9524947](https://github.com/bitnami/charts/commit/95249478d9498b5b57a99b943bd995a1c901cf52)), closes [#4470](https://github.com/bitnami/charts/issues/4470) [#3931](https://github.com/bitnami/charts/issues/3931)
 
 ## <small>8.1.1 (2020-11-24)</small>
 
@@ -1708,7 +1716,7 @@
 
 ## <small>7.5.3 (2020-07-10)</small>
 
-* [bitnami/rabbitmq] Corrected example of extraContainerPorts (#3076) ([bcc42b4](https://github.com/bitnami/charts/commit/bcc42b4e3c7ccf9dabd2023e27dd582bc7f4a862)), closes [#3076](https://github.com/bitnami/charts/issues/3076) [#2023](https://github.com/bitnami/charts/issues/2023) [#2027](https://github.com/bitnami/charts/issues/2027) [bitnami#2023](https://github.com/bitnami/issues/2023) [bitnami#2027](https://github.com/bitnami/issues/2027) [bitnami#2023](https://github.com/bitnami/issues/2023) [bitnami#2027](https://github.com/bitnami/issues/2027)
+* [bitnami/rabbitmq] Corrected example of extraContainerPorts (#3076) ([bcc42b4](https://github.com/bitnami/charts/commit/bcc42b4e3c7ccf9dabd2023e27dd582bc7f4a862)), closes [#3076](https://github.com/bitnami/charts/issues/3076) [#2023](https://github.com/bitnami/charts/issues/2023) [#2027](https://github.com/bitnami/charts/issues/2027) [bitnami#2023](https://github.com/bitnami/issues/2023) [bitnami#2027](https://github.com/bitnami/issues/2027)
 
 ## <small>7.5.2 (2020-07-09)</small>
 

--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.3
-digest: sha256:f9c314553215490ea1b94c70082cb152d6ff5916ce185b4e00f5287f81545b4c
-generated: "2025-06-25T13:14:39.551033+02:00"
+  version: 2.39.0
+digest: sha256:5a987375fae0397adf98b6d984124c87eba34c025f273cd8a6b7bd6c265d830a
+generated: "2026-05-07T18:51:48.5193686+02:00"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 16.0.16
+version: 16.1.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -689,6 +689,22 @@ Because they expose different sets of data, a valid use case is to scrape metric
 | `ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                     |
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.existingSecret`                | It is you own the certificate as secret.                                                                                         | `""`                     |
+| `route.web`                             | Configure the route for the management plugin.                                                                                   |                          |
+| `route.web.enabled`                     | Enable or disable the route for the management plugin                                                                            | `false`                  |
+| `route.web.apiVersion`                  | API version to use for the Route resource (e.g., gateway.networking.k8s.io/v1)                                                   | `""`                     |
+| `route.web.kind`                        | Type of Route to create (e.g., HTTPRoute, TCPRoute, etc.)                                                                        | `""`                     |
+| `route.web.annotations`                 | Annotations to add to the Route resource                                                                                         | `{}`                     |
+| `route.web.labels`                      | Labels to add to the Route resource                                                                                              | `{}`                     |
+| `route.web.hostnames`                   | List of hostnames for which the route will be valid                                                                              | `[]`                     |
+| `route.web.parentRefs`                  | Parent references (e.g., Gateway) for the route                                                                                  | `[]`                     |
+| `route.web.matches`                     | Matching rules for the route                                                                                                     | `[]`                     |
+| `route.web.matches.path.type`           | Path match type (e.g., PathPrefix, Exact)                                                                                        |                          |
+| `route.web.matches.path.value`          | Path value to match                                                                                                              |                          |
+| `route.web.filters`                     | Filters to apply to the route (e.g., rewrites, headers, etc.)                                                                    | `[]`                     |
+| `route.web.sessionPersistence`          | Session persistence configuration (if supported, Experimental in Gateway API v1.5)                                               | `{}`                     |
+| `route.web.timeouts`                    | Timeouts for requests handled by the route                                                                                       | `{}`                     |
+| `route.web.retry`                       | Retry policy configuration for the route (Experimental in Gateway API v1.5)                                                      | `{}`                     |
+| `route.web.backendService`              | Name of the service port key to use as backend (must be one of the keys defined in service.ports)                                | `""`                     |
 | `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                   |
 | `networkPolicy.kubeAPIServerPorts`      | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                               | `[]`                     |
 | `networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                   |

--- a/bitnami/rabbitmq/templates/NOTES.txt
+++ b/bitnami/rabbitmq/templates/NOTES.txt
@@ -141,6 +141,31 @@ To Access the RabbitMQ Management interface:
 {{- end }}
 {{- end }}
 
+{{- if .Values.route }}
+{{- $hasEnabledRoute := false }}
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+{{- $hasEnabledRoute = true }}
+{{- end }}
+{{- end }}
+{{- if $hasEnabledRoute }}
+
+Enabled routes and URLs:
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+{{- if $route.hostnames }}
+{{- range $hostname := $route.hostnames }}
+    - {{ $name }}: http://{{ $hostname }}/
+{{- end }}
+{{- else }}
+    - {{ $name }}: http://<set-hostname>/
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- end }}
+{{- end }}
+
 {{- if .Values.metrics.enabled }}
 
 To access the RabbitMQ Prometheus metrics, get the RabbitMQ Prometheus URL by running:

--- a/bitnami/rabbitmq/templates/httproutes.yaml
+++ b/bitnami/rabbitmq/templates/httproutes.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.route }}
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ printf "%s-%s" (include "common.names.fullname" $) $name }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $route.labels "context" $ ) | nindent 4 }}
+  {{- if or $route.annotations $.Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $route.annotations $.Values.commonAnnotations ) "context" $ ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.sessionPersistence }}
+      sessionPersistence:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.retry }}
+      retry:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - kind: Service
+          name: {{ include "common.names.fullname" $ }}
+          port: {{ index $.Values.service.ports $route.backendService }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/bitnami/rabbitmq/values.schema.json
+++ b/bitnami/rabbitmq/values.schema.json
@@ -31,6 +31,28 @@
       "title": "Number of replicas",
       "description": "Number of replicas to deploy"
     },
+    "route": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "backendService": {
+            "type": "string",
+            "enum": [
+              "amqp",
+              "amqpTls",
+              "dist",
+              "manager",
+              "metrics",
+              "epmd"
+            ],
+            "description": "Only the values defined in service.ports can be used here. The template will automatically resolve the corresponding port number and set this chart's service as the backend."
+          }
+        },
+        "required": ["backendService"]
+      }
+    },
     "persistence": {
       "type": "object",
       "title": "Persistence configuration",

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1279,6 +1279,46 @@ ingress:
   ## @param ingress.existingSecret It is you own the certificate as secret.
   ##
   existingSecret: ""
+## Configure the gateway routes for the RabbitMQ deployment.
+## The 'web' route is specifically designed to direct traffic to the service 
+## exposed via the Management Plugin (which must be enabled).
+## You can define additional routes for other services exposed by the deployment 
+## by adding new dictionary keys at the same level as 'web' (e.g., for AMQP, STOMP, etc.).
+## [[ref]](https://gateway-api.sigs.k8s.io/)
+route:
+  ## @extra route.web Configure the route for the management plugin.
+  web:
+    ## @param route.web.enabled Enable or disable the route for the management plugin
+    enabled: false
+    ## @param route.web.apiVersion [string] API version to use for the Route resource (e.g., gateway.networking.k8s.io/v1)
+    apiVersion: gateway.networking.k8s.io/v1
+    ## @param route.web.kind [string] Type of Route to create (e.g., HTTPRoute, TCPRoute, etc.)
+    kind: HTTPRoute
+    ## @param route.web.annotations [object] Annotations to add to the Route resource
+    annotations: {}
+    ## @param route.web.labels [object] Labels to add to the Route resource
+    labels: {}
+    ## @param route.web.hostnames [array] List of hostnames for which the route will be valid
+    hostnames: []
+    ## @param route.web.parentRefs [array] Parent references (e.g., Gateway) for the route
+    parentRefs: []
+    ## @param route.web.matches [array] Matching rules for the route
+    matches:
+      - path:
+          ## @extra route.web.matches.path.type [string] Path match type (e.g., PathPrefix, Exact)
+          type: PathPrefix
+          ## @extra route.web.matches.path.value [string] Path value to match
+          value: /
+    ## @param route.web.filters [array] Filters to apply to the route (e.g., rewrites, headers, etc.)
+    filters: []
+    ## @param route.web.sessionPersistence [object] Session persistence configuration (if supported, Experimental in Gateway API v1.5)
+    sessionPersistence: {}
+    ## @param route.web.timeouts [object] Timeouts for requests handled by the route
+    timeouts: {}
+    ## @param route.web.retry [object] Retry policy configuration for the route (Experimental in Gateway API v1.5)
+    retry: {}
+    ## @param route.web.backendService [string] Name of the service port key to use as backend (must be one of the keys defined in service.ports)
+    backendService: manager
 ## Network Policies
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##


### PR DESCRIPTION
### Description of the change

This PR adds the ability to create one or more **Routes** for the application deployment. These routes point directly to the services exposed and defined within the chart itself.

### Possible drawbacks

The implementation was primarily designed to handle **HTTPS traffic** for the Management UI. While it is theoretically compatible with other types of routes, extensive testing has not yet been performed for those specific use cases.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)