### PR TITLE
[bitnami/rabbitmq-cluster-operator] use plain HTTP instead of HTTPS for metrics scraping

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.4.40
+version: 4.4.41

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -99,6 +99,7 @@ spec:
           {{- else }}
           args:
             - --metrics-bind-address=:{{ .Values.msgTopologyOperator.containerPorts.metrics }}
+            - --metrics-secure=false # The handling of TLS certificates for the metrics endpoint is not implemented in the chart - feel free to open a PR if you need it
             - --health-probe-bind-address=:{{ .Values.msgTopologyOperator.containerPorts.health }}
           {{- end }}
           env:
@@ -132,7 +133,7 @@ spec:
             - name: https-webhook
               containerPort: 9443
               protocol: TCP
-            - name: https-metrics
+            - name: http-metrics
               containerPort: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
               protocol: TCP
             - name: http-health

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -40,9 +40,9 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: https
+    - name: http
       port: {{ .Values.msgTopologyOperator.metrics.service.ports.http }}
-      targetPort: https-metrics
+      targetPort: http-metrics
       protocol: TCP
       {{- if (and (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) (not (empty .Values.msgTopologyOperator.metrics.service.nodePorts.http))) }}
       nodePort: {{ .Values.msgTopologyOperator.metrics.service.nodePorts.http }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -50,5 +50,4 @@ spec:
       {{- if .Values.msgTopologyOperator.metrics.podMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.msgTopologyOperator.metrics.podMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
-      scheme: HTTPS
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR moves the metrics back to be served via plain HTTP, partially reverting changes made in https://github.com/bitnami/charts/pull/36539

### Benefits

<!-- What benefits will be realized by the code change? -->
The metrics endpoint is served with HTTPS by default, but because this requires a valid TLS certificate, scraping fails (see https://github.com/bitnami/charts/issues/36602)

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Metrics are not secured with TLS anymore. This should be fine, given the setup did not work before and most metrics are served with plain HTTP inside a cluster anyway.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #36601 
- fixes #36602 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) -> does not apply
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
