### PR TITLE
[TNZ-124370] Add kong-operator marketing README

### DIFF
--- a/bitnami/kong-operator/README.md
+++ b/bitnami/kong-operator/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Images Helm chart for Kong Operator
+
+Kong Operator is a Kubernetes Operator that manages Kong Gateway control planes and data planes declaratively through Custom Resource Definitions (CRDs).
+
+[Overview of Kong Operator](https://github.com/kong/kong-operator)
+
+This Helm chart is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Description

Adds the Docker-Hub-style marketing README for the future `kong-operator` Helm chart, mirroring the pattern used for `bitnami/reloader` (see #36575).

Kong Operator (https://github.com/kong/kong-operator, Apache-2.0) is a Kubernetes Operator that manages Kong Gateway control planes and data planes declaratively through CRDs.

**Placeholder / dependency note:** this PR is purely descriptive (no Parameters table, since this public repo's chart READMEs for onboarded-but-not-yet-published charts don't include one). The actual `kong-operator` Helm chart implementation (values.yaml, templates, CRDs, RBAC) and its full Parameters-table README will be delivered in a separate, follow-up PR against `charts-private`. This README is being added ahead of that work as part of the TNZ-124370 onboarding effort.

ai-assisted=yes