### PR TITLE
[bitnami/thanos] per-shard extraFlags + shardLoopId in sharded storegateway

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 17.5.2 (2026-05-20)
+## 17.6.0 (2026-06-03)
 
-* [bitnami/thanos] Fix `containerPorts` in query deployment ([#36533](https://github.com/bitnami/charts/pull/36533))
+* [bitnami/thanos] per-shard extraFlags + shardLoopId in sharded storegateway ([#36543](https://github.com/bitnami/charts/pull/36543))
+
+## <small>17.5.2 (2026-05-25)</small>
+
+* [bitnami/thanos] Fix `containerPorts` in query deployment (#36533) ([b1f6087](https://github.com/bitnami/charts/commit/b1f6087ca0727b8764b3b5a79875f1286300ac17)), closes [#36533](https://github.com/bitnami/charts/issues/36533)
 
 ## <small>17.5.1 (2026-05-19)</small>
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 17.5.2
+version: 17.6.0

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -24,6 +24,11 @@ SPDX-License-Identifier: APACHE-2.0
 {{- range $timeIndex, $_ := until $timeShards }}
 {{- $index := add (mul $hashIndex $timeShards) $timeIndex }}
 {{- $shardSelector := dict "shard" $index }}
+{{- $partition := dict }}
+{{- if $timePartitioning }}
+{{- $partition = (slice $.Values.storegateway.sharded.timePartitioning $timeIndex) | first }}
+{{- end }}
+{{- $renderCtx := merge (dict "shardLoopId" $index) $ }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" $ }}
 kind: StatefulSet
 metadata:
@@ -88,7 +93,7 @@ spec:
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}
       {{- if $.Values.storegateway.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.affinity "context" (set $ "shardLoopId" $index)) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.affinity "context" $renderCtx) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.storegateway.podAffinityPreset "component" "storegateway" "customLabels" $podLabels "extraMatchLabels" $shardSelector "context" $) | nindent 10 }}
@@ -99,10 +104,10 @@ spec:
       dnsConfig: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.dnsConfig "context" $) | nindent 8 }}
       {{- end }}
       {{- if $.Values.storegateway.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.nodeSelector "context" (set $ "shardLoopId" $index)) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.nodeSelector "context" $renderCtx) | nindent 8 }}
       {{- end }}
       {{- if $.Values.storegateway.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.tolerations "context" (set $ "shardLoopId" $index)) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.tolerations "context" $renderCtx) | nindent 8 }}
       {{- end }}
       {{- if $.Values.storegateway.priorityClassName }}
       priorityClassName: {{ $.Values.storegateway.priorityClassName | quote }}
@@ -114,7 +119,7 @@ spec:
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $.Values.storegateway.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if $.Values.storegateway.topologySpreadConstraints }}
-      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.topologySpreadConstraints "context" $) | nindent 8 }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.topologySpreadConstraints "context" $renderCtx) | nindent 8 }}
       {{- end }}
       {{- if or $.Values.storegateway.initContainers (and $.Values.volumePermissions.enabled $.Values.storegateway.persistence.enabled) }}
       initContainers:
@@ -196,7 +201,6 @@ spec:
             {{- end }}
             {{- end }}
             {{- if $timePartitioning }}
-            {{- $partition := (slice $.Values.storegateway.sharded.timePartitioning $timeIndex) | first }}
             {{- if $partition.max }}
             - --max-time={{ $partition.max }}
             {{- end }}
@@ -205,7 +209,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- if $.Values.storegateway.extraFlags }}
-            {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.extraFlags "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.extraFlags "context" $renderCtx) | nindent 12 }}
+            {{- end }}
+            {{- if and $timePartitioning $partition.extraFlags }}
+            {{- include "common.tplvalues.render" (dict "value" $partition.extraFlags "context" $renderCtx) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- if $.Values.storegateway.extraEnvVars }}
@@ -274,21 +281,12 @@ spec:
           {{- if $.Values.storegateway.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $timePartitioning }}
-          {{- $partition := (slice $.Values.storegateway.sharded.timePartitioning $timeIndex) | first }}
-          {{- if $partition.resources }}
+          {{- if and $timePartitioning $partition.resources }}
           resources: {{- toYaml $partition.resources | nindent 12 }}
           {{- else if $.Values.storegateway.resources }}
           resources: {{- toYaml $.Values.storegateway.resources | nindent 12 }}
           {{- else if ne $.Values.storegateway.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" $.Values.storegateway.resourcesPreset) | nindent 12 }}
-          {{- end }}
-          {{- else -}}
-          {{- if $.Values.storegateway.resources }}
-          resources: {{- toYaml $.Values.storegateway.resources | nindent 12 }}
-          {{- else if ne $.Values.storegateway.resourcesPreset "none" }}
-          resources: {{- include "common.resources.preset" (dict "type" $.Values.storegateway.resourcesPreset) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: objstore-config

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -3668,6 +3668,25 @@ storegateway:
   ##     source_labels: ["region"]
   ##     regex: cn-zhangjiakou
   ## @param storegateway.sharded.timePartitioning [array] Setting time timePartitioning will create multiple store deployments based on the number of partitions
+  ## Each `timePartitioning` entry may also set per-shard `resources` and `extraFlags`:
+  ##   - `resources` (dict) overrides `storegateway.resources` for this shard only.
+  ##   - `extraFlags` (list) is appended to the global `storegateway.extraFlags` for this shard.
+  ## The shard index is available as `.shardLoopId` inside `affinity`, `nodeSelector`,
+  ## `tolerations`, `topologySpreadConstraints`, and `extraFlags` values, so per-shard
+  ## selectors can be expressed with templated labels.
+  ## e.g:
+  ## timePartitioning:
+  ##   - min: "-30d"
+  ##     max: ""
+  ##     resources:
+  ##       requests:
+  ##         memory: 4Gi
+  ##       limits:
+  ##         memory: 6Gi
+  ##     extraFlags:
+  ##       - --store.index-header-lazy-reader-idle-timeout=24h
+  ##   - min: ""
+  ##     max: "-30d"
   ## @param storegateway.sharded.service.clusterIPs Array of cluster IPs for each Store Gateway service. Length must be the same as the number of shards
   ## e.g:
   ## clusterIPs:


### PR DESCRIPTION
### Description of the change

Brings the sharded storegateway in line with capabilities other sharded fields already provide:

- Each `timePartitioning` entry may now set its own `extraFlags` list, appended to the global `storegateway.extraFlags`. Mirrors the existing per-partition `resources` override.
- `topologySpreadConstraints` is now rendered with `shardLoopId` in context, matching what `affinity` / `nodeSelector` / `tolerations` already do. Users can write a per-shard label selector (e.g. `shard: '{{ .shardLoopId }}'`) so each shard's replicas spread independently.

Also defines `$partition` once at the top of the iteration loop rather than re-extracting it via `slice ... | first` in each block.

### Benefits

1. Ability to control flags passed to each storegatway shard:

```yaml
  storegateway:
    sharded:
      enabled: true
      timePartitioning:
        # Recent shard — last 30 days. Small block set, eager loading is fine
        # (fast startup anyway) and avoids any cold-query latency for the
        # critical alerting/dashboard path.
        - min: "-30d"
          max: ""
        # Historical shard — everything older. Lazy download keeps boot fast
        # and disk footprint small; the rare ad-hoc historical query pays one
        # S3 GET per block on first touch.
        - min: ""
          max: "-30d"
          extraFlags:
            - --store.enable-index-header-lazy-reader
            - --store.index-header-lazy-download-strategy=lazy
            - --store.index-header-lazy-reader-idle-timeout=15m
```

2. Ability to specify shard ID in storegateway topology spread constraints with `tpl`:

```yaml
  storegateway:
    topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
        labelSelector:
          matchLabels:
            app.kubernetes.io/name: thanos
            app.kubernetes.io/instance: '{{ .Release.Name }}'
            app.kubernetes.io/component: storegateway
            shard: '{{ .shardLoopId }}'
```

### Possible drawbacks

This is already implemented for other shard config fields. No breaking changes.

### Applicable issues

None.

### Additional information

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files. **mMinor version bump, new functionality, backward-compatible**
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm). **Only `values.yaml` needed**
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
