### PR TITLE
[bitnami/redis] Patch host_id() in redis chart for mutiple cluster deployments in different namespaces

### DIFF
--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -379,7 +379,9 @@ data:
         echo $'\n'"$@" >> "/opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf"
     }
     host_id() {
-        echo "$1" | openssl sha1 | awk '{print $2}'
+        printf '%s\n' "{{ include "common.names.namespace" . }}:$1" |
+            openssl sha1 |
+            awk '{print $2}'
     }
     get_sentinel_master_info() {
         if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then


### PR DESCRIPTION
If fullnameOverride is used, and the chart is used in multiple namespaces at the same time, then each node's SENTINEL MYID became the same, because only the host names are used (and they are the same for the same node number, e.g. redis-node-0). Under certain circumstances, they could be merged into one big cluster as a result.