### PR TITLE
[bitnami/kafbat-ui] Add README.md file

### DIFF
--- a/bitnami/kafbat-ui/README.md
+++ b/bitnami/kafbat-ui/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Images Helm chart for Kafbat UI
+
+Kafbat UI is a web-based console for Apache Kafka clusters. Teams use it to inspect topics, consumer groups, and schemas without leaving the browser.
+
+[Overview of Kafbat UI](https://github.com/kafbat/kafka-ui)
+
+This Helm chart is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
Add marketing README for the kafbat-ui private Helm chart.

Kafbat UI is a web-based console for Apache Kafka clusters, available under the Bitnami Secure Images initiative.

Signed-off-by: Dan Goriaynov <dan.goriaynov@broadcom.com>