### PR TITLE
[bitnami/zookeeper] Allow overriding individual fields of updateStrategy 

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 13.8.8
+version: 13.8.9

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -24,7 +24,11 @@ spec:
       app.kubernetes.io/component: zookeeper
   serviceName: {{ printf "%s-%s" (include "common.names.fullname" .) (default "headless" .Values.service.headless.servicenameOverride) | trunc 63 | trimSuffix "-" }}
   {{- if .Values.updateStrategy }}
-  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if .Values.updateStrategy.rollingUpdate }}
+    rollingUpdate: {{- toYaml .Values.updateStrategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
The current style doesn't give subcharts the option to nullify fields within updateStrategy. Therefore, the following isn't possible in a subchart's Value.yaml:

```yaml
  updateStrategy:
    type: OnDelete
    rollingUpdate: null
```

Without the null, I get an error that the updateStrategy OnDelete doesn't allow a non-null value for rollingUpdate.

The reason is that Helm object merges pick any `rollingUpdate` value between the base `bitnami/zookeeper` chart and the subchart, and `null` always gives way to the base chart's value.