### PR TITLE
[bitnami/thanos] Fix `containerPorts` in query deployment

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## 17.5.2 (2026-05-20)
+
+* [bitnami/thanos] Fix `containerPorts` in query deployment ([#36533](https://github.com/bitnami/charts/pull/36533))
+
+## <small>17.5.1 (2026-05-19)</small>
+
+* [bitnami/thanos] Change hpa bucketweb component label to bucketweb (#36531) ([242f0b8](https://github.com/bitnami/charts/commit/242f0b8106575d3853509806fe23d4bad067846c)), closes [#36531](https://github.com/bitnami/charts/issues/36531)
+
 ## 17.5.0 (2026-05-19)
 
-* [bitnami/thanos] Add Thanos httproute ([#36529](https://github.com/bitnami/charts/pull/36529))
+* [bitnami/thanos] Add Thanos httproute (#36529) ([73c0faa](https://github.com/bitnami/charts/commit/73c0faa841fdb2f6b604bb6662dafa29a074df18)), closes [#36529](https://github.com/bitnami/charts/issues/36529)
 
 ## <small>17.4.1 (2026-04-17)</small>
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.5.1
+version: 17.5.2

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -104,8 +104,8 @@ spec:
             - query
             - --log.level={{ .Values.query.logLevel }}
             - --log.format={{ .Values.query.logFormat }}
-            - --grpc-address=0.0.0.0:10901
-            - --http-address=0.0.0.0:10902
+            - --grpc-address=0.0.0.0:{{ .Values.query.containerPorts.grpc }}
+            - --http-address=0.0.0.0:{{ .Values.query.containerPorts.http }}
             {{- if (include "thanos.httpConfigEnabled" .) }}
             - --http.config=/conf/http/http-config.yml
             {{- end }}
@@ -201,10 +201,10 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 10902
+              containerPort: {{ .Values.query.containerPorts.http }}
               protocol: TCP
             - name: grpc
-              containerPort: 10901
+              containerPort: {{ .Values.query.containerPorts.grpc }}
               protocol: TCP
           {{- if .Values.query.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customLivenessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Ensure custom `containerPorts` on query are working properly :
https://github.com/bitnami/charts/blob/1e56a501272c018515f275ada23d84a28de35eff/bitnami/thanos/values.yaml#L217-L222

### Benefits

`query.containerPorts` can be used.

### Possible drawbacks

None, this is a pure template fix that makes the query deployment.

### Applicable issues

The `query.containerPorts` not worked with custom values.
- fixes #

### Additional information

Currently, the query deployment template hardcodes port in http and grpc.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
