### PR TITLE
Change Apache image repository to bitnamilegacy

### DIFF
--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -70,7 +70,7 @@ extraDeploy: []
 ##
 image:
   registry: docker.io
-  repository: bitnami/apache
+  repository: bitnamilegacy/apache
   tag: 2.4.65-debian-12-r2
   digest: ""
   ## Specify a imagePullPolicy


### PR DESCRIPTION
Bitnami has moved older and versioned container image tags from its public catalog to the Bitnami Legacy Registry