### PR TITLE
[bitnami/redis] bugfix: honor custom labels on PVCs

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 23.1.1 (2026-02-12)
+## 23.1.2 (2026-06-01)
 
-* [bitnami/redis] bugfix: use TLS port on readiness probes when TLS is enabled ([#36463](https://github.com/bitnami/charts/pull/36463))
+* [bitnami/redis] bugfix: honor custom labels on PVCs ([#36542](https://github.com/bitnami/charts/pull/36542))
+
+## <small>23.1.1 (2026-02-12)</small>
+
+* [bitnami/redis] bugfix: use TLS port on readiness probes when TLS is enabled (#36463) ([e3296a8](https://github.com/bitnami/charts/commit/e3296a831406bacf5ce661c5274590d0b40efcdd)), closes [#36463](https://github.com/bitnami/charts/issues/36463)
+* [bitnami/redis] feat: add support for sync checks on replica nodes with sentinel (#36461) ([38684e0](https://github.com/bitnami/charts/commit/38684e07d2e5ef68f4c2ff9dcdcf61a3c700c1e8)), closes [#36461](https://github.com/bitnami/charts/issues/36461)
 
 ## <small>23.0.5 (2025-12-11)</small>
 
@@ -104,7 +109,7 @@
 
 ## <small>21.2.10 (2025-07-11)</small>
 
-* [bitnami/redis] Fix external service annotations ignored #33270 (#33776) ([cd64f12](https://github.com/bitnami/charts/commit/cd64f12492a47b8e68154737dc75460de67c5bd1)), closes [#33270](https://github.com/bitnami/charts/issues/33270) [#33776](https://github.com/bitnami/charts/issues/33776) [#33270](https://github.com/bitnami/charts/issues/33270)
+* [bitnami/redis] Fix external service annotations ignored #33270 (#33776) ([cd64f12](https://github.com/bitnami/charts/commit/cd64f12492a47b8e68154737dc75460de67c5bd1)), closes [#33270](https://github.com/bitnami/charts/issues/33270) [#33776](https://github.com/bitnami/charts/issues/33776)
 
 ## <small>21.2.9 (2025-07-09)</small>
 
@@ -1079,7 +1084,7 @@
 ## <small>17.3.6 (2022-10-18)</small>
 
 * [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/redis] Allow podSelector from any namespaceSelector (#12624) ([847dc49](https://github.com/bitnami/charts/commit/847dc4956017a5204179effd56f009ff04c9b3e4)), closes [#12624](https://github.com/bitnami/charts/issues/12624) [#12607](https://github.com/bitnami/charts/issues/12607) [#12607](https://github.com/bitnami/charts/issues/12607)
+* [bitnami/redis] Allow podSelector from any namespaceSelector (#12624) ([847dc49](https://github.com/bitnami/charts/commit/847dc4956017a5204179effd56f009ff04c9b3e4)), closes [#12624](https://github.com/bitnami/charts/issues/12624) [#12607](https://github.com/bitnami/charts/issues/12607)
 
 ## <small>17.3.5 (2022-10-11)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 23.1.1
+version: 23.1.2

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -540,7 +540,7 @@ spec:
       metadata:
         name: redis-data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.persistence.labels .Values.commonLabels ) "context" . ) }}
-        labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
+        labels: {{- include "common.labels.standard" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: master
         {{- if .Values.master.persistence.annotations }}
         annotations: {{- toYaml .Values.master.persistence.annotations | nindent 10 }}

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -555,8 +555,8 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: redis-data
-        {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.persistence.labels .Values.commonLabels ) "context" . ) }}
-        labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
+        {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.replica.persistence.labels .Values.commonLabels ) "context" . ) }}
+        labels: {{- include "common.labels.standard" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: replica
         {{- if .Values.replica.persistence.annotations }}
         annotations: {{- toYaml .Values.replica.persistence.annotations | nindent 10 }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -844,7 +844,8 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: redis-data
-        labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 10 }}
+        {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.replica.persistence.labels .Values.commonLabels ) "context" . ) }}
+        labels: {{- include "common.labels.standard" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: node
         {{- if .Values.replica.persistence.annotations }}
         annotations: {{- toYaml .Values.replica.persistence.annotations | nindent 10 }}
@@ -867,7 +868,7 @@ spec:
       metadata:
         name: sentinel-data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sentinel.persistence.labels .Values.commonLabels ) "context" . ) }}
-        labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
+        labels: {{- include "common.labels.standard" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}
           app.kubernetes.io/component: node
         {{- if .Values.sentinel.persistence.annotations }}
         annotations: {{- toYaml .Values.sentinel.persistence.annotations | nindent 10 }}


### PR DESCRIPTION
### Description of the change

Custom labels supplied via `master.persistence.labels`, `replica.persistence.labels`, `sentinel.persistence.labels`, and `commonLabels` were silently dropped from rendered PVCs in `volumeClaimTemplates`. The templates used `common.labels.matchLabels`, which picks only `app.kubernetes.io/name` and `app.kubernetes.io/instance` out of the input — filtering every other user-supplied label.

Switched the three PVC templates to `common.labels.standard`, which merges custom labels with the standard set. This matches how every other non-selector `labels:` field in the chart is already rendered.

Two adjacent bugs fixed in the same change:
- The replica PVC template was reading `.Values.master.persistence.labels` instead of `.Values.replica.persistence.labels` — a copy-paste from the master template.
- The sentinel `redis-data` PVC ignored `replica.persistence.labels` entirely, even though it inherits every other field from `replica.persistence.*`.

### Benefits

Custom labels on PVCs now work as documented in `values.yaml`. This unblocks label-selector-based tooling (Prometheus alert routing, cost allocation, ownership tags) that previously had no way to land labels on PVCs without manually patching them post-install. Important because `volumeClaimTemplates` are immutable after StatefulSet creation.

### Possible drawbacks

PVCs will now carry the full set of standard labels (`app.kubernetes.io/name`, `instance`, `managed-by`, `version`, `helm.sh/chart`) plus user-supplied labels, where previously they only carried `name` and `instance`. Anyone with external selectors matching PVCs on the *absence* of those keys would be affected, but that would be an unusual setup.

### Applicable issues

- fixes #36536

### Additional information

Validated by rendering each architecture (`standalone`, `replication`, `sentinel`) with custom `*.persistence.labels` + `commonLabels` and confirming the labels appear on the rendered PVCs. Also rendered with defaults to confirm the no-custom-labels case still produces the expected standard label set. `helm lint` passes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
