### PR TITLE
[bitnami/questdb] Add questdb marketing readme

### DIFF
--- a/bitnami/questdb/README.md
+++ b/bitnami/questdb/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Images Helm chart for QuestDB
+
+QuestDB is a high-performance, open-source SQL database for time-series and event data.
+
+[Overview of QuestDB](https://questdb.io)
+
+This Helm chart is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Description

Adds the marketing README for the public questdb chart, adapted from the charts-private README (bitnami/charts-private#8623) with install commands switched to the public OCI registry (`oci://registry-1.docker.io/bitnamicharts/questdb`), following the argo-rollouts precedent (#36568).

ai-assisted=yes