### PR TITLE
[TNZ-122380] docs(distribution): :memo: Add marketing README

### DIFF
--- a/bitnami/distribution/README.md
+++ b/bitnami/distribution/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Images Helm chart for Distribution
+
+Distribution is the CNCF reference implementation of the OCI Distribution Specification, a standalone OCI-compliant registry to store, manage and serve container images and other OCI artifacts.
+
+[Overview of Distribution](https://github.com/distribution/distribution)
+
+This Helm chart is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Summary

- Add the marketing README for the `distribution` Helm chart, now merged and live in charts-private (bitnami/charts-private#8690)
- This chart is only available under the Bitnami Secure Images initiative, following the pattern used for other BSI-only charts (e.g. `openbao`, `reloader`)

## Jira

[TNZ-122380](https://vmw-jira.broadcom.net/browse/TNZ-122380)

ai-assisted=yes