### PR TITLE
fix(mongodb): prevent zombie process leak in readiness probe

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 17.0.2
+version: 17.0.3

--- a/bitnami/mongodb/templates/common-scripts-cm.yaml
+++ b/bitnami/mongodb/templates/common-scripts-cm.yaml
@@ -28,17 +28,7 @@ data:
     # Probes are using localhost/127.0.0.1 to tests if the service is up, ready or healthy. If TLS is enabled, we shouldn't validate the certificate hostname.
     TLS_OPTIONS='--tls {{ if .Values.tls.mTLS.enabled }}--tlsCertificateKeyFile=/certs/mongodb.pem {{ end }}--tlsCAFile=/certs/mongodb-ca-cert --tlsAllowInvalidHostnames'
     {{- end }}
-    # Run the proper check depending on the version
-    [[ $(mongod -version | grep "db version") =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] && VERSION=${BASH_REMATCH[1]}
-    . /opt/bitnami/scripts/libversion.sh
-    VERSION_MAJOR="$(get_sematic_version "$VERSION" 1)"
-    VERSION_MINOR="$(get_sematic_version "$VERSION" 2)"
-    VERSION_PATCH="$(get_sematic_version "$VERSION" 3)"
-    readiness_test='db.isMaster().ismaster || db.isMaster().secondary'
-    if [[ ( "$VERSION_MAJOR" -ge 5 ) || ( "$VERSION_MAJOR" -ge 4 && "$VERSION_MINOR" -ge 4 && "$VERSION_PATCH" -ge 2 ) ]]; then
-        readiness_test='db.hello().isWritablePrimary || db.hello().secondary'
-    fi
-    exec mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval "if (!(${readiness_test})) { throw new Error(\"Not ready\") }"
+    exec mongosh $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'var res; try { res = db.hello(); } catch(e) { res = db.isMaster(); } if (!(res.isWritablePrimary || res.ismaster || res.secondary)) { throw new Error("Not ready"); }'
   ping-mongodb.sh: |
     #!/bin/bash
     {{- if .Values.tls.enabled }}


### PR DESCRIPTION
### Description

This PR prevents a severe process leak in `readiness-probe.sh` caused by Kubelet `SIGKILL`s during timeout events.

**The Issue:**
Currently, `readiness-probe.sh` executes `mongod -version | grep ...` on every single interval. If the probe times out (e.g., during disk IO latency or CPU throttling), Kubelet sends a `SIGKILL` to the script. The bash shell dies, but the pipeline children (`mongod` and `grep`) are orphaned. 

Since `mongod` runs as PID 1 in this container and is not an init system, it does not reap these orphaned processes. They become permanent `<defunct>` zombies. In our production clusters, this pipeline pattern leaked over ~28,000 zombies per pod over a few days, eventually exhausting the node's `pid_max` and BPF/Seccomp kernel limits (`errno 524`), which breaks `kubectl exec` and CSI mounts cluster-wide.

**The Fix:**
- Removed the bash pipeline (`| grep`) and external version detection (`mongod -version`) entirely.
- Replaced the version check with a dynamic JS payload executed directly inside `mongosh` (`try { db.hello(); } catch(e) { db.isMaster(); }`).
- By using a single `exec mongosh` command, the shell is entirely replaced. Zero child processes are spawned by the probe script, completely eliminating the root cause of the zombie leak.


### Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the chart.
- [x] I've bumped the chart version in `Chart.yaml`.