### PR TITLE
fix: replace broken awesome-prometheus-alerts link

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1520,7 +1520,7 @@ metrics:
     namespace: ""
     ## List of rules, used as template by Helm.
     ## @param metrics.prometheusRule.rules List of rules, used as template by Helm.
-    ## These are just examples rules inspired from https://awesome-prometheus-alerts.grep.to/rules.html
+    ## These are just examples rules inspired from https://samber.github.io/awesome-prometheus-alerts/rules.html
     ## rules:
     ##   - alert: RabbitmqDown
     ##     expr: rabbitmq_up{service="{{ template "common.names.fullname" . }}"} == 0


### PR DESCRIPTION
Hi!

The `awesome-prometheus-alerts.grep.to` domain is no longer maintained: the site is gone and the domain now shows a parking page, so the link in this repo is broken.

This PR replaces it with the current home of the project:

https://samber.github.io/awesome-prometheus-alerts

No other changes. Thanks!
