### PR TITLE
[workflows/license-headers] Allow unsafe pr checkout

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -23,6 +23,7 @@ jobs:
         name: Checkout Repository
         with:
           ref: refs/pull/${{ github.event.number }}/merge
+          allow-unsafe-pr-checkout: true
       - id: get-modified-files
         name: 'Get modified files'
         env:


### PR DESCRIPTION
### Description of the change

`license-headers-linter` (`.github/workflows/license-headers.yml`) runs on `pull_request_target`, which executes with the base repository's `GITHUB_TOKEN`, secrets, and cache scope -- even for PRs opened from forks. To check the actual file
  contents changed in a PR, the job's `actions/checkout` step needs to check out the fork's code, but `actions/checkout` has a built-in guard that refuses to do so unless explicitly told it's safe. This currently causes the job to fail at the
  checkout step for every fork-originated PR, e.g. [#36585](https://github.com/bitnami/charts/pull/36585), regardless of whether the PR content itself is valid:

  ```
  Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. ...
  ```

  A prior attempt to work around this by checking out `refs/pull/<number>/merge` instead of the fork repo directly does **not** avoid the guard -- `actions/checkout`'s guard explicitly matches on that ref pattern too (see
  [`unsafe-pr-checkout-helper.ts`](https://github.com/actions/checkout/blob/main/src/unsafe-pr-checkout-helper.ts)):

  ```js
  const PR_REF_PATTERN = /^refs\/pull\/[0-9]+\/(?:head|merge)$/
  ```

  There is no ref/repository trick that avoids this check for a fork PR under `pull_request_target`; the only way to check out fork content in this context is the explicit opt-in the action provides for exactly this purpose.

  ### Fix

  Add `allow-unsafe-pr-checkout: true` to the `actions/checkout` step.

  ### Why this is safe here

  The guard exists to prevent "pwn request" vulnerabilities: a malicious fork PR getting its code *executed* in a context that has access to the base repo's secrets/token, so it can exfiltrate secrets or push malicious artifacts. This job
  doesn't fit that risk profile:

  - **No code from the fork is executed.** The only thing done with the checked-out content is a static text scan via `apache/skywalking-eyes/header`, which reads file headers -- it does not run any script, build step, or binary from the
  checked-out repository.
  - **No secrets are used.** The job's permissions are limited to `contents: read` and `pull-requests: write`; there are no `secrets.*` references anywhere in the job, so there's nothing for a malicious PR to steal even if it could influence
  execution.
  - **Worst case is limited to the job's own scope.** A malicious PR could, at most, tamper with its own `.licenserc.yaml` to try to dodge the header check -- that's a correctness/bypass concern for this one linter, not a path to compromising
  the base repo, its secrets, or other workflows.

  This matches the documented, sanctioned use case for `allow-unsafe-pr-checkout` (see [GitHub's guidance](https://gh.io/securely-using-pull_request_target)): read-only inspection of PR content in jobs that don't execute the fork's code or
  expose secrets to it.

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Gonzalo Gomez Gracia <gonzalo.gomez@broadcom.com>