### PR TITLE
[bitnami/keycloak] added config support for OpenTelemetry

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -35,4 +35,5 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 25.3.2
+version: 25.4.0
+

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -612,6 +612,30 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | `metrics.prometheusRule.labels`            | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                  | `{}`    |
 | `metrics.prometheusRule.groups`            | Groups, containing the alert rules.                                                                    | `[]`    |
 
+### Telemetry parameters
+
+| Name                                     | Description                                                                                                   | Value                     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `telemetry.enabled`                      | Enables OpenTelemetry integration                                                                             | `false`                    |
+| `telemetry.endpoint`                     | The global OTel collector endpoint                                                                            | `http://localhost:4317`   |
+| `telemetry.protocol`                     | The transport protocol for communication. Options: grpc, http/protobuf                                        | `grpc`                    |
+| `telemetry.serviceName`                  | The service name used to identify the data source                                                             | `keycloak`                |
+| `telemetry.resourceAttributes`           | Key-value pairs characterizing the telemetry producer                                                         | `""`                      |
+| `telemetry.headers`                      | Custom request headers for authentication or metadata                                                         | `{}`                      |
+| `telemetry.tracing.enabled`              | Enables OTel tracing                                                                                          | `false`                   |
+| `telemetry.tracing.endpoint`             | Overrides the global endpoint for traces                                                                      | `""`                      |
+| `telemetry.tracing.protocol`             | Overrides the global protocol for traces                                                                      | `""`                      |
+| `telemetry.metrics.enabled`              | Enables exporting metrics to an OTel collector                                                                | `false`                   |
+| `telemetry.metrics.interval`             | The interval between metric export attempts                                                                   | `60s`                     |
+| `telemetry.metrics.endpoint`             | Overrides the global endpoint for metrics                                                                     | `""`                      |
+| `telemetry.metrics.protocol`             | Overrides the global protocol for metrics                                                                     | `""`                      |
+| `telemetry.metrics.headers`              | Specific headers for metrics export                                                                           | `{}`                      |
+| `telemetry.logs.enabled`                 | Enables exporting logs via OTel                                                                               | `false`                   |
+| `telemetry.logs.level`                   | Filters the most verbose log level exported. Options: off, fatal, error, warn, info, debug, trace, all        | `all`                     |
+| `telemetry.logs.endpoint`                | Overrides the global endpoint for logs                                                                        | `""`                      |
+| `telemetry.logs.protocol`                | Overrides the global protocol for logs                                                                        | `""`                      |
+| `telemetry.logs.headers`                 | Specific headers for logs export                                                                              | `{}`                      |
+
 ### keycloak-config-cli parameters
 
 | Name                                                                  | Description                                                                                                                                                                                                                                           | Value                                 |

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -237,6 +237,7 @@ Compile all warnings into a single message.
 {{- $messages := append $messages (include "keycloak.validateValues.database" .) -}}
 {{- $messages := append $messages (include "keycloak.validateValues.tls" .) -}}
 {{- $messages := append $messages (include "keycloak.validateValues.production" .) -}}
+{{- $messages := append $messages (include "keycloak.validateValues.telemetry" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -273,5 +274,14 @@ keycloak: tls.enabled
 keycloak: production
     In order to enable Production mode, you also need to enable
     HTTPS/TLS (--set tls.enabled=true) or use proxy headers (--set proxyHeaders=FOO).
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Keycloak - Telemetry */}}
+{{- define "keycloak.validateValues.telemetry" -}}
+{{- if and .Values.telemetry.enabled .Values.telemetry.metrics.enabled (not .Values.metrics.enabled) -}}
+keycloak: telemetry.metrics.enabled
+    In order to enable OpenTelemetry metrics, you also need to enable
+    metrics (--set metrics.enabled=true).
 {{- end -}}
 {{- end -}}

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -88,3 +88,49 @@ data:
   {{- if .Values.extraStartupArgs }}
   KEYCLOAK_EXTRA_ARGS: {{ .Values.extraStartupArgs | quote }}
   {{- end }}
+{{- if .Values.telemetry.enabled }}
+  KC_TELEMETRY_ENDPOINT: {{ .Values.telemetry.endpoint | quote }}
+  KC_TELEMETRY_PROTOCOL: {{ .Values.telemetry.protocol | quote }}
+  KC_TELEMETRY_SERVICE_NAME: {{ .Values.telemetry.serviceName | quote }}
+  {{- if .Values.telemetry.resourceAttributes }}
+  KC_TELEMETRY_RESOURCE_ATTRIBUTES: {{ .Values.telemetry.resourceAttributes | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.telemetry.headers }}
+  KC_TELEMETRY_HEADER_{{ $key | upper | replace "-" "_" }}: {{ $value | quote }}
+  {{- end }}
+  KC_TRACING_ENABLED: {{ ternary "true" "false" .Values.telemetry.tracing.enabled | quote }}
+  {{- if .Values.telemetry.tracing.endpoint }}
+  KC_TRACING_ENDPOINT: {{ .Values.telemetry.tracing.endpoint | quote }}
+  {{- end }}
+  {{- if .Values.telemetry.tracing.protocol }}
+  KC_TRACING_PROTOCOL: {{ .Values.telemetry.tracing.protocol | quote }}
+  {{- end }}
+  KC_TELEMETRY_METRICS_ENABLED: {{ ternary "true" "false" .Values.telemetry.metrics.enabled | quote }}
+  {{- if .Values.telemetry.metrics.enabled }}
+  KC_TELEMETRY_METRICS_INTERVAL: {{ .Values.telemetry.metrics.interval | quote }}
+  KC_FEATURE_OPENTELEMETRY_METRICS: "enabled"
+  {{- if .Values.telemetry.metrics.endpoint }}
+  KC_TELEMETRY_METRICS_ENDPOINT: {{ .Values.telemetry.metrics.endpoint | quote }}
+  {{- end }}
+  {{- if .Values.telemetry.metrics.protocol }}
+  KC_TELEMETRY_METRICS_PROTOCOL: {{ .Values.telemetry.metrics.protocol | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.telemetry.metrics.headers }}
+  KC_TELEMETRY_METRICS_HEADER_{{ $key | upper | replace "-" "_" }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  KC_TELEMETRY_LOGS_ENABLED: {{ ternary "true" "false" .Values.telemetry.logs.enabled | quote }}
+  {{- if .Values.telemetry.logs.enabled }}
+  KC_TELEMETRY_LOGS_LEVEL: {{ .Values.telemetry.logs.level | quote }}
+  KC_FEATURE_OPENTELEMETRY_LOGS: "enabled"
+  {{- if .Values.telemetry.logs.endpoint }}
+  KC_TELEMETRY_LOGS_ENDPOINT: {{ .Values.telemetry.logs.endpoint | quote }}
+  {{- end }}
+  {{- if .Values.telemetry.logs.protocol }}
+  KC_TELEMETRY_LOGS_PROTOCOL: {{ .Values.telemetry.logs.protocol | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.telemetry.logs.headers }}
+  KC_TELEMETRY_LOGS_HEADER_{{ $key | upper | replace "-" "_" }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -984,6 +984,55 @@ metrics:
     ##             severity: critical
     groups: []
 
+## @section Telemetry parameters
+## Keycloak telemetry configuration
+## ref: https://www.keycloak.org/observability/telemetry
+telemetry:
+  ## @param telemetry.enabled Enables OpenTelemetry integration
+  enabled: false
+  ## @param telemetry.endpoint The global OTel collector endpoint
+  endpoint: "http://localhost:4317"
+  ## @param telemetry.protocol The transport protocol for communication. Options: grpc, http/protobuf
+  protocol: "grpc"
+  ## @param telemetry.serviceName The service name used to identify the data source
+  serviceName: "keycloak"
+  ## @param telemetry.resourceAttributes Key-value pairs characterizing the telemetry producer
+  resourceAttributes: ""
+  ## @param telemetry.headers Custom request headers for authentication or metadata
+  headers: {}
+  ## Traces configuration
+  tracing:
+    ## @param telemetry.tracing.enabled Enables OTel tracing
+    enabled: false
+    ## @param telemetry.tracing.endpoint Overrides the global endpoint for traces
+    endpoint: ""
+    ## @param telemetry.tracing.protocol Overrides the global protocol for traces
+    protocol: ""
+  ## Metrics configuration (experimental)
+  metrics:
+    ## @param telemetry.metrics.enabled Enables exporting metrics to an OTel collector
+    enabled: false
+    ## @param telemetry.metrics.interval The interval between metric export attempts
+    interval: "60s"
+    ## @param telemetry.metrics.endpoint Overrides the global endpoint for metrics
+    endpoint: ""
+    ## @param telemetry.metrics.protocol Overrides the global protocol for metrics
+    protocol: ""
+    ## @param telemetry.metrics.headers Specific headers for metrics export
+    headers: {}
+  ## Logs configuration (preview)
+  logs:
+    ## @param telemetry.logs.enabled Enables exporting logs via OTel
+    enabled: false
+    ## @param telemetry.logs.level Filters the most verbose log level exported. Options: off, fatal, error, warn, info, debug, trace, all
+    level: "all"
+    ## @param telemetry.logs.endpoint Overrides the global endpoint for logs
+    endpoint: ""
+    ## @param telemetry.logs.protocol Overrides the global protocol for logs
+    protocol: ""
+    ## @param telemetry.logs.headers Specific headers for logs export
+    headers: {}
+
 ## @section keycloak-config-cli parameters
 
 ## Configuration for keycloak-config-cli


### PR DESCRIPTION
### Description of the change

Keycloak now supports OpenTelemetry integration. This change adds the required env variables and the matching config to the values.yaml

### Benefits

OpenTelemetry can be enabled and configured using the helm chart.

### Possible drawbacks

none (telemetry is disabled by default)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
