### PR TITLE
[workflows/license-headers] Check out the base repository's mirrored pull-request instead of the fork

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         name: Checkout Repository
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: refs/pull/${{ github.event.number }}/merge
       - id: get-modified-files
         name: 'Get modified files'
         env:


### PR DESCRIPTION
## Description of the change

The `license-headers-linter` job in `.github/workflows/license-headers.yml` runs on `pull_request_target` and its `actions/checkout` step explicitly overrode the checkout target to the PR's fork repository/ref:

```yaml
with:
  ref: ${{ github.event.pull_request.head.ref }}
  repository: ${{ github.event.pull_request.head.repo.full_name }}
```

Since `pull_request_target` runs with the base repository's `GITHUB_TOKEN` and secrets, `actions/checkout` has a built-in safety guard that refuses to check out code from an external fork repository in that context. As a result, the job fails at the checkout step (before ever reaching the actual license header check) for any PR opened from a fork, regardless of whether the PR content is valid -- see [#36585](https://github.com/bitnami/charts/pull/36585) as an example.

## Fix

Check out the base repository's mirrored pull-request ref (`refs/pull/<number>/merge`) instead of pointing directly at the fork. This still gives the job access to the PR's file contents for the license header check, but stays "internal" to the base repository, so the fork-checkout safety guard no longer triggers.

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
