### PR TITLE
[bitnami/neo4j-enterprise] Add neo4j-enterprise marketing readme

### DIFF
--- a/bitnami/neo4j-enterprise/README.md
+++ b/bitnami/neo4j-enterprise/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Images Helm chart for Neo4j Enterprise Edition
+
+Neo4j Enterprise Edition is a high-performance graph database with advanced clustering, cloud integrations, and enterprise-grade security for mission-critical, large-scale deployments. This chart requires a Neo4j Enterprise license (BYOL).
+
+[Overview of Neo4j](https://neo4j.com/product/neo4j-graph-database/)
+
+This Helm chart is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Summary
- Adds the initial marketing README for the upcoming `neo4j-enterprise` chart (currently in review at `bitnami/charts-private#9256`), following the same minimal placeholder pattern used for other charts ahead of their first sync (e.g. `bitnami/dagger`, `bitnami/authentik`).

ai-assisted=yes