### PR TITLE
[bitnami/mongodb-sharded] Recover logging to stdout

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 9.4.14
+version: 9.4.15

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -125,6 +125,40 @@ Return the proper image name (for the init container volume-permissions image)
 {{- end -}}
 
 {{/*
+Init container definition to recover the log dir symlink to stdout.
+The container image ships /opt/bitnami/mongodb/logs/mongodb.log as a symlink to
+/dev/stdout, but that symlink is hidden by the empty-dir volume mounted on top of
+/opt/bitnami/mongodb/logs. This init container recreates it inside the volume.
+The "component" key must point to the per-component values holding
+containerSecurityContext, resources and resourcesPreset (e.g. .Values.mongos).
+*/}}
+{{- define "mongodb-sharded.initContainer.prepareLogDir" -}}
+{{- $component := .component -}}
+{{- $context := .context -}}
+- name: log-dir
+  image: {{ include "mongodb-sharded.image" $context }}
+  imagePullPolicy: {{ $context.Values.image.pullPolicy | quote }}
+  command:
+    - /bin/bash
+  args:
+    - -ec
+    - |
+      ln -sf /dev/stdout "/opt/bitnami/mongodb/logs/mongodb.log"
+  {{- if $component.containerSecurityContext.enabled }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $component.containerSecurityContext "context" $context) | nindent 4 }}
+  {{- end }}
+  {{- if $component.resources }}
+  resources: {{- include "common.tplvalues.render" (dict "value" $component.resources "context" $context) | nindent 4 }}
+  {{- else if ne $component.resourcesPreset "none" }}
+  resources: {{- include "common.resources.preset" (dict "type" $component.resourcesPreset) | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+    - name: empty-dir
+      mountPath: /opt/bitnami/mongodb/logs
+      subPath: app-logs-dir
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "mongodb-sharded.imagePullSecrets" -}}

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -109,6 +109,7 @@ spec:
         {{- with .Values.common.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
+        {{- include "mongodb-sharded.initContainer.prepareLogDir" (dict "component" .Values.configsvr "context" $) | nindent 8 }}
       containers:
         - name: mongodb
           image: {{ include "mongodb-sharded.image" . }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -77,7 +77,6 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.mongos.terminationGracePeriodSeconds }}
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" . | nindent 6 }}
-      {{- if or $.Values.mongos.initContainers $.Values.common.initContainers }}
       initContainers:
         {{- with $.Values.mongos.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
@@ -85,7 +84,7 @@ spec:
         {{- with $.Values.common.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
-      {{- end }}
+        {{- include "mongodb-sharded.initContainer.prepareLogDir" (dict "component" .Values.mongos "context" $) | nindent 8 }}
       containers:
         - name: mongos
           image: {{ include "mongodb-sharded.image" . }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -76,7 +76,6 @@ spec:
       terminationGracePeriodSeconds: {{ $.Values.shardsvr.arbiter.terminationGracePeriodSeconds }}
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" $ | nindent 6 }}
-      {{- if or $.Values.shardsvr.arbiter.initContainers $.Values.common.initContainers }}
       initContainers:
         {{- with $.Values.shardsvr.arbiter.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
@@ -84,7 +83,7 @@ spec:
         {{- with $.Values.common.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
-      {{- end }}
+        {{- include "mongodb-sharded.initContainer.prepareLogDir" (dict "component" $.Values.shardsvr.arbiter "context" $) | nindent 8 }}
       containers:
         - name: {{ printf "%s-arbiter" (include "common.names.fullname" $) }}
           image: {{ include "mongodb-sharded.image" $ }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -112,6 +112,7 @@ spec:
         {{- with $.Values.common.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
         {{- end }}
+        {{- include "mongodb-sharded.initContainer.prepareLogDir" (dict "component" $.Values.shardsvr.dataNode "context" $) | nindent 8 }}
       containers:
         - name: mongodb
           image: {{ include "mongodb-sharded.image" $ }}


### PR DESCRIPTION
## Description of the change

Adds a `log-dir` init container to the `mongodb-sharded` chart that restores the `/opt/bitnami/mongodb/logs/mongodb.log` → `/dev/stdout` symlink inside the `empty-dir` volume, so MongoDB logs reach the container's stdout again.

This is a backport of the fix already applied to the `bitnami/mongodb` chart in #27510; the sharded chart has the same problem but never received the equivalent change.

## Benefits

- Container logs are visible again via `kubectl logs` and can be collected by log shippers.
- The `empty-dir` volume no longer grows without bound with an on-disk `mongodb.log`.

## Possible drawbacks

One additional short-lived init container per pod, using the same image that is already pulled for the main container. This matches the approach taken in `bitnami/mongodb`.

## Applicable issues

Related to #27150 (`[bitnami/mongodb] Logging to stdout no longer default`), which describes the identical root cause for the non-sharded chart, and which was fixed by #27510.

## Root cause

`readOnlyRootFilesystem` support (#23747) introduced an `emptyDir` volume named `empty-dir` mounted at `/opt/bitnami/mongodb/logs` with `subPath: app-logs-dir`.

The container image creates, at build time in `postunpack.sh`, a symlink:

```
/opt/bitnami/mongodb/logs/mongodb.log -> /dev/stdout
```

Mounting a volume on top of that directory hides the symlink. Since the rendered `mongodb.conf` uses:

```yaml
systemLog:
  destination: file
  path: /opt/bitnami/mongodb/logs/mongodb.log
  logAppend: true
```

`mongod` then creates a **real file** on the `emptyDir` instead of writing to stdout. Two consequences:

1. Container stdout goes silent, so log collection stops working — silently, with no error anywhere.
2. The `emptyDir` grows without bound. MongoDB has no size-based automatic log rotation (`logRotate` has to be triggered externally), and the chart does not expose a `sizeLimit` for this volume.

In our own environment, a 4-shard production cluster wrote roughly 515 MB/day/pod to this volume, and a development cluster accumulated 3.9 GB over 3 days.

This matches the diagnosis given by @jotamartos in #27150, where the suggested fix was "an initContainer to copy/generate the symlink to the new empty dir".

## Implementation

Mirrors `bitnami/mongodb` as closely as the sharded chart's values layout allows:

- New named template `mongodb-sharded.initContainer.prepareLogDir` in `templates/_helpers.tpl`, running the same command (`ln -sf /dev/stdout "/opt/bitnami/mongodb/logs/mongodb.log"`) with the same `volumeMounts` (`empty-dir` → `/opt/bitnami/mongodb/logs`, `subPath: app-logs-dir`).
- Because the sharded chart keeps `containerSecurityContext`, `resources` and `resourcesPreset` per component rather than at the top level, the helper takes a `dict` with a `component` key (`.Values.configsvr`, `.Values.shardsvr.dataNode`, `.Values.shardsvr.arbiter`, `.Values.mongos`) and a `context` key. Each workload therefore keeps using its own security context and resources settings.
- Wired into all four workload templates. `initContainers:` was previously conditional in `shard-arbiter-statefulset.yaml` and `mongos-dep-sts.yaml`; it is now unconditional, the same change #27510 made in the `mongodb` chart.

## Real-world validation

We have applied this change to our own clusters (chart 9.4.14, MongoDB 8.0.13) and verified it end to end across all four workload types (config server, shard data, shard arbiter, mongos):

- The init container restored `mongodb.log -> /dev/stdout` inside the volume.
- The `emptyDir` went from 3.9 GB down to 4.0 K.
- Container stdout went from 0 log lines to roughly 1400 lines per 5 minutes, so log collection works again.

## Checklist

- [x] Chart version bumped: `9.4.14` → `9.4.15`
- [x] Variables are documented in the values.yaml (no new values introduced)
- [x] Title of the pull request follows the `[bitnami/mongodb-sharded]` format
- [x] All commits are signed off (DCO)
- [x] `CHANGELOG.md` intentionally not edited — it is generated by `bitnami-bot`

## Verification

`helm lint`:

```
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

`helm template t . --set shardsvr.arbiter.replicaCount=1`, checking that the init container is present in every workload and that its mount matches the main container's:

```
KIND         NAME                                     log-dir  mountPath                    subPath
------------------------------------------------------------------------------------------------------------
StatefulSet  t-mongodb-sharded-configsvr              YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
Deployment   t-mongodb-sharded-mongos                 YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
StatefulSet  t-mongodb-sharded-shard0-arbiter         YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
StatefulSet  t-mongodb-sharded-shard0-data            YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
StatefulSet  t-mongodb-sharded-shard1-arbiter         YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
StatefulSet  t-mongodb-sharded-shard1-data            YES      /opt/bitnami/mongodb/logs    app-logs-dir (vol=empty-dir)
```

Rendered init container (config server):

```yaml
- name: log-dir
  image: docker.io/bitnami/mongodb-sharded:8.0.13-debian-12-r0
  imagePullPolicy: "IfNotPresent"
  command:
    - /bin/bash
  args:
    - -ec
    - |
      ln -sf /dev/stdout "/opt/bitnami/mongodb/logs/mongodb.log"
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
      - ALL
    privileged: false
    readOnlyRootFilesystem: true
    runAsGroup: 1001
    runAsNonRoot: true
    runAsUser: 1001
    seLinuxOptions: {}
    seccompProfile:
      type: RuntimeDefault
  resources:
    limits:
      cpu: 750m
      ephemeral-storage: 2Gi
      memory: 768Mi
    requests:
      cpu: 500m
      ephemeral-storage: 50Mi
      memory: 512Mi
  volumeMounts:
    - name: empty-dir
      mountPath: /opt/bitnami/mongodb/logs
      subPath: app-logs-dir
```

Per-component wiring, verified by setting a distinct value per component
(`--set configsvr.resources.requests.cpu=111m`, `mongos...=222m`,
`shardsvr.dataNode...=333m`, `shardsvr.arbiter...=444m`, plus
`--set mongos.containerSecurityContext.enabled=false`):

```
t-mongodb-sharded-configsvr              cpu=111m    secCtx=yes
t-mongodb-sharded-mongos                 cpu=222m    secCtx=NO
t-mongodb-sharded-shard0-arbiter         cpu=444m    secCtx=yes
t-mongodb-sharded-shard0-data            cpu=333m    secCtx=yes
t-mongodb-sharded-shard1-arbiter         cpu=444m    secCtx=yes
t-mongodb-sharded-shard1-data            cpu=333m    secCtx=yes
```

`--set configsvr.resourcesPreset=none --set mongos.resourcesPreset=none` correctly omits the `resources` key for those two components only.

User-supplied init containers still render, with `log-dir` appended last
(`--set mongos.initContainers[0].name=custom-a --set common.initContainers[0].name=custom-b`):

```
t-mongodb-sharded-mongos                 ['custom-a', 'custom-b', 'log-dir']
t-mongodb-sharded-configsvr              ['custom-b', 'log-dir']
t-mongodb-sharded-shard0-arbiter         ['custom-b', 'log-dir']
t-mongodb-sharded-shard0-data            ['custom-b', 'log-dir']
```
