### PR TITLE
[bitnami/common] Sanitize truncated chart label values

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.31.10 (2026-06-24)
+
+* [bitnami/common] Ensure chart and app version labels end with an alphanumeric character ([#36452](https://github.com/bitnami/charts/issues/36452))
+
 ## 2.31.9 (2026-05-08)
 
 * [bitnami/common] escape ChartVersion in labels ([#36516](https://github.com/bitnami/charts/pull/36516))

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.31.9
+appVersion: 2.31.10
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -22,4 +22,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.31.9
+version: 2.31.10

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -123,10 +123,11 @@ The following table lists the helpers available in the library which are scoped 
 
 ### Labels
 
-| Helper identifier           | Description                                                                 | Expected Input    |
-| --------------------------- | --------------------------------------------------------------------------- | ----------------- |
-| `common.labels.standard`    | Return Kubernetes standard labels                                           | `.` Chart context |
-| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector` | `.` Chart context |
+| Helper identifier           | Description                                                                                     | Expected Input    |
+| --------------------------- | ----------------------------------------------------------------------------------------------- | ----------------- |
+| `common.labels.standard`    | Return Kubernetes standard labels                                                               | `.` Chart context |
+| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector`                     | `.` Chart context |
+| `common.labels.value`       | Sanitize a value for use as a Kubernetes label value, including truncation and trailing cleanup | `string`          |
 
 ### Names
 

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -6,6 +6,16 @@ SPDX-License-Identifier: APACHE-2.0
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Sanitize a value for use as a Kubernetes label value.
+Label values may contain alphanumeric characters, '-', '_' and '.', and must
+start and end with an alphanumeric character. See:
+https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+*/}}
+{{- define "common.labels.value" -}}
+{{- regexReplaceAll "[^A-Za-z0-9]+$" (. | toString | replace "+" "_" | trunc 63) "" -}}
+{{- end -}}
+
+{{/*
 Kubernetes standard labels
 {{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) -}}
 */}}
@@ -13,7 +23,7 @@ Kubernetes standard labels
 {{- if and (hasKey . "customLabels") (hasKey . "context") -}}
 {{- $default := dict "app.kubernetes.io/name" (include "common.names.name" .context) "helm.sh/chart" (include "common.names.chart" .context) "app.kubernetes.io/instance" .context.Release.Name "app.kubernetes.io/managed-by" .context.Release.Service -}}
 {{- with .context.Chart.AppVersion -}}
-{{- $_ := set $default "app.kubernetes.io/version" (. | replace "+" "_") -}}
+{{- $_ := set $default "app.kubernetes.io/version" (include "common.labels.value" .) -}}
 {{- end -}}
 {{ template "common.tplvalues.merge" (dict "values" (list .customLabels $default) "context" .context) }}
 {{- else -}}
@@ -22,7 +32,7 @@ helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}
-app.kubernetes.io/version: {{ . | replace "+" "_" | quote }}
+app.kubernetes.io/version: {{ include "common.labels.value" . | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/common/templates/_names.tpl
+++ b/bitnami/common/templates/_names.tpl
@@ -15,7 +15,7 @@ Expand the name of the chart.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "common.names.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- include "common.labels.value" (printf "%s-%s" .Chart.Name .Chart.Version) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

This updates the bitnami/common label helpers so generated Kubernetes label values remain valid after SemVer build metadata is normalized and truncated.

Specifically:
- Adds a shared common.labels.value helper.
- Applies it to helm.sh/chart.
- Applies it to app.kubernetes.io/version.
- Preserves the existing + to _ conversion and 63-character truncation.
- Trims trailing non-alphanumeric characters after truncation.

This prevents labels such as helm.sh/chart from ending in _ when a long chart version with build metadata is truncated.

### Benefits

Charts can use long SemVer versions containing build metadata without rendering Kubernetes-invalid labels.

Example fixed case:

```text                                                                                                                                                                  
  grid-checkout-internal-gateway@2.1.13-SNAPSHOT-20260126-095732+ba14b1c07afe
```                                                                                                                                                                      

Previously this could truncate to a label ending in _, which Kubernetes rejects. The helper now trims that trailing invalid character while preserving the valid prefix.

### Possible drawbacks

If a generated helm.sh/chart or app.kubernetes.io/version label would previously have ended with a non-alphanumeric character after truncation, the rendered label value is now slightly shorter. The chart version and appVersion themselves are unchanged.

### Applicable issues

- fixes #36452

### Additional information

Validation performed:
- Rendered a temporary consumer chart using a long chart version with build metadata.
- Verified rendered helm.sh/chart and app.kubernetes.io/version labels:
  - are no longer than 63 characters
  - match Kubernetes label value syntax
  - end with an alphanumeric character
- Ran:
```sh
  helm lint bitnami/common
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
